### PR TITLE
Remove trailing periods from plugin header metadata

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Plugin Name: Bonus Hunt Guesser.
- * Plugin URI: https://yourdomain.com/.
- * Description: Comprehensive bonus hunt management system with tournaments, leaderboards, and user guessing functionality.
- * Version: 8.0.08.
- * Author: Bonus Hunt Guesser Development Team.
- * Text Domain: bonus-hunt-guesser.
- * Domain Path: /languages.
- * Requires at least: 6.3.5.
- * Requires PHP: 7.4.
- * License: GPLv2 or later.
- * MySQL tested up to: 5.5.5.
+ * Plugin Name: Bonus Hunt Guesser
+ * Plugin URI: https://yourdomain.com/
+ * Description: Comprehensive bonus hunt management system with tournaments, leaderboards, and user guessing functionality
+ * Version: 8.0.08
+ * Author: Bonus Hunt Guesser Development Team
+ * Text Domain: bonus-hunt-guesser
+ * Domain Path: /languages
+ * Requires at least: 6.3.5
+ * Requires PHP: 7.4
+ * License: GPLv2 or later
+ * MySQL tested up to: 5.5.5
  *
  * @package Bonus_Hunt_Guesser
  */


### PR DESCRIPTION
## Summary
- remove trailing periods from plugin header fields to match metadata exactly

## Testing
- `phpcs bonus-hunt-guesser.php` (fails: 377 errors, 53 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68bc7c05cf3c8333b7dd627e8a5a8372