### PR TITLE
Use Yoda condition for admin hook check

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -82,7 +82,7 @@ class BHG_Admin {
 		 * @param string $hook Current admin page hook.
 		 */
 	public function assets( $hook ) {
-		if ( strpos( $hook, 'bhg' ) !== false ) {
+		if ( false !== strpos( $hook, 'bhg' ) ) {
 			wp_enqueue_style(
 				'bhg-admin',
 				BHG_PLUGIN_URL . 'assets/css/admin.css',


### PR DESCRIPTION
## Summary
- Use Yoda condition to check admin hook before enqueueing assets

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*
- `vendor/bin/phpcs --standard=phpcs.xml admin/class-bhg-admin.php`

------
https://chatgpt.com/codex/tasks/task_e_68bc7772de94833398bc1b7bf135bb83