### PR TITLE
Escape admin header output

### DIFF
--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -5,7 +5,7 @@ if (!defined('ABSPATH')) {
 
 // Check user capabilities
 if (!current_user_can('manage_options')) {
-    wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+    wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
 global $wpdb;
@@ -135,39 +135,39 @@ if (isset($_GET['message'])) {
 ?>
 
 <div class="wrap bhg-admin">
-    <h1><?php _e('Bonus Hunt Guesser', 'bonus-hunt-guesser'); ?></h1>
+    <h1><?php esc_html_e( 'Bonus Hunt Guesser', 'bonus-hunt-guesser' ); ?></h1>
     <hr/>
     
     <div class="bhg-admin-content">
-        <h2><?php _e('Create New Bonus Hunt', 'bonus-hunt-guesser'); ?></h2>
+        <h2><?php esc_html_e( 'Create New Bonus Hunt', 'bonus-hunt-guesser' ); ?></h2>
         <form method="post" action="">
             <?php wp_nonce_field('bhg_create_bonus_hunt', 'bhg_nonce'); ?>
             <input type="hidden" name="bhg_action" value="create_bonus_hunt">
             
             <table class="form-table">
                 <tr>
-                    <th scope="row"><label for="title"><?php _e('Bonus Hunt Title', 'bonus-hunt-guesser'); ?></label></th>
+                    <th scope="row"><label for="title"><?php esc_html_e( 'Bonus Hunt Title', 'bonus-hunt-guesser' ); ?></label></th>
                     <td>
                         <input type="text" name="title" id="title" class="regular-text" required 
                                value="<?php echo isset($_POST['title']) ? esc_attr($_POST['title']) : ''; ?>">
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="starting_balance"><?php _e('Starting Balance (€)', 'bonus-hunt-guesser'); ?></label></th>
+                    <th scope="row"><label for="starting_balance"><?php esc_html_e( 'Starting Balance (€)', 'bonus-hunt-guesser' ); ?></label></th>
                     <td>
-                        <input type="number" name="starting_balance" id="starting_balance" step="0.01" min="0" 
-                               value="<?php echo isset($_POST['starting_balance']) ? floatval($_POST['starting_balance']) : '0'; ?>" required>
+                        <input type="number" name="starting_balance" id="starting_balance" step="0.01" min="0"
+                               value="<?php echo esc_attr( isset( $_POST['starting_balance'] ) ? floatval( $_POST['starting_balance'] ) : '0' ); ?>" required>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="num_bonuses"><?php _e('Number of Bonuses', 'bonus-hunt-guesser'); ?></label></th>
+                    <th scope="row"><label for="num_bonuses"><?php esc_html_e( 'Number of Bonuses', 'bonus-hunt-guesser' ); ?></label></th>
                     <td>
-                        <input type="number" name="num_bonuses" id="num_bonuses" min="1" 
-                               value="<?php echo isset($_POST['num_bonuses']) ? intval($_POST['num_bonuses']) : '10'; ?>" required>
+                        <input type="number" name="num_bonuses" id="num_bonuses" min="1"
+                               value="<?php echo esc_attr( isset( $_POST['num_bonuses'] ) ? intval( $_POST['num_bonuses'] ) : '10' ); ?>" required>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="prizes"><?php _e('Prizes Description', 'bonus-hunt-guesser'); ?></label></th>
+                    <th scope="row"><label for="prizes"><?php esc_html_e( 'Prizes Description', 'bonus-hunt-guesser' ); ?></label></th>
                     <td>
                         <textarea name="prizes" id="prizes" rows="5" class="large-text"><?php 
                             echo isset($_POST['prizes']) ? esc_textarea($_POST['prizes']) : ''; 
@@ -175,20 +175,20 @@ if (isset($_GET['message'])) {
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="status"><?php _e('Status', 'bonus-hunt-guesser'); ?></label></th>
+                    <th scope="row"><label for="status"><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></label></th>
                     <td>
                         <select name="status" id="status" required>
-                            <option value="active"><?php _e('Active', 'bonus-hunt-guesser'); ?></option>
-                            <option value="upcoming"><?php _e('Upcoming', 'bonus-hunt-guesser'); ?></option>
-                            <option value="completed"><?php _e('Completed', 'bonus-hunt-guesser'); ?></option>
+                            <option value="active"><?php esc_html_e( 'Active', 'bonus-hunt-guesser' ); ?></option>
+                            <option value="upcoming"><?php esc_html_e( 'Upcoming', 'bonus-hunt-guesser' ); ?></option>
+                            <option value="completed"><?php esc_html_e( 'Completed', 'bonus-hunt-guesser' ); ?></option>
                         </select>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="affiliate_site_id"><?php _e('Affiliate Website', 'bonus-hunt-guesser'); ?></label></th>
+                    <th scope="row"><label for="affiliate_site_id"><?php esc_html_e( 'Affiliate Website', 'bonus-hunt-guesser' ); ?></label></th>
                     <td>
                         <select name="affiliate_site_id" id="affiliate_site_id">
-                            <option value="0"><?php _e('None', 'bonus-hunt-guesser'); ?></option>
+                            <option value="0"><?php esc_html_e( 'None', 'bonus-hunt-guesser' ); ?></option>
                             <?php foreach ($affiliate_sites as $site) : ?>
                                 <option value="<?php echo esc_attr($site->id); ?>">
                                     <?php echo esc_html($site->name); ?>
@@ -199,23 +199,23 @@ if (isset($_GET['message'])) {
                 </tr>
             </table>
             
-            <?php submit_button(__('Create Bonus Hunt', 'bonus-hunt-guesser')); ?>
+            <?php submit_button( esc_html__( 'Create Bonus Hunt', 'bonus-hunt-guesser' ) ); ?>
         </form>
         
         <hr>
         
-        <h2><?php _e('Existing Bonus Hunts', 'bonus-hunt-guesser'); ?></h2>
+        <h2><?php esc_html_e( 'Existing Bonus Hunts', 'bonus-hunt-guesser' ); ?></h2>
         <table class="wp-list-table widefat fixed striped">
             <thead>
                 <tr>
-                    <th><?php _e('ID', 'bonus-hunt-guesser'); ?></th>
-                    <th><?php _e('Title', 'bonus-hunt-guesser'); ?></th>
-                    <th><?php _e('Starting Balance', 'bonus-hunt-guesser'); ?></th>
-                    <th><?php _e('Final Balance', 'bonus-hunt-guesser'); ?></th>
-                    <th><?php _e('Number of Bonuses', 'bonus-hunt-guesser'); ?></th>
-                    <th><?php _e('Status', 'bonus-hunt-guesser'); ?></th>
-                    <th><?php _e('Created', 'bonus-hunt-guesser'); ?></th>
-                    <th><?php _e('Actions', 'bonus-hunt-guesser'); ?></th>
+                    <th><?php esc_html_e( 'ID', 'bonus-hunt-guesser' ); ?></th>
+                    <th><?php esc_html_e( 'Title', 'bonus-hunt-guesser' ); ?></th>
+                    <th><?php esc_html_e( 'Starting Balance', 'bonus-hunt-guesser' ); ?></th>
+                    <th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
+                    <th><?php esc_html_e( 'Number of Bonuses', 'bonus-hunt-guesser' ); ?></th>
+                    <th><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></th>
+                    <th><?php esc_html_e( 'Created', 'bonus-hunt-guesser' ); ?></th>
+                    <th><?php esc_html_e( 'Actions', 'bonus-hunt-guesser' ); ?></th>
                 </tr>
             </thead>
             <tbody>
@@ -224,12 +224,12 @@ if (isset($_GET['message'])) {
                         <tr>
                             <td><?php echo esc_html($hunt->id); ?></td>
                             <td><?php echo esc_html($hunt->title); ?></td>
-                            <td>€<?php echo number_format($hunt->starting_balance, 2); ?></td>
+                            <td>€<?php echo esc_html( number_format( $hunt->starting_balance, 2 ) ); ?></td>
                             <td>
                                 <?php if ($hunt->final_balance !== null) : ?>
-                                    €<?php echo number_format($hunt->final_balance, 2); ?>
+                                    €<?php echo esc_html( number_format( $hunt->final_balance, 2 ) ); ?>
                                 <?php else : ?>
-                                    <em><?php _e('Not set', 'bonus-hunt-guesser'); ?></em>
+                                    <em><?php esc_html_e( 'Not set', 'bonus-hunt-guesser' ); ?></em>
                                 <?php endif; ?>
                             </td>
                             <td><?php echo esc_html($hunt->num_bonuses); ?></td>
@@ -238,10 +238,10 @@ if (isset($_GET['message'])) {
                                     <?php echo esc_html(ucfirst($hunt->status)); ?>
                                 </span>
                             </td>
-                            <td><?php echo date_i18n(get_option('date_format'), strtotime($hunt->created_at)); ?></td>
+                            <td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $hunt->created_at ) ) ); ?></td>
                             <td>
-                                <a href="<?php echo admin_url('admin.php?page=bhg_bonus_hunts&action=edit&id=' . $hunt->id); ?>" class="button button-small">
-                                    <?php _e('Edit', 'bonus-hunt-guesser'); ?>
+                                <a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg_bonus_hunts&action=edit&id=' . intval( $hunt->id ) ) ); ?>" class="button button-small">
+                                    <?php esc_html_e( 'Edit', 'bonus-hunt-guesser' ); ?>
                                 </a>
                                 <form method="post" style="display:inline;">
                                     <?php wp_nonce_field('bhg_delete_bonus_hunt', 'bhg_nonce'); ?>
@@ -249,7 +249,7 @@ if (isset($_GET['message'])) {
                                     <input type="hidden" name="id" value="<?php echo esc_attr($hunt->id); ?>">
                                     <button type="submit" class="button button-small button-danger"
                                             onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to delete this bonus hunt?', 'bonus-hunt-guesser' ) ); ?>');">
-                                        <?php _e('Delete', 'bonus-hunt-guesser'); ?>
+                                        <?php esc_html_e( 'Delete', 'bonus-hunt-guesser' ); ?>
                                     </button>
                                 </form>
                             </td>
@@ -257,7 +257,7 @@ if (isset($_GET['message'])) {
                     <?php endforeach; ?>
                 <?php else : ?>
                     <tr>
-                        <td colspan="8"><?php _e('No bonus hunts found.', 'bonus-hunt-guesser'); ?></td>
+                        <td colspan="8"><?php esc_html_e( 'No bonus hunts found.', 'bonus-hunt-guesser' ); ?></td>
                     </tr>
                 <?php endif; ?>
             </tbody>


### PR DESCRIPTION
## Summary
- Escape admin headings and labels with `esc_html_e`
- Sanitize dynamic values and URLs before output

## Testing
- `composer run phpcs` (fails: includes/upgrade/add-winners-limit.php)
- `php -l admin/views/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc79561e588333ad2087181f018554