### PR TITLE
Sanitize user table request vars

### DIFF
--- a/admin/class-bhg-users-table.php
+++ b/admin/class-bhg-users-table.php
@@ -63,10 +63,12 @@ class BHG_Users_Table extends WP_List_Table {
 	}
 
 	public function prepare_items() {
-		$paged   = isset($_REQUEST['paged']) ? max(1, (int)$_REQUEST['paged']) : 1;
-		$orderby = isset($_REQUEST['orderby']) ? sanitize_key($_REQUEST['orderby']) : 'username';
-		$order   = isset($_REQUEST['order']) && in_array(strtolower($_REQUEST['order']), ['asc','desc'], true) ? strtoupper($_REQUEST['order']) : 'ASC';
-		$search  = isset($_REQUEST['s']) ? sanitize_text_field(wp_unslash($_REQUEST['s'])) : '';
+                $paged   = isset( $_REQUEST['paged'] ) ? max( 1, (int) wp_unslash( $_REQUEST['paged'] ) ) : 1;
+                $orderby = isset( $_REQUEST['orderby'] ) ? sanitize_key( wp_unslash( $_REQUEST['orderby'] ) ) : 'username';
+                $order   = isset( $_REQUEST['order'] ) && in_array( strtolower( wp_unslash( $_REQUEST['order'] ) ), [ 'asc', 'desc' ], true )
+                        ? strtoupper( wp_unslash( $_REQUEST['order'] ) )
+                        : 'ASC';
+                $search  = isset( $_REQUEST['s'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ) : '';
 
 		// Whitelist orderby
 		$allowed = ['username','email','role','guesses','wins'];


### PR DESCRIPTION
## Summary
- ensure request vars are unslashed before sanitization and casting in admin user table

## Testing
- `vendor/bin/phpcs admin/class-bhg-users-table.php` (fails: 237 errors, 38 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68bc7c03a6548333b95ba2de5ec8a1d4