### PR TITLE
Sanitize email data in hunt results notification

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -297,20 +297,27 @@ class BHG_Admin {
 					if ( ! $u ) {
 						continue;
 					}
-					$body = strtr(
-						$template,
-						array(
-							'{{username}}' => $u->user_login,
-							'{{hunt}}'     => $hunt_title,
-							'{{final}}'    => number_format( $final_balance, 2 ),
-							'{{winner}}'   => $winner_first,
-							'{{winners}}'  => $winner_list,
-						)
-					);
+										$username   = sanitize_text_field( $u->user_login );
+										$hunt_title = sanitize_text_field( $hunt_title );
+
+										$body = strtr(
+											$template,
+											array(
+												'{{username}}' => esc_html( $username ),
+												'{{hunt}}' => esc_html( $hunt_title ),
+												'{{final}}' => number_format( $final_balance, 2 ),
+												'{{winner}}' => $winner_first,
+												'{{winners}}' => $winner_list,
+											)
+										);
+
 										wp_mail(
 											$u->user_email,
-											// translators: %s: bonus hunt title.
-												sprintf( __( 'Results for %s', 'bonus-hunt-guesser' ), $hunt_title ? $hunt_title : 'Bonus Hunt' ),
+											sprintf(
+														/* translators: %s: bonus hunt title. */
+												__( 'Results for %s', 'bonus-hunt-guesser' ),
+												$hunt_title ? $hunt_title : __( 'Bonus Hunt', 'bonus-hunt-guesser' )
+											),
 											$body
 										);
 				}


### PR DESCRIPTION
## Summary
- sanitize username and hunt title before including them in hunt results emails
- escape placeholders when inserting into the email template
- document placeholder for the results email subject

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml admin/class-bhg-admin.php`
- `composer phpcs` *(fails: existing coding-standard issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7959e91c833384b1ecc3044975f1