### PR TITLE
chore: refine phpcs config and format codebase

### DIFF
--- a/admin/class-bhg-users-table.php
+++ b/admin/class-bhg-users-table.php
@@ -1,171 +1,190 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
-if (!class_exists('WP_List_Table')) {
+if ( ! class_exists( 'WP_List_Table' ) ) {
 	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
 class BHG_Users_Table extends WP_List_Table {
 
-	private $items_data = [];
+	private $items_data  = array();
 	private $total_items = 0;
-	private $per_page = 30;
+	private $per_page    = 30;
 
 	public function __construct() {
-		parent::__construct([
-			'singular' => 'bhg_user',
-			'plural'   => 'bhg_users',
-			'ajax'     => false
-		]);
+		parent::__construct(
+			array(
+				'singular' => 'bhg_user',
+				'plural'   => 'bhg_users',
+				'ajax'     => false,
+			)
+		);
 	}
 
 	public function get_columns() {
-		return [
-			'id'       => __('ID', 'bonus-hunt-guesser'),
-			'username' => __('Username', 'bonus-hunt-guesser'),
-			'email'    => __('Email', 'bonus-hunt-guesser'),
-			'role'     => __('Role', 'bonus-hunt-guesser'),
-			'guesses'  => __('Guesses', 'bonus-hunt-guesser'),
-			'wins'     => __('Wins', 'bonus-hunt-guesser'),
-			'profile'  => __('Profile', 'bonus-hunt-guesser'),
-		];
+		return array(
+			'id'       => __( 'ID', 'bonus-hunt-guesser' ),
+			'username' => __( 'Username', 'bonus-hunt-guesser' ),
+			'email'    => __( 'Email', 'bonus-hunt-guesser' ),
+			'role'     => __( 'Role', 'bonus-hunt-guesser' ),
+			'guesses'  => __( 'Guesses', 'bonus-hunt-guesser' ),
+			'wins'     => __( 'Wins', 'bonus-hunt-guesser' ),
+			'profile'  => __( 'Profile', 'bonus-hunt-guesser' ),
+		);
 	}
 
 	public function get_sortable_columns() {
-		return [
-			'username' => ['username', true],
-			'email'    => ['email', false],
-			'role'     => ['role', false],
-			'guesses'  => ['guesses', false],
-			'wins'     => ['wins', false],
-		];
+		return array(
+			'username' => array( 'username', true ),
+			'email'    => array( 'email', false ),
+			'role'     => array( 'role', false ),
+			'guesses'  => array( 'guesses', false ),
+			'wins'     => array( 'wins', false ),
+		);
 	}
 
-	public function column_default($item, $column_name) {
-		switch ($column_name) {
+	public function column_default( $item, $column_name ) {
+		switch ( $column_name ) {
 			case 'id':
-				return (int)$item['id'];
+				return (int) $item['id'];
 			case 'username':
-				return esc_html($item['username']);
+				return esc_html( $item['username'] );
 			case 'email':
-				return esc_html($item['email']);
+				return esc_html( $item['email'] );
 			case 'role':
-				return esc_html($item['role']);
+				return esc_html( $item['role'] );
 			case 'guesses':
-				return (int)$item['guesses'];
+				return (int) $item['guesses'];
 			case 'wins':
-				return (int)$item['wins'];
+				return (int) $item['wins'];
 			case 'profile':
-				$url = esc_url(admin_url('user-edit.php?user_id='.(int)$item['id']));
-				return '<a class="button" href="'.$url.'">'.esc_html__('Edit', 'bonus-hunt-guesser').'</a>';
+				$url = esc_url( admin_url( 'user-edit.php?user_id=' . (int) $item['id'] ) );
+				return '<a class="button" href="' . $url . '">' . esc_html__( 'Edit', 'bonus-hunt-guesser' ) . '</a>';
 		}
 		return '';
 	}
 
 	public function prepare_items() {
-                $paged   = isset( $_REQUEST['paged'] ) ? max( 1, (int) wp_unslash( $_REQUEST['paged'] ) ) : 1;
-                $orderby = isset( $_REQUEST['orderby'] ) ? sanitize_key( wp_unslash( $_REQUEST['orderby'] ) ) : 'username';
-                $order   = isset( $_REQUEST['order'] ) && in_array( strtolower( wp_unslash( $_REQUEST['order'] ) ), [ 'asc', 'desc' ], true )
-                        ? strtoupper( wp_unslash( $_REQUEST['order'] ) )
-                        : 'ASC';
-                $search  = isset( $_REQUEST['s'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ) : '';
+				$paged   = isset( $_REQUEST['paged'] ) ? max( 1, (int) wp_unslash( $_REQUEST['paged'] ) ) : 1;
+				$orderby = isset( $_REQUEST['orderby'] ) ? sanitize_key( wp_unslash( $_REQUEST['orderby'] ) ) : 'username';
+				$order   = isset( $_REQUEST['order'] ) && in_array( strtolower( wp_unslash( $_REQUEST['order'] ) ), array( 'asc', 'desc' ), true )
+						? strtoupper( wp_unslash( $_REQUEST['order'] ) )
+						: 'ASC';
+				$search  = isset( $_REQUEST['s'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ) : '';
 
 		// Whitelist orderby
-		$allowed = ['username','email','role','guesses','wins'];
-		if (!in_array($orderby, $allowed, true)) $orderby = 'username';
-
-		// Fetch users via WP_User_Query
-		$args = [
-			'number' => $this->per_page,
-			'offset' => ($paged - 1) * $this->per_page,
-			'fields' => ['ID','user_login','user_email','roles'],
-			'orderby'=> in_array($orderby, ['username','email']) ? ($orderby === 'username' ? 'login' : 'email') : 'login',
-			'order'  => $order,
-		];
-		if ($search) {
-			$args['search'] = '*' . $search . '*';
-			$args['search_columns'] = ['user_login','user_email'];
+		$allowed = array( 'username', 'email', 'role', 'guesses', 'wins' );
+		if ( ! in_array( $orderby, $allowed, true ) ) {
+			$orderby = 'username';
 		}
 
-		$query = new WP_User_Query($args);
-		$users = (array)$query->get_results();
-		$this->total_items = (int)$query->get_total();
+		// Fetch users via WP_User_Query
+		$args = array(
+			'number'  => $this->per_page,
+			'offset'  => ( $paged - 1 ) * $this->per_page,
+			'fields'  => array( 'ID', 'user_login', 'user_email', 'roles' ),
+			'orderby' => in_array( $orderby, array( 'username', 'email' ) ) ? ( $orderby === 'username' ? 'login' : 'email' ) : 'login',
+			'order'   => $order,
+		);
+		if ( $search ) {
+			$args['search']         = '*' . $search . '*';
+			$args['search_columns'] = array( 'user_login', 'user_email' );
+		}
+
+		$query             = new WP_User_Query( $args );
+		$users             = (array) $query->get_results();
+		$this->total_items = (int) $query->get_total();
 
 		// Build base items
-		$items = [];
-		$ids = [];
-		foreach ($users as $u) {
-			if ($u instanceof WP_User) {
-				$roles = (array) $u->roles;
-				$role = $roles ? reset($roles) : '';
-				$uid = (int)$u->ID;
-				$ids[] = $uid;
-				$items[$uid] = [
+		$items = array();
+		$ids   = array();
+		foreach ( $users as $u ) {
+			if ( $u instanceof WP_User ) {
+				$roles         = (array) $u->roles;
+				$role          = $roles ? reset( $roles ) : '';
+				$uid           = (int) $u->ID;
+				$ids[]         = $uid;
+				$items[ $uid ] = array(
 					'id'       => $uid,
 					'username' => $u->user_login,
 					'email'    => $u->user_email,
 					'role'     => $role,
 					'guesses'  => 0,
 					'wins'     => 0,
-				];
+				);
 			}
 		}
 
 		global $wpdb;
-		if (!empty($ids)) {
-			$in = implode(',', array_map('intval', $ids));
+		if ( ! empty( $ids ) ) {
+			$in      = implode( ',', array_map( 'intval', $ids ) );
 			$g_table = $wpdb->prefix . 'bhg_guesses';
 			$w_table = $wpdb->prefix . 'bhg_tournament_results';
 
 			// Guesses per user
-			$placeholders = implode(',', array_fill(0, count($ids), '%d'));
-			$sql_g = "SELECT user_id, COUNT(*) c FROM `$g_table` WHERE user_id IN ($placeholders) GROUP BY user_id";
-			$g_counts = $wpdb->get_results( $wpdb->prepare( $sql_g, $ids ) );
+			$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+			$sql_g        = "SELECT user_id, COUNT(*) c FROM `$g_table` WHERE user_id IN ($placeholders) GROUP BY user_id";
+			$g_counts     = $wpdb->get_results( $wpdb->prepare( $sql_g, $ids ) );
 			foreach ( (array) $g_counts as $row ) {
-				$uid = (int)$row->user_id;
-				if (isset($items[ $uid ])) $items[$uid]['guesses'] = (int)$row->c;
+				$uid = (int) $row->user_id;
+				if ( isset( $items[ $uid ] ) ) {
+					$items[ $uid ]['guesses'] = (int) $row->c;
+				}
 			}
 
 			// Wins per user (if table exists)
-			$exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $w_table));
-			if ($exists) {
-				$placeholders = implode(',', array_fill(0, count($ids), '%d'));
-				$sql_w = "SELECT user_id, SUM(wins) c FROM `$w_table` WHERE user_id IN ($placeholders) GROUP BY user_id";
-				$w_counts = $wpdb->get_results( $wpdb->prepare( $sql_w, $ids ) );
+			$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $w_table ) );
+			if ( $exists ) {
+				$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+				$sql_w        = "SELECT user_id, SUM(wins) c FROM `$w_table` WHERE user_id IN ($placeholders) GROUP BY user_id";
+				$w_counts     = $wpdb->get_results( $wpdb->prepare( $sql_w, $ids ) );
 				foreach ( (array) $w_counts as $row ) {
-					$uid = (int)$row->user_id;
-					if (isset($items[ $uid ])) $items[$uid]['wins'] = (int)$row->c;
+					$uid = (int) $row->user_id;
+					if ( isset( $items[ $uid ] ) ) {
+						$items[ $uid ]['wins'] = (int) $row->c;
+					}
 				}
 			}
 		}
 
 		// Server-side sort for role/guesses/wins
-		if (in_array($orderby, ['role','guesses','wins'], true)) {
-			$items = array_values($items);
-			usort($items, function($a,$b) use ($orderby,$order) {
-				$av = $a[$orderby]; $bv = $b[$orderby];
-				if ($av == $bv) return 0;
-				if ($order === 'ASC') return ($av < $bv) ? -1 : 1;
-				return ($av > $bv) ? -1 : 1;
-			});
+		if ( in_array( $orderby, array( 'role', 'guesses', 'wins' ), true ) ) {
+			$items = array_values( $items );
+			usort(
+				$items,
+				function ( $a, $b ) use ( $orderby, $order ) {
+					$av = $a[ $orderby ];
+					$bv = $b[ $orderby ];
+					if ( $av == $bv ) {
+						return 0;
+					}
+					if ( $order === 'ASC' ) {
+						return ( $av < $bv ) ? -1 : 1;
+					}
+					return ( $av > $bv ) ? -1 : 1;
+				}
+			);
 		} else {
-			$items = array_values($items);
+			$items = array_values( $items );
 		}
 
-		$this->items = $items;
-		$this->_column_headers = [$this->get_columns(), [], $this->get_sortable_columns(), 'username'];
+		$this->items           = $items;
+		$this->_column_headers = array( $this->get_columns(), array(), $this->get_sortable_columns(), 'username' );
 
-		$this->set_pagination_args([
-			'total_items' => $this->total_items,
-			'per_page'    => $this->per_page,
-			'total_pages' => ceil($this->total_items / $this->per_page),
-		]);
+		$this->set_pagination_args(
+			array(
+				'total_items' => $this->total_items,
+				'per_page'    => $this->per_page,
+				'total_pages' => ceil( $this->total_items / $this->per_page ),
+			)
+		);
 	}
 
-	public function extra_tablenav($which) {
-		if ($which === 'top') {
+	public function extra_tablenav( $which ) {
+		if ( $which === 'top' ) {
 			echo '<div class="alignleft actions">';
-			$this->search_box( __('Search users','bonus-hunt-guesser'), 'bhg-users' );
+			$this->search_box( __( 'Search users', 'bonus-hunt-guesser' ), 'bhg-users' );
 			echo '</div>';
 		}
 	}

--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -1,27 +1,28 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
-if (!current_user_can('manage_options')) {
-	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
 global $wpdb;
-$table = $wpdb->prefix . 'bhg_ads';
-$allowed_tables = [ $wpdb->prefix . 'bhg_ads' ];
+$table          = $wpdb->prefix . 'bhg_ads';
+$allowed_tables = array( $wpdb->prefix . 'bhg_ads' );
 if ( ! in_array( $table, $allowed_tables, true ) ) {
 	wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
-$table  = esc_sql( $table );
+$table = esc_sql( $table );
 
-$action   = isset( $_GET['action'] ) ? sanitize_key( wp_unslash( $_GET['action'] ) ) : '';
-$ad_id    = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
-$edit_id  = isset( $_GET['edit'] ) ? absint( wp_unslash( $_GET['edit'] ) ) : 0;
+$action  = isset( $_GET['action'] ) ? sanitize_key( wp_unslash( $_GET['action'] ) ) : '';
+$ad_id   = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
+$edit_id = isset( $_GET['edit'] ) ? absint( wp_unslash( $_GET['edit'] ) ) : 0;
 
 // Delete action
 if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
 	$nonce = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );
 	if ( wp_verify_nonce( $nonce, 'bhg_delete_ad' ) && current_user_can( 'manage_options' ) ) {
-		$wpdb->delete( $table, [ 'id' => $ad_id ], [ '%d' ] );
-		wp_safe_redirect( remove_query_arg( [ 'action', 'id', '_wpnonce' ] ) );
+		$wpdb->delete( $table, array( 'id' => $ad_id ), array( '%d' ) );
+		wp_safe_redirect( remove_query_arg( array( 'action', 'id', '_wpnonce' ) ) );
 		exit;
 	}
 }
@@ -32,123 +33,143 @@ $ads = $wpdb->get_results(
 );
 ?>
 <div class="wrap">
-  <h1 class="wp-heading-inline"><?php echo esc_html__('Advertising', 'bonus-hunt-guesser'); ?></h1>
+	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Advertising', 'bonus-hunt-guesser' ); ?></h1>
 
-  <h2 style="margin-top:1em"><?php echo esc_html__('Existing Ads', 'bonus-hunt-guesser'); ?></h2>
-  <table class="widefat striped">
+	<h2 style="margin-top:1em"><?php echo esc_html__( 'Existing Ads', 'bonus-hunt-guesser' ); ?></h2>
+	<table class="widefat striped">
 	<thead>
-	  <tr>
-		<th><?php echo esc_html__('ID', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Title/Content', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Placement', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Visible To', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Active', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
-	  </tr>
+		<tr>
+		<th><?php echo esc_html__( 'ID', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Title/Content', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Placement', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Visible To', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Active', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Actions', 'bonus-hunt-guesser' ); ?></th>
+		</tr>
 	</thead>
 	<tbody>
-	  <?php if (empty($ads)) : ?>
-		<tr><td colspan="6"><?php echo esc_html__('No ads yet.', 'bonus-hunt-guesser'); ?></td></tr>
-	  <?php else : foreach ($ads as $ad) : ?>
+		<?php if ( empty( $ads ) ) : ?>
+		<tr><td colspan="6"><?php echo esc_html__( 'No ads yet.', 'bonus-hunt-guesser' ); ?></td></tr>
+			<?php
+		else :
+			foreach ( $ads as $ad ) :
+				?>
 		<tr>
-		  <td><?php echo (int)$ad->id; ?></td>
-		  <td><?php echo isset($ad->title) && $ad->title !== '' ? esc_html($ad->title) : wp_kses_post(wp_trim_words($ad->content, 12)); ?></td>
-		  <td><?php echo esc_html(isset($ad->placement)? $ad->placement : 'none'); ?></td>
-		  <td><?php echo esc_html(isset($ad->visible_to)? $ad->visible_to : 'all'); ?></td>
-		  <td><?php echo (int)$ad->active === 1 ? esc_html__('Yes','bonus-hunt-guesser') : esc_html__('No','bonus-hunt-guesser'); ?></td>
-		  <td>
-			<a class="button" href="<?php echo esc_url(add_query_arg(['edit'=> (int)$ad->id])); ?>"><?php echo esc_html__('Edit', 'bonus-hunt-guesser'); ?></a>
-			<a class="button-link-delete" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['action'=>'delete','id'=>(int)$ad->id]), 'bhg_delete_ad')); ?>" onclick="return confirm('<?php echo esc_js( __( 'Delete this ad?', 'bonus-hunt-guesser' ) ); ?>');"><?php echo esc_html__('Remove', 'bonus-hunt-guesser'); ?></a>
-		  </td>
+			<td><?php echo (int) $ad->id; ?></td>
+			<td><?php echo isset( $ad->title ) && $ad->title !== '' ? esc_html( $ad->title ) : wp_kses_post( wp_trim_words( $ad->content, 12 ) ); ?></td>
+			<td><?php echo esc_html( isset( $ad->placement ) ? $ad->placement : 'none' ); ?></td>
+			<td><?php echo esc_html( isset( $ad->visible_to ) ? $ad->visible_to : 'all' ); ?></td>
+			<td><?php echo (int) $ad->active === 1 ? esc_html__( 'Yes', 'bonus-hunt-guesser' ) : esc_html__( 'No', 'bonus-hunt-guesser' ); ?></td>
+			<td>
+			<a class="button" href="<?php echo esc_url( add_query_arg( array( 'edit' => (int) $ad->id ) ) ); ?>"><?php echo esc_html__( 'Edit', 'bonus-hunt-guesser' ); ?></a>
+			<a class="button-link-delete" href="
+				<?php
+				echo esc_url(
+					wp_nonce_url(
+						add_query_arg(
+							array(
+								'action' => 'delete',
+								'id'     => (int) $ad->id,
+							)
+						),
+						'bhg_delete_ad'
+					)
+				);
+				?>
+												" onclick="return confirm('<?php echo esc_js( __( 'Delete this ad?', 'bonus-hunt-guesser' ) ); ?>');"><?php echo esc_html__( 'Remove', 'bonus-hunt-guesser' ); ?></a>
+			</td>
 		</tr>
-	  <?php endforeach; endif; ?>
+					<?php
+		endforeach;
+endif;
+		?>
 	</tbody>
-  </table>
+	</table>
 
-  <h2 style="margin-top:2em"><?php echo $edit_id ? esc_html__('Edit Ad', 'bonus-hunt-guesser') : esc_html__('Add Ad', 'bonus-hunt-guesser'); ?></h2>
-  <?php
-        $ad = null;
-        if ( $edit_id ) {
-                $ad = $wpdb->get_row(
-                        $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $edit_id )
-                );
-        }
-  ?>
-  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="max-width:800px">
-	<?php wp_nonce_field('bhg_save_ad'); ?>
+	<h2 style="margin-top:2em"><?php echo $edit_id ? esc_html__( 'Edit Ad', 'bonus-hunt-guesser' ) : esc_html__( 'Add Ad', 'bonus-hunt-guesser' ); ?></h2>
+	<?php
+		$ad = null;
+	if ( $edit_id ) {
+			$ad = $wpdb->get_row(
+				$wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $edit_id )
+			);
+	}
+	?>
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="max-width:800px">
+	<?php wp_nonce_field( 'bhg_save_ad' ); ?>
 	<input type="hidden" name="action" value="bhg_save_ad">
-	<?php if ($ad) : ?>
-	  <input type="hidden" name="id" value="<?php echo (int)$ad->id; ?>">
+	<?php if ( $ad ) : ?>
+		<input type="hidden" name="id" value="<?php echo (int) $ad->id; ?>">
 	<?php endif; ?>
 
 	<table class="form-table" role="presentation">
-	  <tbody>
+		<tbody>
 		<tr>
-		  <th scope="row"><label for="bhg_ad_title"><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input class="regular-text" id="bhg_ad_title" name="title" value="<?php echo esc_attr($ad ? ($ad->title ?? '') : ''); ?>"></td>
+			<th scope="row"><label for="bhg_ad_title"><?php echo esc_html__( 'Title', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input class="regular-text" id="bhg_ad_title" name="title" value="<?php echo esc_attr( $ad ? ( $ad->title ?? '' ) : '' ); ?>"></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_ad_content"><?php echo esc_html__('Content', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><textarea class="large-text" rows="3" id="bhg_ad_content" name="content"><?php echo esc_textarea($ad ? ($ad->content ?? '') : ''); ?></textarea></td>
+			<th scope="row"><label for="bhg_ad_content"><?php echo esc_html__( 'Content', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><textarea class="large-text" rows="3" id="bhg_ad_content" name="content"><?php echo esc_textarea( $ad ? ( $ad->content ?? '' ) : '' ); ?></textarea></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_ad_link"><?php echo esc_html__('Link URL (optional)', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input class="regular-text" id="bhg_ad_link" name="link_url" value="<?php echo esc_attr($ad ? ($ad->link_url ?? '') : ''); ?>"></td>
+			<th scope="row"><label for="bhg_ad_link"><?php echo esc_html__( 'Link URL (optional)', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input class="regular-text" id="bhg_ad_link" name="link_url" value="<?php echo esc_attr( $ad ? ( $ad->link_url ?? '' ) : '' ); ?>"></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_ad_place"><?php echo esc_html__('Placement', 'bonus-hunt-guesser'); ?></label></th>
-		  <td>
+			<th scope="row"><label for="bhg_ad_place"><?php echo esc_html__( 'Placement', 'bonus-hunt-guesser' ); ?></label></th>
+			<td>
 			<select id="bhg_ad_place" name="placement">
-			  <?php
-				$placement_opts   = ['none', 'footer', 'bottom', 'sidebar', 'shortcode'];
-				$placement_labels = [
-					'none'      => __('None', 'bonus-hunt-guesser'),
-					'footer'    => __('Footer', 'bonus-hunt-guesser'),
-					'bottom'    => __('Bottom', 'bonus-hunt-guesser'),
-					'sidebar'   => __('Sidebar', 'bonus-hunt-guesser'),
-					'shortcode' => __('Shortcode', 'bonus-hunt-guesser'),
-				];
-				$sel = $ad ? ($ad->placement ?? 'none') : 'none';
+				<?php
+				$placement_opts   = array( 'none', 'footer', 'bottom', 'sidebar', 'shortcode' );
+				$placement_labels = array(
+					'none'      => __( 'None', 'bonus-hunt-guesser' ),
+					'footer'    => __( 'Footer', 'bonus-hunt-guesser' ),
+					'bottom'    => __( 'Bottom', 'bonus-hunt-guesser' ),
+					'sidebar'   => __( 'Sidebar', 'bonus-hunt-guesser' ),
+					'shortcode' => __( 'Shortcode', 'bonus-hunt-guesser' ),
+				);
+				$sel              = $ad ? ( $ad->placement ?? 'none' ) : 'none';
 				foreach ( $placement_opts as $o ) {
 					$label = $placement_labels[ $o ] ?? $o;
 					echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
 				}
-			  ?>
+				?>
 			</select>
-		  </td>
+			</td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_ad_vis"><?php echo esc_html__('Visible To', 'bonus-hunt-guesser'); ?></label></th>
-		  <td>
+			<th scope="row"><label for="bhg_ad_vis"><?php echo esc_html__( 'Visible To', 'bonus-hunt-guesser' ); ?></label></th>
+			<td>
 			<select id="bhg_ad_vis" name="visible_to">
-			  <?php
-				$visible_opts   = ['all', 'guests', 'logged_in', 'affiliates', 'non_affiliates'];
-				$visible_labels = [
-					'all'            => __('All', 'bonus-hunt-guesser'),
-					'guests'         => __('Guests', 'bonus-hunt-guesser'),
-					'logged_in'      => __('Logged In', 'bonus-hunt-guesser'),
-					'affiliates'     => __('Affiliates', 'bonus-hunt-guesser'),
-					'non_affiliates' => __('Non Affiliates', 'bonus-hunt-guesser'),
-				];
-				$sel = $ad ? ($ad->visible_to ?? 'all') : 'all';
+				<?php
+				$visible_opts   = array( 'all', 'guests', 'logged_in', 'affiliates', 'non_affiliates' );
+				$visible_labels = array(
+					'all'            => __( 'All', 'bonus-hunt-guesser' ),
+					'guests'         => __( 'Guests', 'bonus-hunt-guesser' ),
+					'logged_in'      => __( 'Logged In', 'bonus-hunt-guesser' ),
+					'affiliates'     => __( 'Affiliates', 'bonus-hunt-guesser' ),
+					'non_affiliates' => __( 'Non Affiliates', 'bonus-hunt-guesser' ),
+				);
+				$sel            = $ad ? ( $ad->visible_to ?? 'all' ) : 'all';
 				foreach ( $visible_opts as $o ) {
 					$label = $visible_labels[ $o ] ?? $o;
 					echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
 				}
-			  ?>
+				?>
 			</select>
-		  </td>
+			</td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_ad_targets"><?php echo esc_html__('Target Page Slugs', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input class="regular-text" id="bhg_ad_targets" name="target_pages" value="<?php echo esc_attr($ad ? ($ad->target_pages ?? '') : ''); ?>" placeholder="page-slug-1,page-slug-2"></td>
+			<th scope="row"><label for="bhg_ad_targets"><?php echo esc_html__( 'Target Page Slugs', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input class="regular-text" id="bhg_ad_targets" name="target_pages" value="<?php echo esc_attr( $ad ? ( $ad->target_pages ?? '' ) : '' ); ?>" placeholder="page-slug-1,page-slug-2"></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_ad_active"><?php echo esc_html__('Active', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input type="checkbox" id="bhg_ad_active" name="active" value="1" <?php checked($ad ? ($ad->active ?? 1) : 1, 1); ?>></td>
+			<th scope="row"><label for="bhg_ad_active"><?php echo esc_html__( 'Active', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input type="checkbox" id="bhg_ad_active" name="active" value="1" <?php checked( $ad ? ( $ad->active ?? 1 ) : 1, 1 ); ?>></td>
 		</tr>
-	  </tbody>
+		</tbody>
 	</table>
-	<?php submit_button($ad ? __('Update Ad', 'bonus-hunt-guesser') : __('Create Ad', 'bonus-hunt-guesser')); ?>
-  </form>
+	<?php submit_button( $ad ? __( 'Update Ad', 'bonus-hunt-guesser' ) : __( 'Create Ad', 'bonus-hunt-guesser' ) ); ?>
+	</form>
 </div>

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -1,80 +1,93 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
-if (!current_user_can('manage_options')) {
-	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 global $wpdb;
 $table = $wpdb->prefix . 'bhg_affiliates';
 
 // Load for edit
-$edit_id = isset($_GET['edit']) ? (int) $_GET['edit'] : 0;
-$row = $edit_id ? $wpdb->get_row($wpdb->prepare("SELECT * FROM `$table` WHERE id=%d", $edit_id)) : null;
+$edit_id = isset( $_GET['edit'] ) ? (int) $_GET['edit'] : 0;
+$row     = $edit_id ? $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `$table` WHERE id=%d", $edit_id ) ) : null;
 
 // List
 $rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
 ?>
 <div class="wrap">
-  <h1 class="wp-heading-inline"><?php echo esc_html__('Affiliates', 'bonus-hunt-guesser'); ?></h1>
+	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Affiliates', 'bonus-hunt-guesser' ); ?></h1>
 
-  <h2 style="margin-top:1em"><?php echo esc_html__('All Affiliate Websites', 'bonus-hunt-guesser'); ?></h2>
-  <table class="widefat striped">
+	<h2 style="margin-top:1em"><?php echo esc_html__( 'All Affiliate Websites', 'bonus-hunt-guesser' ); ?></h2>
+	<table class="widefat striped">
 	<thead>
-	  <tr>
-		<th><?php esc_html_e('ID','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Name','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('URL','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Status','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Actions','bonus-hunt-guesser'); ?></th>
-	  </tr>
+		<tr>
+		<th><?php esc_html_e( 'ID', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Name', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'URL', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Actions', 'bonus-hunt-guesser' ); ?></th>
+		</tr>
 	</thead>
 	<tbody>
-	  <?php if (empty($rows)) : ?>
-		<tr><td colspan="5"><em><?php esc_html_e('No affiliates yet.','bonus-hunt-guesser'); ?></em></td></tr>
-	  <?php else : foreach ($rows as $r) : ?>
+		<?php if ( empty( $rows ) ) : ?>
+		<tr><td colspan="5"><em><?php esc_html_e( 'No affiliates yet.', 'bonus-hunt-guesser' ); ?></em></td></tr>
+			<?php
+		else :
+			foreach ( $rows as $r ) :
+				?>
 		<tr>
-		  <td><?php echo (int)$r->id; ?></td>
-		  <td><?php echo esc_html($r->name); ?></td>
-		  <td><?php echo esc_html($r->url); ?></td>
-		  <td><?php echo esc_html($r->status); ?></td>
-		  <td>
-			<a class="button" href="<?php echo esc_url(add_query_arg(['edit'=>(int)$r->id])); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
-			<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline" onsubmit="return confirm('<?php echo esc_js(__('Delete this affiliate?', 'bonus-hunt-guesser')); ?>');">
-			  <?php wp_nonce_field('bhg_delete_affiliate'); ?>
-			  <input type="hidden" name="action" value="bhg_delete_affiliate">
-			  <input type="hidden" name="id" value="<?php echo (int)$r->id; ?>">
-			  <button class="button-link-delete" type="submit"><?php esc_html_e('Remove','bonus-hunt-guesser'); ?></button>
+			<td><?php echo (int) $r->id; ?></td>
+			<td><?php echo esc_html( $r->name ); ?></td>
+			<td><?php echo esc_html( $r->url ); ?></td>
+			<td><?php echo esc_html( $r->status ); ?></td>
+			<td>
+			<a class="button" href="<?php echo esc_url( add_query_arg( array( 'edit' => (int) $r->id ) ) ); ?>"><?php esc_html_e( 'Edit', 'bonus-hunt-guesser' ); ?></a>
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline" onsubmit="return confirm('<?php echo esc_js( __( 'Delete this affiliate?', 'bonus-hunt-guesser' ) ); ?>');">
+							<?php wp_nonce_field( 'bhg_delete_affiliate' ); ?>
+				<input type="hidden" name="action" value="bhg_delete_affiliate">
+				<input type="hidden" name="id" value="<?php echo (int) $r->id; ?>">
+				<button class="button-link-delete" type="submit"><?php esc_html_e( 'Remove', 'bonus-hunt-guesser' ); ?></button>
 			</form>
-		  </td>
+			</td>
 		</tr>
-	  <?php endforeach; endif; ?>
+					<?php
+					endforeach;
+endif;
+		?>
 	</tbody>
-  </table>
-
-  <h2 style="margin-top:2em"><?php echo $row ? esc_html__('Edit Affiliate','bonus-hunt-guesser') : esc_html__('Add Affiliate','bonus-hunt-guesser'); ?></h2>
-  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="max-width:800px">
-	<?php wp_nonce_field('bhg_save_affiliate'); ?>
-	<input type="hidden" name="action" value="bhg_save_affiliate">
-	<?php if ($row): ?><input type="hidden" name="id" value="<?php echo (int)$row->id; ?>"><?php endif; ?>
-	<table class="form-table">
-	  <tr>
-		<th><label for="aff_name"><?php esc_html_e('Name','bonus-hunt-guesser'); ?></label></th>
-		<td><input class="regular-text" id="aff_name" name="name" value="<?php echo esc_attr($row->name ?? ''); ?>" required></td>
-	  </tr>
-	  <tr>
-		<th><label for="aff_url"><?php esc_html_e('URL','bonus-hunt-guesser'); ?></label></th>
-		<td><input class="regular-text" id="aff_url" name="url" value="<?php echo esc_attr($row->url ?? ''); ?>" placeholder="https://example.com"></td>
-	  </tr>
-	  <tr>
-		<th><label for="aff_status"><?php esc_html_e('Status','bonus-hunt-guesser'); ?></label></th>
-		<td>
-		  <select id="aff_status" name="status">
-			<?php $opts=['active','inactive']; $cur = $row->status ?? 'active'; foreach ($opts as $o): ?>
-			  <option value="<?php echo esc_attr($o); ?>" <?php selected($cur, $o); ?>><?php echo esc_html(ucfirst($o)); ?></option>
-			<?php endforeach; ?>
-		  </select>
-		</td>
-	  </tr>
 	</table>
-	<?php submit_button($row ? __('Update Affiliate','bonus-hunt-guesser') : __('Create Affiliate','bonus-hunt-guesser')); ?>
-  </form>
+
+	<h2 style="margin-top:2em"><?php echo $row ? esc_html__( 'Edit Affiliate', 'bonus-hunt-guesser' ) : esc_html__( 'Add Affiliate', 'bonus-hunt-guesser' ); ?></h2>
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="max-width:800px">
+	<?php wp_nonce_field( 'bhg_save_affiliate' ); ?>
+	<input type="hidden" name="action" value="bhg_save_affiliate">
+	<?php
+	if ( $row ) :
+		?>
+		<input type="hidden" name="id" value="<?php echo (int) $row->id; ?>"><?php endif; ?>
+	<table class="form-table">
+		<tr>
+		<th><label for="aff_name"><?php esc_html_e( 'Name', 'bonus-hunt-guesser' ); ?></label></th>
+		<td><input class="regular-text" id="aff_name" name="name" value="<?php echo esc_attr( $row->name ?? '' ); ?>" required></td>
+		</tr>
+		<tr>
+		<th><label for="aff_url"><?php esc_html_e( 'URL', 'bonus-hunt-guesser' ); ?></label></th>
+		<td><input class="regular-text" id="aff_url" name="url" value="<?php echo esc_attr( $row->url ?? '' ); ?>" placeholder="https://example.com"></td>
+		</tr>
+		<tr>
+		<th><label for="aff_status"><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></label></th>
+		<td>
+			<select id="aff_status" name="status">
+			<?php
+			$opts = array( 'active', 'inactive' );
+			$cur  = $row->status ?? 'active'; foreach ( $opts as $o ) :
+				?>
+				<option value="<?php echo esc_attr( $o ); ?>" <?php selected( $cur, $o ); ?>><?php echo esc_html( ucfirst( $o ) ); ?></option>
+						<?php endforeach; ?>
+			</select>
+		</td>
+		</tr>
+	</table>
+	<?php submit_button( $row ? __( 'Update Affiliate', 'bonus-hunt-guesser' ) : __( 'Create Affiliate', 'bonus-hunt-guesser' ) ); ?>
+	</form>
 </div>

--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -33,15 +33,15 @@ $pages    = max( 1, (int) ceil( $total / $per_page ) );
 $base     = remove_query_arg( 'ppaged' );
 ?>
 <div class="wrap">
-        <?php
-        $message = isset( $_GET['message'] ) ? sanitize_text_field( wp_unslash( $_GET['message'] ) ) : '';
-        if ( 'guess_deleted' === $message ) {
-                echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__( 'Guess removed successfully.', 'bonus-hunt-guesser' ) . '</p></div>';
-        } elseif ( 'error' === $message ) {
-                echo '<div class="notice notice-error is-dismissible"><p>' . esc_html__( 'An error occurred. Please try again.', 'bonus-hunt-guesser' ) . '</p></div>';
-        }
-        ?>
-        <h1 class="wp-heading-inline"><?php echo esc_html__( 'Edit Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
+		<?php
+		$message = isset( $_GET['message'] ) ? sanitize_text_field( wp_unslash( $_GET['message'] ) ) : '';
+		if ( 'guess_deleted' === $message ) {
+				echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__( 'Guess removed successfully.', 'bonus-hunt-guesser' ) . '</p></div>';
+		} elseif ( 'error' === $message ) {
+				echo '<div class="notice notice-error is-dismissible"><p>' . esc_html__( 'An error occurred. Please try again.', 'bonus-hunt-guesser' ) . '</p></div>';
+		}
+		?>
+		<h1 class="wp-heading-inline"><?php echo esc_html__( 'Edit Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
 
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
 		<?php wp_nonce_field( 'bhg_save_hunt' ); ?>
@@ -83,7 +83,7 @@ $base     = remove_query_arg( 'ppaged' );
 				</tr>
 				<tr>
 					<th scope="row"><label for="bhg_final"><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></label></th>
-                                       <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html__( '-', 'bonus-hunt-guesser' ) ); ?>"></td>
+										<td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html__( '-', 'bonus-hunt-guesser' ) ); ?>"></td>
 				</tr>
 				<tr>
 					<th scope="row"><label for="bhg_status"><?php echo esc_html__( 'Status', 'bonus-hunt-guesser' ); ?></label></th>
@@ -96,7 +96,7 @@ $base     = remove_query_arg( 'ppaged' );
 				</tr>
 			</tbody>
 		</table>
-                <?php submit_button( esc_html__( 'Save Hunt', 'bonus-hunt-guesser' ) ); ?>
+				<?php submit_button( esc_html__( 'Save Hunt', 'bonus-hunt-guesser' ) ); ?>
 	</form>
 
 	<h2 class="bhg-margin-top-large"><?php esc_html_e( 'Participants', 'bonus-hunt-guesser' ); ?></h2>
@@ -117,29 +117,29 @@ $base     = remove_query_arg( 'ppaged' );
 				<?php
 			else :
 				foreach ( $rows as $r ) :
-					$u    = get_userdata( (int) $r->user_id );
-                                        $name = $u ? $u->display_name : sprintf( esc_html__( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
+					$u                        = get_userdata( (int) $r->user_id );
+										$name = $u ? $u->display_name : sprintf( esc_html__( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
 					?>
 				<tr>
 					<td><a href="<?php echo esc_url( admin_url( 'user-edit.php?user_id=' . (int) $r->user_id ) ); ?>"><?php echo esc_html( $name ); ?></a></td>
 					<td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>
-                                       <td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '-', 'bonus-hunt-guesser' ); ?></td>
-                                       <td>
-                                               <?php
-                                               $delete_url = wp_nonce_url(
-                                                       add_query_arg(
-                                                               array(
-                                                                       'action'   => 'bhg_delete_guess',
-                                                                       'guess_id' => (int) $r->id,
-                                                               ),
-                                                               admin_url( 'admin-post.php' )
-                                                       ),
-                                                       'bhg_delete_guess'
-                                               );
-                                               ?>
-                                               <a href="<?php echo esc_url( $delete_url ); ?>" class="button-link-delete" onclick="return confirm('<?php echo esc_js( __( 'Delete this guess?', 'bonus-hunt-guesser' ) ); ?>');"><?php esc_html_e( 'Remove', 'bonus-hunt-guesser' ); ?></a>
-                                       </td>
-                                </tr>
+										<td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '-', 'bonus-hunt-guesser' ); ?></td>
+										<td>
+												<?php
+												$delete_url = wp_nonce_url(
+													add_query_arg(
+														array(
+															'action'   => 'bhg_delete_guess',
+															'guess_id' => (int) $r->id,
+														),
+														admin_url( 'admin-post.php' )
+													),
+													'bhg_delete_guess'
+												);
+												?>
+												<a href="<?php echo esc_url( $delete_url ); ?>" class="button-link-delete" onclick="return confirm('<?php echo esc_js( __( 'Delete this guess?', 'bonus-hunt-guesser' ) ); ?>');"><?php esc_html_e( 'Remove', 'bonus-hunt-guesser' ); ?></a>
+										</td>
+								</tr>
 							<?php
 			endforeach;
 endif;

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -1,12 +1,17 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
-if (!current_user_can('manage_options')) wp_die(esc_html__('Insufficient permissions','bonus-hunt-guesser'));
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'Insufficient permissions', 'bonus-hunt-guesser' ) );
+}
 global $wpdb;
-$hunt_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-$hunts = $wpdb->prefix.'bhg_bonus_hunts';
-$guesses = $wpdb->prefix.'bhg_guesses';
-$hunt = $wpdb->get_row($wpdb->prepare("SELECT * FROM `$hunts` WHERE id=%d",$hunt_id));
-if(!$hunt) { echo '<div class="wrap"><h1>'.esc_html__('Hunt not found','bonus-hunt-guesser').'</h1></div>'; return; }
+$hunt_id = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
+$hunts   = $wpdb->prefix . 'bhg_bonus_hunts';
+$guesses = $wpdb->prefix . 'bhg_guesses';
+$hunt    = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `$hunts` WHERE id=%d", $hunt_id ) );
+if ( ! $hunt ) {
+	echo '<div class="wrap"><h1>' . esc_html__( 'Hunt not found', 'bonus-hunt-guesser' ) . '</h1></div>';
+	return; }
 $rows = $wpdb->get_results(
 	$wpdb->prepare(
 		"SELECT g.*, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
@@ -16,23 +21,38 @@ $rows = $wpdb->get_results(
 );
 ?>
 <div class="wrap">
-  <h1><?php echo esc_html__('Results for ','bonus-hunt-guesser').esc_html($hunt->title); ?></h1>
-  <table class="widefat striped">
+	<h1><?php echo esc_html__( 'Results for ', 'bonus-hunt-guesser' ) . esc_html( $hunt->title ); ?></h1>
+	<table class="widefat striped">
 	<thead><tr>
-	  <th><?php esc_html_e('Position','bonus-hunt-guesser'); ?></th>
-	  <th><?php esc_html_e('User','bonus-hunt-guesser'); ?></th>
-	  <th><?php esc_html_e('Guess','bonus-hunt-guesser'); ?></th>
-	  <th><?php esc_html_e('Difference','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e( 'Position', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'User', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Guess', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Difference', 'bonus-hunt-guesser' ); ?></th>
 	</tr></thead>
 	<tbody>
-	<?php $pos=1; foreach($rows as $r): $wcount = (int)$hunt->winners_count; if ($wcount < 1) $wcount = 3; $isWinner = $pos <= $wcount; ?>
-	  <tr <?php if($isWinner) echo 'class="bhg-winner-row"'; ?>>
-		<td><?php echo (int)$pos; ?></td>
-		<td><?php echo esc_html($r->display_name); ?></td>
-		<td><?php echo esc_html(number_format_i18n((float)$r->guess,2)); ?></td>
-		<td><?php echo esc_html(number_format_i18n((float)$r->diff,2)); ?></td>
-	  </tr>
-	<?php $pos++; endforeach; ?>
+	<?php
+	$pos = 1;
+	foreach ( $rows as $r ) :
+		$wcount = (int) $hunt->winners_count;
+		if ( $wcount < 1 ) {
+			$wcount = 3;
+		} $isWinner = $pos <= $wcount;
+		?>
+		<tr 
+		<?php
+		if ( $isWinner ) {
+			echo 'class="bhg-winner-row"';}
+		?>
+		>
+		<td><?php echo (int) $pos; ?></td>
+		<td><?php echo esc_html( $r->display_name ); ?></td>
+		<td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>
+		<td><?php echo esc_html( number_format_i18n( (float) $r->diff, 2 ) ); ?></td>
+		</tr>
+		<?php
+		++$pos;
+endforeach;
+	?>
 	</tbody>
-  </table>
+	</table>
 </div>

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -1,5 +1,6 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
 /**
  * Admin view for managing bonus hunts.
@@ -10,14 +11,14 @@ if ( ! current_user_can( 'manage_options' ) ) {
 }
 
 global $wpdb;
-$hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
-$guesses_table = $wpdb->prefix . 'bhg_guesses';
-$allowed_tables = [
+$hunts_table    = $wpdb->prefix . 'bhg_bonus_hunts';
+$guesses_table  = $wpdb->prefix . 'bhg_guesses';
+$allowed_tables = array(
 	$wpdb->prefix . 'bhg_bonus_hunts',
 	$wpdb->prefix . 'bhg_guesses',
 	$wpdb->prefix . 'bhg_affiliates',
 	$wpdb->users,
-];
+);
 if ( ! in_array( $hunts_table, $allowed_tables, true ) || ! in_array( $guesses_table, $allowed_tables, true ) ) {
 	wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
@@ -28,148 +29,188 @@ $view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] 
 
 /** LIST VIEW */
 if ( 'list' === $view ) :
-        $current_page = max( 1, isset( $_GET['paged'] ) ? (int) wp_unslash( $_GET['paged'] ) : 1 );
-        $per_page     = 30;
-        $offset       = ( $current_page - 1 ) * $per_page;
+		$current_page = max( 1, isset( $_GET['paged'] ) ? (int) wp_unslash( $_GET['paged'] ) : 1 );
+		$per_page     = 30;
+		$offset       = ( $current_page - 1 ) * $per_page;
 
-        $hunts = $wpdb->get_results(
-                $wpdb->prepare(
-                        "SELECT * FROM {$hunts_table} ORDER BY id DESC LIMIT %d OFFSET %d",
-                        $per_page,
-                        $offset
-                )
-        );
+		$hunts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$hunts_table} ORDER BY id DESC LIMIT %d OFFSET %d",
+				$per_page,
+				$offset
+			)
+		);
 
-        $total    = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$hunts_table}" );
-        $base_url = remove_query_arg( [ 'paged' ] );
-?>
+		$total    = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$hunts_table}" );
+		$base_url = remove_query_arg( array( 'paged' ) );
+	?>
 <div class="wrap">
-  <h1 class="wp-heading-inline"><?php echo esc_html__('Bonus Hunts', 'bonus-hunt-guesser'); ?></h1>
-  <a href="<?php echo esc_url(add_query_arg(['view'=>'add'])); ?>" class="page-title-action"><?php echo esc_html__('Add New', 'bonus-hunt-guesser'); ?></a>
+	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Bonus Hunts', 'bonus-hunt-guesser' ); ?></h1>
+	<a href="<?php echo esc_url( add_query_arg( array( 'view' => 'add' ) ) ); ?>" class="page-title-action"><?php echo esc_html__( 'Add New', 'bonus-hunt-guesser' ); ?></a>
 
-  <?php if ( isset( $_GET['closed'] ) && '1' === sanitize_text_field( wp_unslash( $_GET['closed'] ) ) ) : ?>
+	<?php if ( isset( $_GET['closed'] ) && '1' === sanitize_text_field( wp_unslash( $_GET['closed'] ) ) ) : ?>
 	<div class="notice notice-success is-dismissible"><p><?php echo esc_html__( 'Hunt closed successfully.', 'bonus-hunt-guesser' ); ?></p></div>
-  <?php endif; ?>
+	<?php endif; ?>
 
-  <table class="widefat striped bhg-margin-top-small">
+	<table class="widefat striped bhg-margin-top-small">
 	<thead>
-	  <tr>
-		<th><?php echo esc_html__('ID', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Start Balance', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Final Balance', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Winners', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Status', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
-	  </tr>
+		<tr>
+		<th><?php echo esc_html__( 'ID', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Title', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Winners', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Status', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Actions', 'bonus-hunt-guesser' ); ?></th>
+		</tr>
 	</thead>
 	<tbody>
-	  <?php if ( empty( $hunts ) ) : ?>
-		<tr><td colspan="7"><?php echo esc_html__('No hunts found.', 'bonus-hunt-guesser'); ?></td></tr>
-	  <?php else : foreach ( $hunts as $h ) : ?>
+		<?php if ( empty( $hunts ) ) : ?>
+		<tr><td colspan="7"><?php echo esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ); ?></td></tr>
+			<?php
+		else :
+			foreach ( $hunts as $h ) :
+				?>
 		<tr>
-		  <td><?php echo (int) $h->id; ?></td>
-		  <td><a href="<?php echo esc_url( add_query_arg( [ 'view' => 'edit', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html( $h->title ); ?></a></td>
-		  <td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-                  <td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-		  <td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
-		  <td><?php echo esc_html( $h->status ); ?></td>
-		  <td>
-			<a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'edit', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Edit', 'bonus-hunt-guesser' ); ?></a>
-			<?php if ( 'open' === $h->status ) : ?>
-			  <a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'close', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
+			<td><?php echo (int) $h->id; ?></td>
+			<td><a href="
+				<?php
+				echo esc_url(
+					add_query_arg(
+						array(
+							'view' => 'edit',
+							'id'   => (int) $h->id,
+						)
+					)
+				);
+				?>
+							"><?php echo esc_html( $h->title ); ?></a></td>
+			<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
+					<td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+			<td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
+			<td><?php echo esc_html( $h->status ); ?></td>
+			<td>
+			<a class="button" href="
+				<?php
+				echo esc_url(
+					add_query_arg(
+						array(
+							'view' => 'edit',
+							'id'   => (int) $h->id,
+						)
+					)
+				);
+				?>
+									"><?php echo esc_html__( 'Edit', 'bonus-hunt-guesser' ); ?></a>
+				<?php if ( 'open' === $h->status ) : ?>
+				<a class="button" href="
+					<?php
+					echo esc_url(
+						add_query_arg(
+							array(
+								'view' => 'close',
+								'id'   => (int) $h->id,
+							)
+						)
+					);
+					?>
+										"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
 			<?php elseif ( $h->final_balance !== null ) : ?>
-			  <a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
+				<a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
 			<?php endif; ?>
-		  </td>
+			</td>
 		</tr>
-          <?php endforeach; endif; ?>
-        </tbody>
-  </table>
+				<?php
+			endforeach;
+endif;
+		?>
+		</tbody>
+	</table>
 
-  <?php
-        $total_pages = (int) ceil( $total / $per_page );
-        if ( $total_pages > 1 ) {
-                echo '<div class="tablenav"><div class="tablenav-pages">';
-                echo paginate_links(
-                        [
-                                'base'      => add_query_arg( 'paged', '%#%', $base_url ),
-                                'format'    => '',
-                                'prev_text' => '&laquo;',
-                                'next_text' => '&raquo;',
-                                'total'     => $total_pages,
-                                'current'   => $current_page,
-                        ]
-                );
-                echo '</div></div>';
-        }
-  ?>
+	<?php
+		$total_pages = (int) ceil( $total / $per_page );
+	if ( $total_pages > 1 ) {
+			echo '<div class="tablenav"><div class="tablenav-pages">';
+			echo paginate_links(
+				array(
+					'base'      => add_query_arg( 'paged', '%#%', $base_url ),
+					'format'    => '',
+					'prev_text' => '&laquo;',
+					'next_text' => '&raquo;',
+					'total'     => $total_pages,
+					'current'   => $current_page,
+				)
+			);
+			echo '</div></div>';
+	}
+	?>
 </div>
 <?php endif; ?>
 
 <?php
 /** CLOSE VIEW */
 if ( 'close' === $view ) :
-        $id   = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
-	$hunt = $wpdb->get_row(
+		$id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
+	$hunt   = $wpdb->get_row(
 		$wpdb->prepare( "SELECT * FROM {$hunts_table} WHERE id = %d", $id )
 	);
 	if ( ! $hunt || 'open' !== $hunt->status ) :
 		echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt.', 'bonus-hunt-guesser' ) . '</p></div>';
 	else :
-?>
+		?>
 <div class="wrap">
-  <h1 class="wp-heading-inline"><?php echo esc_html__( 'Close Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
-  <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-400 bhg-margin-top-small">
-	<?php wp_nonce_field( 'bhg_close_hunt' ); ?>
+	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Close Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-400 bhg-margin-top-small">
+		<?php wp_nonce_field( 'bhg_close_hunt' ); ?>
 	<input type="hidden" name="action" value="bhg_close_hunt" />
 	<input type="hidden" name="hunt_id" value="<?php echo (int) $hunt->id; ?>" />
 	<table class="form-table" role="presentation">
-	  <tbody>
+		<tbody>
 		<tr>
-		  <th scope="row"><label for="bhg_final_balance"><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></label></th>
-		  <td><input type="number" step="0.01" min="0" id="bhg_final_balance" name="final_balance" required></td>
+			<th scope="row"><label for="bhg_final_balance"><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input type="number" step="0.01" min="0" id="bhg_final_balance" name="final_balance" required></td>
 		</tr>
-	  </tbody>
+		</tbody>
 	</table>
-        <?php submit_button( esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ) ); ?>
-  </form>
+		<?php submit_button( esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ) ); ?>
+	</form>
 </div>
-<?php
+		<?php
 	endif;
 endif;
 ?>
 
 <?php
 /** ADD VIEW */
-if ($view === 'add') : ?>
+if ( $view === 'add' ) :
+	?>
 <div class="wrap">
-  <h1 class="wp-heading-inline"><?php echo esc_html__('Add New Bonus Hunt', 'bonus-hunt-guesser'); ?></h1>
-  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="bhg-max-width-900 bhg-margin-top-small">
-	<?php wp_nonce_field('bhg_save_hunt'); ?>
+	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Add New Bonus Hunt', 'bonus-hunt-guesser' ); ?></h1>
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
+	<?php wp_nonce_field( 'bhg_save_hunt' ); ?>
 	<input type="hidden" name="action" value="bhg_save_hunt" />
 
 	<table class="form-table" role="presentation">
-	  <tbody>
+		<tbody>
 		<tr>
-		  <th scope="row"><label for="bhg_title"><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input required class="regular-text" id="bhg_title" name="title" value=""></td>
+			<th scope="row"><label for="bhg_title"><?php echo esc_html__( 'Title', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input required class="regular-text" id="bhg_title" name="title" value=""></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_starting"><?php echo esc_html__('Starting Balance', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input type="number" step="0.01" min="0" id="bhg_starting" name="starting_balance" value=""></td>
+			<th scope="row"><label for="bhg_starting"><?php echo esc_html__( 'Starting Balance', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input type="number" step="0.01" min="0" id="bhg_starting" name="starting_balance" value=""></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_num"><?php echo esc_html__('Number of Bonuses', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input type="number" min="0" id="bhg_num" name="num_bonuses" value=""></td>
+			<th scope="row"><label for="bhg_num"><?php echo esc_html__( 'Number of Bonuses', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input type="number" min="0" id="bhg_num" name="num_bonuses" value=""></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_prizes"><?php echo esc_html__('Prizes', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"></textarea></td>
+			<th scope="row"><label for="bhg_prizes"><?php echo esc_html__( 'Prizes', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"></textarea></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__('Affiliate Site', 'bonus-hunt-guesser'); ?></label></th>
-		  <td>
+			<th scope="row"><label for="bhg_affiliate"><?php echo esc_html__( 'Affiliate Site', 'bonus-hunt-guesser' ); ?></label></th>
+			<td>
 			<?php
 			$aff_table = $wpdb->prefix . 'bhg_affiliates';
 			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
@@ -182,46 +223,51 @@ if ($view === 'add') : ?>
 			$sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
 			?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
-			  <option value="0"><?php echo esc_html__('None', 'bonus-hunt-guesser'); ?></option>
-			  <?php foreach ($affs as $a): ?>
-				<option value="<?php echo (int)$a->id; ?>" <?php if ($sel === (int)$a->id) echo 'selected'; ?>><?php echo esc_html($a->name); ?></option>
-			  <?php endforeach; ?>
+				<option value="0"><?php echo esc_html__( 'None', 'bonus-hunt-guesser' ); ?></option>
+				<?php foreach ( $affs as $a ) : ?>
+				<option value="<?php echo (int) $a->id; ?>" 
+					<?php
+					if ( $sel === (int) $a->id ) {
+						echo 'selected';}
+					?>
+				><?php echo esc_html( $a->name ); ?></option>
+				<?php endforeach; ?>
 			</select>
-		  </td>
+			</td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_winners"><?php echo esc_html__('Number of Winners', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="3"></td>
+			<th scope="row"><label for="bhg_winners"><?php echo esc_html__( 'Number of Winners', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="3"></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_status"><?php echo esc_html__('Status', 'bonus-hunt-guesser'); ?></label></th>
-		  <td>
+			<th scope="row"><label for="bhg_status"><?php echo esc_html__( 'Status', 'bonus-hunt-guesser' ); ?></label></th>
+			<td>
 			<select id="bhg_status" name="status">
-			  <option value="open"><?php echo esc_html__('Open', 'bonus-hunt-guesser'); ?></option>
-			  <option value="closed"><?php echo esc_html__('Closed', 'bonus-hunt-guesser'); ?></option>
+				<option value="open"><?php echo esc_html__( 'Open', 'bonus-hunt-guesser' ); ?></option>
+				<option value="closed"><?php echo esc_html__( 'Closed', 'bonus-hunt-guesser' ); ?></option>
 			</select>
-		  </td>
+			</td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_final"><?php echo esc_html__('Final Balance (optional)', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value=""></td>
+			<th scope="row"><label for="bhg_final"><?php echo esc_html__( 'Final Balance (optional)', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value=""></td>
 		</tr>
-	  </tbody>
+		</tbody>
 	</table>
-        <?php submit_button( esc_html__( 'Create Bonus Hunt', 'bonus-hunt-guesser' ) ); ?>
-  </form>
+		<?php submit_button( esc_html__( 'Create Bonus Hunt', 'bonus-hunt-guesser' ) ); ?>
+	</form>
 </div>
 <?php endif; ?>
 
 <?php
 /** EDIT VIEW */
-if ($view === 'edit') :
-        $id    = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
-	$hunt  = $wpdb->get_row(
+if ( $view === 'edit' ) :
+		$id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
+	$hunt   = $wpdb->get_row(
 		$wpdb->prepare( "SELECT * FROM {$hunts_table} WHERE id = %d", $id )
 	);
-	if (!$hunt) {
-		echo '<div class="notice notice-error"><p>'.esc_html__('Invalid hunt', 'bonus-hunt-guesser').'</p></div>';
+	if ( ! $hunt ) {
+		echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt', 'bonus-hunt-guesser' ) . '</p></div>';
 		return;
 	}
 	$users_table = $wpdb->users;
@@ -235,36 +281,36 @@ if ($view === 'edit') :
 			$id
 		)
 	);
-?>
+	?>
 <div class="wrap">
-  <h1 class="wp-heading-inline"><?php echo esc_html__( 'Edit Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
+	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Edit Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
 
-  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="bhg-max-width-900 bhg-margin-top-small">
-	<?php wp_nonce_field('bhg_save_hunt'); ?>
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
+	<?php wp_nonce_field( 'bhg_save_hunt' ); ?>
 	<input type="hidden" name="action" value="bhg_save_hunt" />
-	<input type="hidden" name="id" value="<?php echo (int)$hunt->id; ?>" />
+	<input type="hidden" name="id" value="<?php echo (int) $hunt->id; ?>" />
 
 	<table class="form-table" role="presentation">
-	  <tbody>
+		<tbody>
 		<tr>
-		  <th scope="row"><label for="bhg_title"><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input required class="regular-text" id="bhg_title" name="title" value="<?php echo esc_attr($hunt->title); ?>"></td>
+			<th scope="row"><label for="bhg_title"><?php echo esc_html__( 'Title', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input required class="regular-text" id="bhg_title" name="title" value="<?php echo esc_attr( $hunt->title ); ?>"></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_starting"><?php echo esc_html__('Starting Balance', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input type="number" step="0.01" min="0" id="bhg_starting" name="starting_balance" value="<?php echo esc_attr($hunt->starting_balance); ?>"></td>
+			<th scope="row"><label for="bhg_starting"><?php echo esc_html__( 'Starting Balance', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input type="number" step="0.01" min="0" id="bhg_starting" name="starting_balance" value="<?php echo esc_attr( $hunt->starting_balance ); ?>"></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_num"><?php echo esc_html__('Number of Bonuses', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input type="number" min="0" id="bhg_num" name="num_bonuses" value="<?php echo esc_attr($hunt->num_bonuses); ?>"></td>
+			<th scope="row"><label for="bhg_num"><?php echo esc_html__( 'Number of Bonuses', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input type="number" min="0" id="bhg_num" name="num_bonuses" value="<?php echo esc_attr( $hunt->num_bonuses ); ?>"></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_prizes"><?php echo esc_html__('Prizes', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"><?php echo esc_textarea($hunt->prizes); ?></textarea></td>
+			<th scope="row"><label for="bhg_prizes"><?php echo esc_html__( 'Prizes', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"><?php echo esc_textarea( $hunt->prizes ); ?></textarea></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__('Affiliate Site', 'bonus-hunt-guesser'); ?></label></th>
-		  <td>
+			<th scope="row"><label for="bhg_affiliate"><?php echo esc_html__( 'Affiliate Site', 'bonus-hunt-guesser' ); ?></label></th>
+			<td>
 			<?php
 			$aff_table = $wpdb->prefix . 'bhg_affiliates';
 			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
@@ -277,69 +323,80 @@ if ($view === 'edit') :
 			$sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
 			?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
-			  <option value="0"><?php echo esc_html__('None', 'bonus-hunt-guesser'); ?></option>
-			  <?php foreach ($affs as $a): ?>
-				<option value="<?php echo (int)$a->id; ?>" <?php if ($sel === (int)$a->id) echo 'selected'; ?>><?php echo esc_html($a->name); ?></option>
-			  <?php endforeach; ?>
+				<option value="0"><?php echo esc_html__( 'None', 'bonus-hunt-guesser' ); ?></option>
+				<?php foreach ( $affs as $a ) : ?>
+				<option value="<?php echo (int) $a->id; ?>" 
+					<?php
+					if ( $sel === (int) $a->id ) {
+						echo 'selected';}
+					?>
+				><?php echo esc_html( $a->name ); ?></option>
+				<?php endforeach; ?>
 			</select>
-		  </td>
+			</td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_winners"><?php echo esc_html__('Number of Winners', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr($hunt->winners_count ?: 3); ?>"></td>
+			<th scope="row"><label for="bhg_winners"><?php echo esc_html__( 'Number of Winners', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ?: 3 ); ?>"></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_final"><?php echo esc_html__('Final Balance', 'bonus-hunt-guesser'); ?></label></th>
-                  <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html__( '—', 'bonus-hunt-guesser' ) ); ?>"></td>
+			<th scope="row"><label for="bhg_final"><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></label></th>
+					<td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html__( '—', 'bonus-hunt-guesser' ) ); ?>"></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="bhg_status"><?php echo esc_html__('Status', 'bonus-hunt-guesser'); ?></label></th>
-		  <td>
+			<th scope="row"><label for="bhg_status"><?php echo esc_html__( 'Status', 'bonus-hunt-guesser' ); ?></label></th>
+			<td>
 			<select id="bhg_status" name="status">
-			  <option value="open" <?php selected($hunt->status, 'open'); ?>><?php echo esc_html__('Open', 'bonus-hunt-guesser'); ?></option>
-			  <option value="closed" <?php selected($hunt->status, 'closed'); ?>><?php echo esc_html__('Closed', 'bonus-hunt-guesser'); ?></option>
+				<option value="open" <?php selected( $hunt->status, 'open' ); ?>><?php echo esc_html__( 'Open', 'bonus-hunt-guesser' ); ?></option>
+				<option value="closed" <?php selected( $hunt->status, 'closed' ); ?>><?php echo esc_html__( 'Closed', 'bonus-hunt-guesser' ); ?></option>
 			</select>
-		  </td>
+			</td>
 		</tr>
-	  </tbody>
+		</tbody>
 	</table>
-        <?php submit_button( esc_html__( 'Save Hunt', 'bonus-hunt-guesser' ) ); ?>
-  </form>
+		<?php submit_button( esc_html__( 'Save Hunt', 'bonus-hunt-guesser' ) ); ?>
+	</form>
 
-  <h2 class="bhg-margin-top-large"><?php echo esc_html__('Participants', 'bonus-hunt-guesser'); ?></h2>
-  <table class="widefat striped">
+	<h2 class="bhg-margin-top-large"><?php echo esc_html__( 'Participants', 'bonus-hunt-guesser' ); ?></h2>
+	<table class="widefat striped">
 	<thead>
-	  <tr>
-		<th><?php echo esc_html__('User', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Guess', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
-	  </tr>
+		<tr>
+		<th><?php echo esc_html__( 'User', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Guess', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Actions', 'bonus-hunt-guesser' ); ?></th>
+		</tr>
 	</thead>
 	<tbody>
-	  <?php if (empty($guesses)) : ?>
-		<tr><td colspan="3"><?php echo esc_html__('No participants yet.', 'bonus-hunt-guesser'); ?></td></tr>
-	  <?php else : foreach ($guesses as $g) : ?>
-		<tr>
-		  <td>
+		<?php if ( empty( $guesses ) ) : ?>
+		<tr><td colspan="3"><?php echo esc_html__( 'No participants yet.', 'bonus-hunt-guesser' ); ?></td></tr>
 			<?php
-                          /* translators: %d: user ID. */
-                          $name = $g->display_name ? $g->display_name : sprintf( esc_html__( 'user#%d', 'bonus-hunt-guesser' ), (int) $g->user_id );
-			  $url  = admin_url('user-edit.php?user_id=' . (int)$g->user_id);
-			  echo '<a href="' . esc_url($url) . '">' . esc_html($name) . '</a>';
-			?>
-		  </td>
-		  <td><?php echo esc_html(number_format_i18n((float)($g->guess ?? 0), 2)); ?></td>
-		  <td>
-			<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" onsubmit="return confirm('<?php echo esc_js(__('Delete this guess?', 'bonus-hunt-guesser')); ?>');" class="bhg-inline-form">
-			  <?php wp_nonce_field('bhg_delete_guess'); ?>
-			  <input type="hidden" name="action" value="bhg_delete_guess">
-			  <input type="hidden" name="guess_id" value="<?php echo (int)$g->id; ?>">
-			  <button type="submit" class="button-link-delete"><?php echo esc_html__('Remove', 'bonus-hunt-guesser'); ?></button>
+		else :
+			foreach ( $guesses as $g ) :
+				?>
+		<tr>
+			<td>
+							<?php
+										/* translators: %d: user ID. */
+										$name = $g->display_name ? $g->display_name : sprintf( esc_html__( 'user#%d', 'bonus-hunt-guesser' ), (int) $g->user_id );
+							$url              = admin_url( 'user-edit.php?user_id=' . (int) $g->user_id );
+							echo '<a href="' . esc_url( $url ) . '">' . esc_html( $name ) . '</a>';
+							?>
+			</td>
+			<td><?php echo esc_html( number_format_i18n( (float) ( $g->guess ?? 0 ), 2 ) ); ?></td>
+			<td>
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( __( 'Delete this guess?', 'bonus-hunt-guesser' ) ); ?>');" class="bhg-inline-form">
+				<?php wp_nonce_field( 'bhg_delete_guess' ); ?>
+				<input type="hidden" name="action" value="bhg_delete_guess">
+				<input type="hidden" name="guess_id" value="<?php echo (int) $g->id; ?>">
+				<button type="submit" class="button-link-delete"><?php echo esc_html__( 'Remove', 'bonus-hunt-guesser' ); ?></button>
 			</form>
-		  </td>
+			</td>
 		</tr>
-	  <?php endforeach; endif; ?>
+					<?php
+		endforeach;
+endif;
+		?>
 	</tbody>
-  </table>
+	</table>
 </div>
 <?php endif; ?>

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -21,57 +21,57 @@ if ( ! function_exists( 'bhg_get_latest_closed_hunts' ) ) {
 $hunts = bhg_get_latest_closed_hunts( 3 );
 ?>
 <div class="wrap">
-  <h1><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h1>
-  <table class="widefat striped">
+	<h1><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h1>
+	<table class="widefat striped">
 	<thead>
-	  <tr>
+		<tr>
 		<th><?php esc_html_e( 'Bonushunt', 'bonus-hunt-guesser' ); ?></th>
 		<th><?php esc_html_e( 'All Winners', 'bonus-hunt-guesser' ); ?></th>
 		<th><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
 		<th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
 		<th><?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?></th>
-	  </tr>
+		</tr>
 	</thead>
 	<tbody>
-	  <?php if ( $hunts ) : ?>
-		<?php foreach ( $hunts as $h ) : ?>
-		  <?php
-		  $winners = function_exists( 'bhg_get_top_winners_for_hunt' )
-			  ? bhg_get_top_winners_for_hunt( $h->id, (int) $h->winners_count )
-			  : array();
-		  ?>
-		  <tr>
+		<?php if ( $hunts ) : ?>
+			<?php foreach ( $hunts as $h ) : ?>
+				<?php
+				$winners = function_exists( 'bhg_get_top_winners_for_hunt' )
+				? bhg_get_top_winners_for_hunt( $h->id, (int) $h->winners_count )
+				: array();
+				?>
+			<tr>
 			<td><?php echo esc_html( $h->title ); ?></td>
 			<td>
-			  <?php
-			  if ( $winners ) {
-				  $out = array();
-				  foreach ( $winners as $w ) {
-					  $u  = get_userdata( (int) $w->user_id );
-					  $nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
-                                          $out[] = sprintf(
-                                                  '%s %s %s (%s %s)',
-                                                  esc_html( $nm ),
-                                                  esc_html__( '—', 'bonus-hunt-guesser' ),
-                                                  esc_html( number_format_i18n( (float) $w->guess, 2 ) ),
-                                                  esc_html__( 'diff', 'bonus-hunt-guesser' ),
-                                                  esc_html( number_format_i18n( (float) $w->diff, 2 ) )
-                                          );
-				  }
-				  echo esc_html( implode( ' • ', $out ) );
-			  } else {
-				  esc_html_e( 'No winners yet', 'bonus-hunt-guesser' );
-			  }
-			  ?>
+				<?php
+				if ( $winners ) {
+					$out = array();
+					foreach ( $winners as $w ) {
+						$u                         = get_userdata( (int) $w->user_id );
+						$nm                        = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
+											$out[] = sprintf(
+												'%s %s %s (%s %s)',
+												esc_html( $nm ),
+												esc_html__( '—', 'bonus-hunt-guesser' ),
+												esc_html( number_format_i18n( (float) $w->guess, 2 ) ),
+												esc_html__( 'diff', 'bonus-hunt-guesser' ),
+												esc_html( number_format_i18n( (float) $w->diff, 2 ) )
+											);
+					}
+					echo esc_html( implode( ' • ', $out ) );
+				} else {
+					esc_html_e( 'No winners yet', 'bonus-hunt-guesser' );
+				}
+				?>
 			</td>
 			<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-                        <td><?php echo ( $h->final_balance !== null ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-                        <td><?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-		  </tr>
+						<td><?php echo ( $h->final_balance !== null ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+						<td><?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+			</tr>
 		<?php endforeach; ?>
-	  <?php else : ?>
+		<?php else : ?>
 		<tr><td colspan="5"><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></td></tr>
-	  <?php endif; ?>
+		<?php endif; ?>
 	</tbody>
-  </table>
+	</table>
 </div>

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -1,26 +1,26 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
-if (!current_user_can('manage_options')) {
-	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
 // Handle form submissions
-if (isset($_POST['bhg_action'])) {
-	if ($_POST['bhg_action'] === 'db_cleanup' && isset($_POST['bhg_db_cleanup'])) {
-		if (!wp_verify_nonce($_POST['bhg_nonce'], 'bhg_db_cleanup_action')) {
-			wp_die(esc_html__('Security check failed', 'bonus-hunt-guesser'));
+if ( isset( $_POST['bhg_action'] ) ) {
+	if ( $_POST['bhg_action'] === 'db_cleanup' && isset( $_POST['bhg_db_cleanup'] ) ) {
+		if ( ! wp_verify_nonce( $_POST['bhg_nonce'], 'bhg_db_cleanup_action' ) ) {
+			wp_die( esc_html__( 'Security check failed', 'bonus-hunt-guesser' ) );
 		}
-		
+
 		// Perform database cleanup
 		bhg_database_cleanup();
 		$cleanup_completed = true;
-	} 
-	elseif ($_POST['bhg_action'] === 'db_optimize' && isset($_POST['bhg_db_optimize'])) {
-		if (!wp_verify_nonce($_POST['bhg_nonce'], 'bhg_db_optimize_action')) {
-			wp_die(esc_html__('Security check failed', 'bonus-hunt-guesser'));
+	} elseif ( $_POST['bhg_action'] === 'db_optimize' && isset( $_POST['bhg_db_optimize'] ) ) {
+		if ( ! wp_verify_nonce( $_POST['bhg_nonce'], 'bhg_db_optimize_action' ) ) {
+			wp_die( esc_html__( 'Security check failed', 'bonus-hunt-guesser' ) );
 		}
-		
+
 		// Perform database optimization
 		bhg_database_optimize();
 		$optimize_completed = true;
@@ -30,7 +30,7 @@ if (isset($_POST['bhg_action'])) {
 // Database cleanup function
 function bhg_database_cleanup() {
 	global $wpdb;
-	
+
 	$tables = array(
 		$wpdb->prefix . 'bhg_bonus_hunts',
 		$wpdb->prefix . 'bhg_guesses',
@@ -39,15 +39,15 @@ function bhg_database_cleanup() {
 		$wpdb->prefix . 'bhg_translations',
 		$wpdb->prefix . 'bhg_affiliate_websites',
 		$wpdb->prefix . 'bhg_hunt_winners',
-		$wpdb->prefix . 'bhg_ads'
+		$wpdb->prefix . 'bhg_ads',
 	);
-	
+
 	foreach ( $tables as $table ) {
 		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
 			$wpdb->query( "TRUNCATE TABLE {$table}" );
 		}
 	}
-	
+
 	// Reinsert default data if needed
 	bhg_insert_demo_data();
 }
@@ -55,7 +55,7 @@ function bhg_database_cleanup() {
 // Database optimization function
 function bhg_database_optimize() {
 	global $wpdb;
-	
+
 	$tables = array(
 		$wpdb->prefix . 'bhg_bonus_hunts',
 		$wpdb->prefix . 'bhg_guesses',
@@ -64,9 +64,9 @@ function bhg_database_optimize() {
 		$wpdb->prefix . 'bhg_translations',
 		$wpdb->prefix . 'bhg_affiliate_websites',
 		$wpdb->prefix . 'bhg_hunt_winners',
-		$wpdb->prefix . 'bhg_ads'
+		$wpdb->prefix . 'bhg_ads',
 	);
-	
+
 	foreach ( $tables as $table ) {
 		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
 			$wpdb->query( "OPTIMIZE TABLE {$table}" );
@@ -78,56 +78,56 @@ function bhg_database_optimize() {
 function bhg_insert_demo_data() {
 	// This would typically be in a separate file like includes/demo.php
 	global $wpdb;
-	
+
 	// Insert default bonus hunt
 	$wpdb->insert(
 		$wpdb->prefix . 'bhg_bonus_hunts',
 		array(
-			'title' => 'Demo Bonus Hunt',
-			'starting_balance' => 2000,
+			'title'             => 'Demo Bonus Hunt',
+			'starting_balance'  => 2000,
 			'number_of_bonuses' => 10,
-			'status' => 'active',
-			'created_at' => current_time('mysql')
+			'status'            => 'active',
+			'created_at'        => current_time( 'mysql' ),
 		),
-		array('%s', '%d', '%d', '%s', '%s')
+		array( '%s', '%d', '%d', '%s', '%s' )
 	);
 }
 ?>
 <div class="wrap bhg-wrap">
-	<h1><?php esc_html_e('Database Tools', 'bonus-hunt-guesser'); ?></h1>
-	<p><?php esc_html_e('Tables are automatically created on activation. If you need to reinstall them, deactivate and activate the plugin again.', 'bonus-hunt-guesser'); ?></p>
+	<h1><?php esc_html_e( 'Database Tools', 'bonus-hunt-guesser' ); ?></h1>
+	<p><?php esc_html_e( 'Tables are automatically created on activation. If you need to reinstall them, deactivate and activate the plugin again.', 'bonus-hunt-guesser' ); ?></p>
 	
-	<?php if (isset($cleanup_completed) && $cleanup_completed) : ?>
+	<?php if ( isset( $cleanup_completed ) && $cleanup_completed ) : ?>
 		<div class="notice notice-success">
-			<p><?php esc_html_e('Database cleanup completed successfully.', 'bonus-hunt-guesser'); ?></p>
+			<p><?php esc_html_e( 'Database cleanup completed successfully.', 'bonus-hunt-guesser' ); ?></p>
 		</div>
 	<?php endif; ?>
 	
-	<?php if (isset($optimize_completed) && $optimize_completed) : ?>
+	<?php if ( isset( $optimize_completed ) && $optimize_completed ) : ?>
 		<div class="notice notice-success">
-			<p><?php esc_html_e('Database optimization completed successfully.', 'bonus-hunt-guesser'); ?></p>
+			<p><?php esc_html_e( 'Database optimization completed successfully.', 'bonus-hunt-guesser' ); ?></p>
 		</div>
 	<?php endif; ?>
 	
 	<form method="post" action="">
-		<?php wp_nonce_field('bhg_db_cleanup_action', 'bhg_nonce'); ?>
+		<?php wp_nonce_field( 'bhg_db_cleanup_action', 'bhg_nonce' ); ?>
 		<input type="hidden" name="bhg_action" value="db_cleanup">
 		<p>
-			<input type="submit" name="bhg_db_cleanup" class="button button-secondary" value="<?php esc_attr_e('Run Database Cleanup', 'bonus-hunt-guesser'); ?>"
-				   onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to run database cleanup? This action cannot be undone.', 'bonus-hunt-guesser' ) ); ?>')">
+			<input type="submit" name="bhg_db_cleanup" class="button button-secondary" value="<?php esc_attr_e( 'Run Database Cleanup', 'bonus-hunt-guesser' ); ?>"
+					onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to run database cleanup? This action cannot be undone.', 'bonus-hunt-guesser' ) ); ?>')">
 		</p>
 		<p class="description">
-			<?php esc_html_e('Note: This will remove any demo data and reset tables to their initial state.', 'bonus-hunt-guesser'); ?>
+			<?php esc_html_e( 'Note: This will remove any demo data and reset tables to their initial state.', 'bonus-hunt-guesser' ); ?>
 		</p>
 	</form>
 	
-	<h2><?php esc_html_e('Current Database Status', 'bonus-hunt-guesser'); ?></h2>
+	<h2><?php esc_html_e( 'Current Database Status', 'bonus-hunt-guesser' ); ?></h2>
 	<table class="wp-list-table widefat fixed striped">
 		<thead>
 			<tr>
-				<th><?php esc_html_e('Table Name', 'bonus-hunt-guesser'); ?></th>
-				<th><?php esc_html_e('Status', 'bonus-hunt-guesser'); ?></th>
-				<th><?php esc_html_e('Rows', 'bonus-hunt-guesser'); ?></th>
+				<th><?php esc_html_e( 'Table Name', 'bonus-hunt-guesser' ); ?></th>
+				<th><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></th>
+				<th><?php esc_html_e( 'Rows', 'bonus-hunt-guesser' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -141,30 +141,30 @@ function bhg_insert_demo_data() {
 				'bhg_translations',
 				'bhg_affiliate_websites',
 				'bhg_hunt_winners',
-				'bhg_ads'
+				'bhg_ads',
 			);
-			
+
 			foreach ( $tables as $table ) {
 				$table_name = $wpdb->prefix . $table;
 				$exists     = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name;
 				$row_count  = $exists ? (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$table_name}`" ) : 0;
-				
+
 				echo '<tr>';
-				echo '<td>' . esc_html($table_name) . '</td>';
-				echo '<td><span class="' . ($exists ? 'dashicons dashicons-yes-alt" style="color: #46b450"' : 'dashicons dashicons-no" style="color: #dc3232"') . '"></span> ' . ($exists ? esc_html__('Exists', 'bonus-hunt-guesser') : esc_html__('Missing', 'bonus-hunt-guesser')) . '</td>';
-				echo '<td>' . esc_html(number_format_i18n($row_count)) . '</td>';
+				echo '<td>' . esc_html( $table_name ) . '</td>';
+				echo '<td><span class="' . ( $exists ? 'dashicons dashicons-yes-alt" style="color: #46b450"' : 'dashicons dashicons-no" style="color: #dc3232"' ) . '"></span> ' . ( $exists ? esc_html__( 'Exists', 'bonus-hunt-guesser' ) : esc_html__( 'Missing', 'bonus-hunt-guesser' ) ) . '</td>';
+				echo '<td>' . esc_html( number_format_i18n( $row_count ) ) . '</td>';
 				echo '</tr>';
 			}
 			?>
 		</tbody>
 	</table>
 	
-	<h2><?php esc_html_e('Database Maintenance', 'bonus-hunt-guesser'); ?></h2>
+	<h2><?php esc_html_e( 'Database Maintenance', 'bonus-hunt-guesser' ); ?></h2>
 	<form method="post" action="">
-		<?php wp_nonce_field('bhg_db_optimize_action', 'bhg_nonce'); ?>
+		<?php wp_nonce_field( 'bhg_db_optimize_action', 'bhg_nonce' ); ?>
 		<input type="hidden" name="bhg_action" value="db_optimize">
 		<p>
-			<input type="submit" name="bhg_db_optimize" class="button button-primary" value="<?php esc_attr_e('Optimize Database Tables', 'bonus-hunt-guesser'); ?>">
+			<input type="submit" name="bhg_db_optimize" class="button button-primary" value="<?php esc_attr_e( 'Optimize Database Tables', 'bonus-hunt-guesser' ); ?>">
 		</p>
 	</form>
 </div>

--- a/admin/views/demo-data.php
+++ b/admin/views/demo-data.php
@@ -1,4 +1,3 @@
 <?php
 // Demo data installer for Bonus Hunt Guesser
 // Seeds sample hunts, guesses, tournaments, ads, translations
-?>

--- a/admin/views/demo-tools.php
+++ b/admin/views/demo-tools.php
@@ -1,14 +1,14 @@
 <?php
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
 <div class="wrap">
-	<h1><?php esc_html_e('Demo Tools', 'bonus-hunt-guesser'); ?></h1>
-	<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+	<h1><?php esc_html_e( 'Demo Tools', 'bonus-hunt-guesser' ); ?></h1>
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 		<input type="hidden" name="action" value="bhg_demo_reseed">
-		<?php wp_nonce_field('bhg_demo_reseed_action', 'bhg_demo_reseed_nonce'); ?>
-		<p><?php esc_html_e('This will delete all demo data and pages, then recreate fresh demo content.', 'bonus-hunt-guesser'); ?></p>
-		<p><input type="submit" class="button button-primary" value="<?php esc_attr_e('Reset & Reseed Demo Data', 'bonus-hunt-guesser'); ?>"></p>
+		<?php wp_nonce_field( 'bhg_demo_reseed_action', 'bhg_demo_reseed_nonce' ); ?>
+		<p><?php esc_html_e( 'This will delete all demo data and pages, then recreate fresh demo content.', 'bonus-hunt-guesser' ); ?></p>
+		<p><input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Reset & Reseed Demo Data', 'bonus-hunt-guesser' ); ?>"></p>
 	</form>
 </div>

--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -1,302 +1,309 @@
 <?php
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 // Check user capabilities
-if (!current_user_can('manage_options')) {
-    wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
 global $wpdb;
-$bhg_db = new BHG_DB();
+$bhg_db  = new BHG_DB();
 $message = '';
 
 // Process form submissions
-if (isset($_POST['bhg_action'])) {
-    $action = sanitize_text_field($_POST['bhg_action']);
-    
-    // Verify nonce based on action
-    $nonce_action = 'bhg_' . $action;
-    if (!isset($_POST['bhg_nonce']) || !wp_verify_nonce($_POST['bhg_nonce'], $nonce_action)) {
-        wp_die('Security check failed');
-    }
-    
-    switch ($action) {
-        case 'create_bonus_hunt':
-            // Handle bonus hunt creation with proper sanitization
-            $title = sanitize_text_field($_POST['title']);
-            $starting_balance = floatval($_POST['starting_balance']);
-            $num_bonuses = intval($_POST['num_bonuses']);
-            $prizes = sanitize_textarea_field($_POST['prizes']);
-            $status = sanitize_text_field($_POST['status']);
-            $affiliate_site_id = isset($_POST['affiliate_site_id']) ? intval($_POST['affiliate_site_id']) : 0;
-            
-            // Save to database
-            $result = $bhg_db->create_bonus_hunt(array(
-                'title' => $title,
-                'starting_balance' => $starting_balance,
-                'num_bonuses' => $num_bonuses,
-                'prizes' => $prizes,
-                'status' => $status,
-                'affiliate_site_id' => $affiliate_site_id,
-                'created_by' => get_current_user_id(),
-                'created_at' => current_time('mysql')
-            ));
-            
-            if ($result) {
-                $message = 'success';
-            } else {
-                $message = 'error';
-            }
-            break;
-            
-        case 'update_bonus_hunt':
-            // Handle bonus hunt update
-            $id = intval($_POST['id']);
-            $title = sanitize_text_field($_POST['title']);
-            $starting_balance = floatval($_POST['starting_balance']);
-            $num_bonuses = intval($_POST['num_bonuses']);
-            $prizes = sanitize_textarea_field($_POST['prizes']);
-            $status = sanitize_text_field($_POST['status']);
-            $final_balance = isset($_POST['final_balance']) ? floatval($_POST['final_balance']) : null;
-            $affiliate_site_id = isset($_POST['affiliate_site_id']) ? intval($_POST['affiliate_site_id']) : 0;
-            
-            $result = $bhg_db->update_bonus_hunt($id, array(
-                'title' => $title,
-                'starting_balance' => $starting_balance,
-                'num_bonuses' => $num_bonuses,
-                'prizes' => $prizes,
-                'status' => $status,
-                'final_balance' => $final_balance,
-                'affiliate_site_id' => $affiliate_site_id
-            ));
-            
-            if ($result) {
-                $message = 'updated';
-            } else {
-                $message = 'error';
-            }
-            break;
-            
-        case 'delete_bonus_hunt':
-            // Handle bonus hunt deletion
-            $id = intval($_POST['id']);
-            $result = $bhg_db->delete_bonus_hunt($id);
-            
-            if ($result) {
-                $message = 'deleted';
-            } else {
-                $message = 'error';
-            }
-            break;
-            
-        default:
-            // Unknown action
-            break;
-    }
-    
-    // Redirect to avoid form resubmission
-    $redirect_url = esc_url_raw( add_query_arg( 'message', $message, $_SERVER['REQUEST_URI'] ) );
-    wp_safe_redirect( $redirect_url );
-    exit;
+if ( isset( $_POST['bhg_action'] ) ) {
+	$action = sanitize_text_field( $_POST['bhg_action'] );
+
+	// Verify nonce based on action
+	$nonce_action = 'bhg_' . $action;
+	if ( ! isset( $_POST['bhg_nonce'] ) || ! wp_verify_nonce( $_POST['bhg_nonce'], $nonce_action ) ) {
+		wp_die( 'Security check failed' );
+	}
+
+	switch ( $action ) {
+		case 'create_bonus_hunt':
+			// Handle bonus hunt creation with proper sanitization
+			$title             = sanitize_text_field( $_POST['title'] );
+			$starting_balance  = floatval( $_POST['starting_balance'] );
+			$num_bonuses       = intval( $_POST['num_bonuses'] );
+			$prizes            = sanitize_textarea_field( $_POST['prizes'] );
+			$status            = sanitize_text_field( $_POST['status'] );
+			$affiliate_site_id = isset( $_POST['affiliate_site_id'] ) ? intval( $_POST['affiliate_site_id'] ) : 0;
+
+			// Save to database
+			$result = $bhg_db->create_bonus_hunt(
+				array(
+					'title'             => $title,
+					'starting_balance'  => $starting_balance,
+					'num_bonuses'       => $num_bonuses,
+					'prizes'            => $prizes,
+					'status'            => $status,
+					'affiliate_site_id' => $affiliate_site_id,
+					'created_by'        => get_current_user_id(),
+					'created_at'        => current_time( 'mysql' ),
+				)
+			);
+
+			if ( $result ) {
+				$message = 'success';
+			} else {
+				$message = 'error';
+			}
+			break;
+
+		case 'update_bonus_hunt':
+			// Handle bonus hunt update
+			$id                = intval( $_POST['id'] );
+			$title             = sanitize_text_field( $_POST['title'] );
+			$starting_balance  = floatval( $_POST['starting_balance'] );
+			$num_bonuses       = intval( $_POST['num_bonuses'] );
+			$prizes            = sanitize_textarea_field( $_POST['prizes'] );
+			$status            = sanitize_text_field( $_POST['status'] );
+			$final_balance     = isset( $_POST['final_balance'] ) ? floatval( $_POST['final_balance'] ) : null;
+			$affiliate_site_id = isset( $_POST['affiliate_site_id'] ) ? intval( $_POST['affiliate_site_id'] ) : 0;
+
+			$result = $bhg_db->update_bonus_hunt(
+				$id,
+				array(
+					'title'             => $title,
+					'starting_balance'  => $starting_balance,
+					'num_bonuses'       => $num_bonuses,
+					'prizes'            => $prizes,
+					'status'            => $status,
+					'final_balance'     => $final_balance,
+					'affiliate_site_id' => $affiliate_site_id,
+				)
+			);
+
+			if ( $result ) {
+				$message = 'updated';
+			} else {
+				$message = 'error';
+			}
+			break;
+
+		case 'delete_bonus_hunt':
+			// Handle bonus hunt deletion
+			$id     = intval( $_POST['id'] );
+			$result = $bhg_db->delete_bonus_hunt( $id );
+
+			if ( $result ) {
+				$message = 'deleted';
+			} else {
+				$message = 'error';
+			}
+			break;
+
+		default:
+			// Unknown action
+			break;
+	}
+
+	// Redirect to avoid form resubmission
+	$redirect_url = esc_url_raw( add_query_arg( 'message', $message, $_SERVER['REQUEST_URI'] ) );
+	wp_safe_redirect( $redirect_url );
+	exit;
 }
 
 // Get all bonus hunts
-$bonus_hunts = $bhg_db->get_all_bonus_hunts();
+$bonus_hunts     = $bhg_db->get_all_bonus_hunts();
 $affiliate_sites = $bhg_db->get_affiliate_websites();
 
 // Display status messages
-if (isset($_GET['message'])) {
-    $message_type = sanitize_text_field($_GET['message']);
-    switch ($message_type) {
-        case 'success':
-            echo '<div class="notice notice-success is-dismissible"><p>' .
-                esc_html__( 'Bonus hunt created successfully!', 'bonus-hunt-guesser' ) .
-                '</p></div>';
-            break;
-        case 'updated':
-            echo '<div class="notice notice-success is-dismissible"><p>' .
-                esc_html__( 'Bonus hunt updated successfully!', 'bonus-hunt-guesser' ) .
-                '</p></div>';
-            break;
-        case 'deleted':
-            echo '<div class="notice notice-success is-dismissible"><p>' .
-                esc_html__( 'Bonus hunt deleted successfully!', 'bonus-hunt-guesser' ) .
-                '</p></div>';
-            break;
-        case 'error':
-            echo '<div class="notice notice-error is-dismissible"><p>' .
-                esc_html__( 'An error occurred. Please try again.', 'bonus-hunt-guesser' ) .
-                '</p></div>';
-            break;
-    }
+if ( isset( $_GET['message'] ) ) {
+	$message_type = sanitize_text_field( $_GET['message'] );
+	switch ( $message_type ) {
+		case 'success':
+			echo '<div class="notice notice-success is-dismissible"><p>' .
+				esc_html__( 'Bonus hunt created successfully!', 'bonus-hunt-guesser' ) .
+				'</p></div>';
+			break;
+		case 'updated':
+			echo '<div class="notice notice-success is-dismissible"><p>' .
+				esc_html__( 'Bonus hunt updated successfully!', 'bonus-hunt-guesser' ) .
+				'</p></div>';
+			break;
+		case 'deleted':
+			echo '<div class="notice notice-success is-dismissible"><p>' .
+				esc_html__( 'Bonus hunt deleted successfully!', 'bonus-hunt-guesser' ) .
+				'</p></div>';
+			break;
+		case 'error':
+			echo '<div class="notice notice-error is-dismissible"><p>' .
+				esc_html__( 'An error occurred. Please try again.', 'bonus-hunt-guesser' ) .
+				'</p></div>';
+			break;
+	}
 }
 ?>
 
 <div class="wrap bhg-admin">
-    <h1><?php esc_html_e( 'Bonus Hunt Guesser', 'bonus-hunt-guesser' ); ?></h1>
-    <hr/>
-    
-    <div class="bhg-admin-content">
-        <h2><?php esc_html_e( 'Create New Bonus Hunt', 'bonus-hunt-guesser' ); ?></h2>
-        <form method="post" action="">
-            <?php wp_nonce_field('bhg_create_bonus_hunt', 'bhg_nonce'); ?>
-            <input type="hidden" name="bhg_action" value="create_bonus_hunt">
-            
-            <table class="form-table">
-                <tr>
-                    <th scope="row"><label for="title"><?php esc_html_e( 'Bonus Hunt Title', 'bonus-hunt-guesser' ); ?></label></th>
-                    <td>
-                        <input type="text" name="title" id="title" class="regular-text" required 
-                               value="<?php echo isset($_POST['title']) ? esc_attr($_POST['title']) : ''; ?>">
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="starting_balance"><?php esc_html_e( 'Starting Balance (€)', 'bonus-hunt-guesser' ); ?></label></th>
-                    <td>
-                        <input type="number" name="starting_balance" id="starting_balance" step="0.01" min="0"
-                               value="<?php echo esc_attr( isset( $_POST['starting_balance'] ) ? floatval( $_POST['starting_balance'] ) : '0' ); ?>" required>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="num_bonuses"><?php esc_html_e( 'Number of Bonuses', 'bonus-hunt-guesser' ); ?></label></th>
-                    <td>
-                        <input type="number" name="num_bonuses" id="num_bonuses" min="1"
-                               value="<?php echo esc_attr( isset( $_POST['num_bonuses'] ) ? intval( $_POST['num_bonuses'] ) : '10' ); ?>" required>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="prizes"><?php esc_html_e( 'Prizes Description', 'bonus-hunt-guesser' ); ?></label></th>
-                    <td>
-                        <textarea name="prizes" id="prizes" rows="5" class="large-text"><?php 
-                            echo isset($_POST['prizes']) ? esc_textarea($_POST['prizes']) : ''; 
-                        ?></textarea>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="status"><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></label></th>
-                    <td>
-                        <select name="status" id="status" required>
-                            <option value="active"><?php esc_html_e( 'Active', 'bonus-hunt-guesser' ); ?></option>
-                            <option value="upcoming"><?php esc_html_e( 'Upcoming', 'bonus-hunt-guesser' ); ?></option>
-                            <option value="completed"><?php esc_html_e( 'Completed', 'bonus-hunt-guesser' ); ?></option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="affiliate_site_id"><?php esc_html_e( 'Affiliate Website', 'bonus-hunt-guesser' ); ?></label></th>
-                    <td>
-                        <select name="affiliate_site_id" id="affiliate_site_id">
-                            <option value="0"><?php esc_html_e( 'None', 'bonus-hunt-guesser' ); ?></option>
-                            <?php foreach ($affiliate_sites as $site) : ?>
-                                <option value="<?php echo esc_attr($site->id); ?>">
-                                    <?php echo esc_html($site->name); ?>
-                                </option>
-                            <?php endforeach; ?>
-                        </select>
-                    </td>
-                </tr>
-            </table>
-            
-            <?php submit_button( esc_html__( 'Create Bonus Hunt', 'bonus-hunt-guesser' ) ); ?>
-        </form>
-        
-        <hr>
-        
-        <h2><?php esc_html_e( 'Existing Bonus Hunts', 'bonus-hunt-guesser' ); ?></h2>
-        <table class="wp-list-table widefat fixed striped">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'ID', 'bonus-hunt-guesser' ); ?></th>
-                    <th><?php esc_html_e( 'Title', 'bonus-hunt-guesser' ); ?></th>
-                    <th><?php esc_html_e( 'Starting Balance', 'bonus-hunt-guesser' ); ?></th>
-                    <th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
-                    <th><?php esc_html_e( 'Number of Bonuses', 'bonus-hunt-guesser' ); ?></th>
-                    <th><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></th>
-                    <th><?php esc_html_e( 'Created', 'bonus-hunt-guesser' ); ?></th>
-                    <th><?php esc_html_e( 'Actions', 'bonus-hunt-guesser' ); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php if (!empty($bonus_hunts)) : ?>
-                    <?php foreach ($bonus_hunts as $hunt) : ?>
-                        <tr>
-                            <td><?php echo esc_html($hunt->id); ?></td>
-                            <td><?php echo esc_html($hunt->title); ?></td>
-                            <td>€<?php echo esc_html( number_format( $hunt->starting_balance, 2 ) ); ?></td>
-                            <td>
-                                <?php if ($hunt->final_balance !== null) : ?>
-                                    €<?php echo esc_html( number_format( $hunt->final_balance, 2 ) ); ?>
-                                <?php else : ?>
-                                    <em><?php esc_html_e( 'Not set', 'bonus-hunt-guesser' ); ?></em>
-                                <?php endif; ?>
-                            </td>
-                            <td><?php echo esc_html($hunt->num_bonuses); ?></td>
-                            <td>
-                                <span class="bhg-status bhg-status-<?php echo esc_attr($hunt->status); ?>">
-                                    <?php echo esc_html(ucfirst($hunt->status)); ?>
-                                </span>
-                            </td>
-                            <td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $hunt->created_at ) ) ); ?></td>
-                            <td>
-                                <a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg_bonus_hunts&action=edit&id=' . intval( $hunt->id ) ) ); ?>" class="button button-small">
-                                    <?php esc_html_e( 'Edit', 'bonus-hunt-guesser' ); ?>
-                                </a>
-                                <form method="post" style="display:inline;">
-                                    <?php wp_nonce_field('bhg_delete_bonus_hunt', 'bhg_nonce'); ?>
-                                    <input type="hidden" name="bhg_action" value="delete_bonus_hunt">
-                                    <input type="hidden" name="id" value="<?php echo esc_attr($hunt->id); ?>">
-                                    <button type="submit" class="button button-small button-danger"
-                                            onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to delete this bonus hunt?', 'bonus-hunt-guesser' ) ); ?>');">
-                                        <?php esc_html_e( 'Delete', 'bonus-hunt-guesser' ); ?>
-                                    </button>
-                                </form>
-                            </td>
-                        </tr>
-                    <?php endforeach; ?>
-                <?php else : ?>
-                    <tr>
-                        <td colspan="8"><?php esc_html_e( 'No bonus hunts found.', 'bonus-hunt-guesser' ); ?></td>
-                    </tr>
-                <?php endif; ?>
-            </tbody>
-        </table>
-    </div>
+	<h1><?php esc_html_e( 'Bonus Hunt Guesser', 'bonus-hunt-guesser' ); ?></h1>
+	<hr/>
+	
+	<div class="bhg-admin-content">
+		<h2><?php esc_html_e( 'Create New Bonus Hunt', 'bonus-hunt-guesser' ); ?></h2>
+		<form method="post" action="">
+			<?php wp_nonce_field( 'bhg_create_bonus_hunt', 'bhg_nonce' ); ?>
+			<input type="hidden" name="bhg_action" value="create_bonus_hunt">
+			
+			<table class="form-table">
+				<tr>
+					<th scope="row"><label for="title"><?php esc_html_e( 'Bonus Hunt Title', 'bonus-hunt-guesser' ); ?></label></th>
+					<td>
+						<input type="text" name="title" id="title" class="regular-text" required 
+								value="<?php echo isset( $_POST['title'] ) ? esc_attr( $_POST['title'] ) : ''; ?>">
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="starting_balance"><?php esc_html_e( 'Starting Balance (€)', 'bonus-hunt-guesser' ); ?></label></th>
+					<td>
+						<input type="number" name="starting_balance" id="starting_balance" step="0.01" min="0"
+								value="<?php echo esc_attr( isset( $_POST['starting_balance'] ) ? floatval( $_POST['starting_balance'] ) : '0' ); ?>" required>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="num_bonuses"><?php esc_html_e( 'Number of Bonuses', 'bonus-hunt-guesser' ); ?></label></th>
+					<td>
+						<input type="number" name="num_bonuses" id="num_bonuses" min="1"
+								value="<?php echo esc_attr( isset( $_POST['num_bonuses'] ) ? intval( $_POST['num_bonuses'] ) : '10' ); ?>" required>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="prizes"><?php esc_html_e( 'Prizes Description', 'bonus-hunt-guesser' ); ?></label></th>
+					<td>
+						<textarea name="prizes" id="prizes" rows="5" class="large-text">
+						<?php
+							echo isset( $_POST['prizes'] ) ? esc_textarea( $_POST['prizes'] ) : '';
+						?>
+						</textarea>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="status"><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></label></th>
+					<td>
+						<select name="status" id="status" required>
+							<option value="active"><?php esc_html_e( 'Active', 'bonus-hunt-guesser' ); ?></option>
+							<option value="upcoming"><?php esc_html_e( 'Upcoming', 'bonus-hunt-guesser' ); ?></option>
+							<option value="completed"><?php esc_html_e( 'Completed', 'bonus-hunt-guesser' ); ?></option>
+						</select>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="affiliate_site_id"><?php esc_html_e( 'Affiliate Website', 'bonus-hunt-guesser' ); ?></label></th>
+					<td>
+						<select name="affiliate_site_id" id="affiliate_site_id">
+							<option value="0"><?php esc_html_e( 'None', 'bonus-hunt-guesser' ); ?></option>
+							<?php foreach ( $affiliate_sites as $site ) : ?>
+								<option value="<?php echo esc_attr( $site->id ); ?>">
+									<?php echo esc_html( $site->name ); ?>
+								</option>
+							<?php endforeach; ?>
+						</select>
+					</td>
+				</tr>
+			</table>
+			
+			<?php submit_button( esc_html__( 'Create Bonus Hunt', 'bonus-hunt-guesser' ) ); ?>
+		</form>
+		
+		<hr>
+		
+		<h2><?php esc_html_e( 'Existing Bonus Hunts', 'bonus-hunt-guesser' ); ?></h2>
+		<table class="wp-list-table widefat fixed striped">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'ID', 'bonus-hunt-guesser' ); ?></th>
+					<th><?php esc_html_e( 'Title', 'bonus-hunt-guesser' ); ?></th>
+					<th><?php esc_html_e( 'Starting Balance', 'bonus-hunt-guesser' ); ?></th>
+					<th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
+					<th><?php esc_html_e( 'Number of Bonuses', 'bonus-hunt-guesser' ); ?></th>
+					<th><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></th>
+					<th><?php esc_html_e( 'Created', 'bonus-hunt-guesser' ); ?></th>
+					<th><?php esc_html_e( 'Actions', 'bonus-hunt-guesser' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php if ( ! empty( $bonus_hunts ) ) : ?>
+					<?php foreach ( $bonus_hunts as $hunt ) : ?>
+						<tr>
+							<td><?php echo esc_html( $hunt->id ); ?></td>
+							<td><?php echo esc_html( $hunt->title ); ?></td>
+							<td>€<?php echo esc_html( number_format( $hunt->starting_balance, 2 ) ); ?></td>
+							<td>
+								<?php if ( $hunt->final_balance !== null ) : ?>
+									€<?php echo esc_html( number_format( $hunt->final_balance, 2 ) ); ?>
+								<?php else : ?>
+									<em><?php esc_html_e( 'Not set', 'bonus-hunt-guesser' ); ?></em>
+								<?php endif; ?>
+							</td>
+							<td><?php echo esc_html( $hunt->num_bonuses ); ?></td>
+							<td>
+								<span class="bhg-status bhg-status-<?php echo esc_attr( $hunt->status ); ?>">
+									<?php echo esc_html( ucfirst( $hunt->status ) ); ?>
+								</span>
+							</td>
+							<td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $hunt->created_at ) ) ); ?></td>
+							<td>
+								<a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg_bonus_hunts&action=edit&id=' . intval( $hunt->id ) ) ); ?>" class="button button-small">
+									<?php esc_html_e( 'Edit', 'bonus-hunt-guesser' ); ?>
+								</a>
+								<form method="post" style="display:inline;">
+									<?php wp_nonce_field( 'bhg_delete_bonus_hunt', 'bhg_nonce' ); ?>
+									<input type="hidden" name="bhg_action" value="delete_bonus_hunt">
+									<input type="hidden" name="id" value="<?php echo esc_attr( $hunt->id ); ?>">
+									<button type="submit" class="button button-small button-danger"
+											onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to delete this bonus hunt?', 'bonus-hunt-guesser' ) ); ?>');">
+										<?php esc_html_e( 'Delete', 'bonus-hunt-guesser' ); ?>
+									</button>
+								</form>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+				<?php else : ?>
+					<tr>
+						<td colspan="8"><?php esc_html_e( 'No bonus hunts found.', 'bonus-hunt-guesser' ); ?></td>
+					</tr>
+				<?php endif; ?>
+			</tbody>
+		</table>
+	</div>
 </div>
 
 <style>
 .bhg-status {
-    padding: 4px 8px;
-    border-radius: 3px;
-    font-size: 12px;
-    font-weight: bold;
+	padding: 4px 8px;
+	border-radius: 3px;
+	font-size: 12px;
+	font-weight: bold;
 }
 
 .bhg-status-active {
-    background-color: #46b450;
-    color: white;
+	background-color: #46b450;
+	color: white;
 }
 
 .bhg-status-upcoming {
-    background-color: #ffb900;
-    color: white;
+	background-color: #ffb900;
+	color: white;
 }
 
 .bhg-status-completed {
-    background-color: #0073aa;
-    color: white;
+	background-color: #0073aa;
+	color: white;
 }
 
 .button-danger {
-    background: #d63638;
-    border-color: #d63638;
-    color: white;
+	background: #d63638;
+	border-color: #d63638;
+	color: white;
 }
 
 .button-danger:hover {
-    background: #b32d2e;
-    border-color: #b32d2e;
-    color: white;
+	background: #b32d2e;
+	border-color: #b32d2e;
+	color: white;
 }
 </style>

--- a/admin/views/hunt-results.php
+++ b/admin/views/hunt-results.php
@@ -1,46 +1,55 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
-if (!current_user_can('manage_options')) { wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser')); }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( __( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) ); }
 
-$hunt_id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
-if (!$hunt_id) { wp_die(__('Missing hunt id', 'bonus-hunt-guesser')); }
+$hunt_id = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
+if ( ! $hunt_id ) {
+	wp_die( __( 'Missing hunt id', 'bonus-hunt-guesser' ) ); }
 
-check_admin_referer('bhg_view_results_' . $hunt_id, 'bhg_nonce');
+check_admin_referer( 'bhg_view_results_' . $hunt_id, 'bhg_nonce' );
 
-if (!function_exists('bhg_get_hunt') || !function_exists('bhg_get_all_ranked_guesses')) {
-    wp_die(__('Required helper functions are missing. Please include class-bhg-bonus-hunts.php helpers.', 'bonus-hunt-guesser'));
+if ( ! function_exists( 'bhg_get_hunt' ) || ! function_exists( 'bhg_get_all_ranked_guesses' ) ) {
+	wp_die( __( 'Required helper functions are missing. Please include class-bhg-bonus-hunts.php helpers.', 'bonus-hunt-guesser' ) );
 }
 
-$hunt = bhg_get_hunt($hunt_id);
-if (!$hunt) { wp_die(__('Hunt not found','bonus-hunt-guesser')); }
+$hunt = bhg_get_hunt( $hunt_id );
+if ( ! $hunt ) {
+	wp_die( __( 'Hunt not found', 'bonus-hunt-guesser' ) ); }
 
-$rows = bhg_get_all_ranked_guesses($hunt_id);
-$winners_limit = (int) ($hunt->winners_limit ?? 3);
+$rows          = bhg_get_all_ranked_guesses( $hunt_id );
+$winners_limit = (int) ( $hunt->winners_limit ?? 3 );
 ?>
 <div class="wrap">
-  <h1><?php echo esc_html(sprintf(__('Results — %s','bonus-hunt-guesser'), $hunt->title)); ?></h1>
-  <table class="widefat striped">
-    <thead><tr>
-      <th>#</th>
-      <th><?php esc_html_e('User','bonus-hunt-guesser'); ?></th>
-      <th><?php esc_html_e('Guess','bonus-hunt-guesser'); ?></th>
-      <th><?php esc_html_e('Diff','bonus-hunt-guesser'); ?></th>
-    </tr></thead>
-    <tbody>
-      <?php if ($rows): $i=1; foreach ($rows as $r):
-        $highlight = ($i <= $winners_limit) ? ' style="background:#e6ffed;"' : '';
-        $u = get_userdata((int)$r->user_id);
-        $name = $u ? $u->user_login : ('#'.$r->user_id);
-      ?>
-      <tr<?php echo $highlight; ?>>
-        <td><?php echo (int)$i; ?></td>
-        <td><a href="<?php echo esc_url( admin_url('user-edit.php?user_id='.(int)$r->user_id) ); ?>"><?php echo esc_html($name); ?></a></td>
-        <td><?php echo esc_html(number_format_i18n((float)$r->guess, 2)); ?></td>
-        <td><?php echo esc_html(number_format_i18n((float)$r->diff, 2)); ?></td>
-      </tr>
-      <?php $i++; endforeach; else: ?>
-        <tr><td colspan="4"><?php esc_html_e('No guesses yet.','bonus-hunt-guesser'); ?></td></tr>
-      <?php endif; ?>
-    </tbody>
-  </table>
+	<h1><?php echo esc_html( sprintf( __( 'Results — %s', 'bonus-hunt-guesser' ), $hunt->title ) ); ?></h1>
+	<table class="widefat striped">
+	<thead><tr>
+		<th>#</th>
+		<th><?php esc_html_e( 'User', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Guess', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Diff', 'bonus-hunt-guesser' ); ?></th>
+	</tr></thead>
+	<tbody>
+		<?php
+		if ( $rows ) :
+			$i = 1; foreach ( $rows as $r ) :
+				$highlight = ( $i <= $winners_limit ) ? ' style="background:#e6ffed;"' : '';
+				$u         = get_userdata( (int) $r->user_id );
+				$name      = $u ? $u->user_login : ( '#' . $r->user_id );
+				?>
+		<tr<?php echo $highlight; ?>>
+		<td><?php echo (int) $i; ?></td>
+		<td><a href="<?php echo esc_url( admin_url( 'user-edit.php?user_id=' . (int) $r->user_id ) ); ?>"><?php echo esc_html( $name ); ?></a></td>
+		<td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>
+		<td><?php echo esc_html( number_format_i18n( (float) $r->diff, 2 ) ); ?></td>
+		</tr>
+					<?php
+					++$i;
+endforeach; else :
+	?>
+		<tr><td colspan="4"><?php esc_html_e( 'No guesses yet.', 'bonus-hunt-guesser' ); ?></td></tr>
+		<?php endif; ?>
+	</tbody>
+	</table>
 </div>

--- a/admin/views/hunts-edit.php
+++ b/admin/views/hunts-edit.php
@@ -1,89 +1,95 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
-if (!current_user_can('manage_options')) { wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser')); }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) ); }
 
-$hunt_id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
-if (!$hunt_id) { wp_die(esc_html__('Missing hunt id','bonus-hunt-guesser')); }
+$hunt_id = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
+if ( ! $hunt_id ) {
+	wp_die( esc_html__( 'Missing hunt id', 'bonus-hunt-guesser' ) ); }
 
-check_admin_referer('bhg_edit_hunt_' . $hunt_id, 'bhg_nonce');
+check_admin_referer( 'bhg_edit_hunt_' . $hunt_id, 'bhg_nonce' );
 
 // Handle delete guess action
-if (isset($_POST['bhg_remove_guess']) && isset($_POST['bhg_remove_guess_nonce']) && wp_verify_nonce($_POST['bhg_remove_guess_nonce'], 'bhg_remove_guess_action')) {
-	$guess_id = (int) ($_POST['guess_id'] ?? 0);
-	if ($guess_id > 0 && function_exists('bhg_remove_guess')) {
-		bhg_remove_guess($guess_id);
-		echo '<div class="notice notice-success is-dismissible"><p>'.esc_html__('Guess removed.','bonus-hunt-guesser').'</p></div>';
+if ( isset( $_POST['bhg_remove_guess'] ) && isset( $_POST['bhg_remove_guess_nonce'] ) && wp_verify_nonce( $_POST['bhg_remove_guess_nonce'], 'bhg_remove_guess_action' ) ) {
+	$guess_id = (int) ( $_POST['guess_id'] ?? 0 );
+	if ( $guess_id > 0 && function_exists( 'bhg_remove_guess' ) ) {
+		bhg_remove_guess( $guess_id );
+		echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__( 'Guess removed.', 'bonus-hunt-guesser' ) . '</p></div>';
 	}
 }
 
-if (!function_exists('bhg_get_hunt') || !function_exists('bhg_get_hunt_participants')) {
-	wp_die(esc_html__('Missing helper functions. Please include class-bhg-bonus-hunts-helpers.php.', 'bonus-hunt-guesser'));
+if ( ! function_exists( 'bhg_get_hunt' ) || ! function_exists( 'bhg_get_hunt_participants' ) ) {
+	wp_die( esc_html__( 'Missing helper functions. Please include class-bhg-bonus-hunts-helpers.php.', 'bonus-hunt-guesser' ) );
 }
 
-$hunt = bhg_get_hunt($hunt_id);
-if (!$hunt) { wp_die(esc_html__('Hunt not found','bonus-hunt-guesser')); }
+$hunt = bhg_get_hunt( $hunt_id );
+if ( ! $hunt ) {
+	wp_die( esc_html__( 'Hunt not found', 'bonus-hunt-guesser' ) ); }
 
-$paged = max(1, isset($_GET['ppaged']) ? (int) $_GET['ppaged'] : 1);
+$paged    = max( 1, isset( $_GET['ppaged'] ) ? (int) $_GET['ppaged'] : 1 );
 $per_page = 30;
-$data = bhg_get_hunt_participants($hunt_id, $paged, $per_page);
-$rows = $data['rows'];
-$total = (int) $data['total'];
-$pages = max(1, (int) ceil($total / $per_page));
+$data     = bhg_get_hunt_participants( $hunt_id, $paged, $per_page );
+$rows     = $data['rows'];
+$total    = (int) $data['total'];
+$pages    = max( 1, (int) ceil( $total / $per_page ) );
 ?>
 <div class="wrap">
-  <h1><?php echo esc_html(sprintf(__('Edit Hunt — %s','bonus-hunt-guesser'), $hunt->title)); ?></h1>
+	<h1><?php echo esc_html( sprintf( __( 'Edit Hunt — %s', 'bonus-hunt-guesser' ), $hunt->title ) ); ?></h1>
 
-  <!-- Your existing edit form for the hunt would be above this line -->
+	<!-- Your existing edit form for the hunt would be above this line -->
 
-  <h2 style="margin-top:2em;"><?php esc_html_e('Participants','bonus-hunt-guesser'); ?></h2>
-  <p><?php echo esc_html(sprintf(_n('%s participant', '%s participants', $total, 'bonus-hunt-guesser'), number_format_i18n($total))); ?></p>
+	<h2 style="margin-top:2em;"><?php esc_html_e( 'Participants', 'bonus-hunt-guesser' ); ?></h2>
+	<p><?php echo esc_html( sprintf( _n( '%s participant', '%s participants', $total, 'bonus-hunt-guesser' ), number_format_i18n( $total ) ) ); ?></p>
 
-  <table class="widefat striped">
+	<table class="widefat striped">
 	<thead>
-	  <tr>
-		<th><?php esc_html_e('User','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Guess','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Date','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Actions','bonus-hunt-guesser'); ?></th>
-	  </tr>
+		<tr>
+		<th><?php esc_html_e( 'User', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Guess', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Date', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Actions', 'bonus-hunt-guesser' ); ?></th>
+		</tr>
 	</thead>
 	<tbody>
-	  <?php if ($rows): foreach ($rows as $r): 
-		$u = get_userdata((int)$r->user_id);
-		$name = $u ? $u->user_login : ('#'.$r->user_id);
-	  ?>
-		<tr>
-		  <td><a href="<?php echo esc_url( admin_url('user-edit.php?user_id='.(int)$r->user_id) ); ?>"><?php echo esc_html($name); ?></a></td>
-		  <td><?php echo esc_html(number_format_i18n((float)$r->guess, 2)); ?></td>
-                  <td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-		  <td>
-			<form method="post" style="display:inline">
-			  <?php wp_nonce_field('bhg_remove_guess_action','bhg_remove_guess_nonce'); ?>
-			  <input type="hidden" name="guess_id" value="<?php echo (int)$r->id; ?>">
-			  <button type="submit" name="bhg_remove_guess" class="button button-link-delete" onclick="return confirm('<?php echo esc_js(__('Remove this guess?','bonus-hunt-guesser')); ?>');">
-				<?php esc_html_e('Remove','bonus-hunt-guesser'); ?>
-			  </button>
-			</form>
-		  </td>
-		</tr>
-	  <?php endforeach; else: ?>
-		<tr><td colspan="4"><?php esc_html_e('No participants yet.','bonus-hunt-guesser'); ?></td></tr>
-	  <?php endif; ?>
-	</tbody>
-  </table>
-
-  <?php if ($pages > 1): ?>
-	<div class="tablenav">
-	  <div class="tablenav-pages">
 		<?php
-		  $base = remove_query_arg('ppaged');
-		  for ($i=1; $i<=$pages; $i++) {
-			$url = esc_url( add_query_arg('ppaged', $i, $base) );
+		if ( $rows ) :
+			foreach ( $rows as $r ) :
+				$u    = get_userdata( (int) $r->user_id );
+				$name = $u ? $u->user_login : ( '#' . $r->user_id );
+				?>
+		<tr>
+			<td><a href="<?php echo esc_url( admin_url( 'user-edit.php?user_id=' . (int) $r->user_id ) ); ?>"><?php echo esc_html( $name ); ?></a></td>
+			<td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>
+					<td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+			<td>
+			<form method="post" style="display:inline">
+				<?php wp_nonce_field( 'bhg_remove_guess_action', 'bhg_remove_guess_nonce' ); ?>
+				<input type="hidden" name="guess_id" value="<?php echo (int) $r->id; ?>">
+				<button type="submit" name="bhg_remove_guess" class="button button-link-delete" onclick="return confirm('<?php echo esc_js( __( 'Remove this guess?', 'bonus-hunt-guesser' ) ); ?>');">
+				<?php esc_html_e( 'Remove', 'bonus-hunt-guesser' ); ?>
+				</button>
+			</form>
+			</td>
+		</tr>
+						<?php endforeach; else : ?>
+		<tr><td colspan="4"><?php esc_html_e( 'No participants yet.', 'bonus-hunt-guesser' ); ?></td></tr>
+		<?php endif; ?>
+	</tbody>
+	</table>
+
+	<?php if ( $pages > 1 ) : ?>
+	<div class="tablenav">
+		<div class="tablenav-pages">
+		<?php
+			$base = remove_query_arg( 'ppaged' );
+		for ( $i = 1; $i <= $pages; $i++ ) {
+			$url   = esc_url( add_query_arg( 'ppaged', $i, $base ) );
 			$class = $i === $paged ? ' class="page-numbers current"' : ' class="page-numbers"';
-			echo '<a'.$class.' href="'.$url.'">'.$i.'</a> ';
-		  }
+			echo '<a' . $class . ' href="' . $url . '">' . $i . '</a> ';
+		}
 		?>
-	  </div>
+		</div>
 	</div>
-  <?php endif; ?>
+	<?php endif; ?>
 </div>

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -1,80 +1,85 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
-if (!current_user_can('manage_options')) { wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser')); }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) ); }
 
 global $wpdb;
 $t = $wpdb->prefix . 'bhg_hunts';
 
-$paged = max(1, isset($_GET['paged']) ? (int) $_GET['paged'] : 1);
+$paged    = max( 1, isset( $_GET['paged'] ) ? (int) $_GET['paged'] : 1 );
 $per_page = 20;
-$offset = ($paged - 1) * $per_page;
+$offset   = ( $paged - 1 ) * $per_page;
 
-$rows = $wpdb->get_results(
-  $wpdb->prepare(
-	"SELECT id, title, start_balance, final_balance, status, winners_limit, closed_at
+$rows  = $wpdb->get_results(
+	$wpdb->prepare(
+		"SELECT id, title, start_balance, final_balance, status, winners_limit, closed_at
 	 FROM $t
 	 ORDER BY id DESC
 	 LIMIT %d OFFSET %d",
-	$per_page,
-	$offset
-  )
+		$per_page,
+		$offset
+	)
 );
 $total = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $t" );
-$pages = max(1, (int) ceil($total / $per_page));
+$pages = max( 1, (int) ceil( $total / $per_page ) );
 
 ?>
 <div class="wrap">
-  <h1><?php esc_html_e('Bonus Hunts','bonus-hunt-guesser'); ?></h1>
-  <table class="widefat striped">
+	<h1><?php esc_html_e( 'Bonus Hunts', 'bonus-hunt-guesser' ); ?></h1>
+	<table class="widefat striped">
 	<thead>
-	  <tr>
-		<th><?php esc_html_e('ID','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Title','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Start Balance','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Final Balance','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Status','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Winners','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Closed At','bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Actions','bonus-hunt-guesser'); ?></th>
-	  </tr>
+		<tr>
+		<th><?php esc_html_e( 'ID', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Title', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Winners', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Actions', 'bonus-hunt-guesser' ); ?></th>
+		</tr>
 	</thead>
 	<tbody>
-	  <?php if ($rows): foreach ($rows as $r): ?>
-		<tr>
-		  <td><?php echo (int)$r->id; ?></td>
-		  <td><strong><a href="<?php echo esc_url( admin_url('admin.php?page=bhg-hunts-edit&id='.(int)$r->id) ); ?>"><?php echo esc_html($r->title); ?></a></strong></td>
-		  <td><?php echo esc_html(number_format_i18n((float)$r->start_balance, 2)); ?></td>
-                  <td><?php echo ($r->final_balance !== null) ? esc_html( number_format_i18n( (float) $r->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-		  <td><?php echo esc_html($r->status); ?></td>
-		  <td><?php echo (int)$r->winners_limit; ?></td>
-                  <td><?php echo $r->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-		  <td>
-			<?php
-			  $results_url = wp_nonce_url( admin_url('admin.php?page=bhg-hunt-results&id='.(int)$r->id), 'bhg_view_results_'.(int)$r->id, 'bhg_nonce' );
-			  $edit_url    = wp_nonce_url( admin_url('admin.php?page=bhg-hunts-edit&id='.(int)$r->id), 'bhg_edit_hunt_'.(int)$r->id, 'bhg_nonce' );
-			?>
-			<a class="button" href="<?php echo esc_url($results_url); ?>"><?php esc_html_e('Results','bonus-hunt-guesser'); ?></a>
-			<a class="button" href="<?php echo esc_url($edit_url); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
-		  </td>
-		</tr>
-	  <?php endforeach; else: ?>
-		<tr><td colspan="8"><?php esc_html_e('No hunts found.','bonus-hunt-guesser'); ?></td></tr>
-	  <?php endif; ?>
-	</tbody>
-  </table>
-
-  <?php if ($pages > 1): ?>
-	<div class="tablenav">
-	  <div class="tablenav-pages">
 		<?php
-		  $base = remove_query_arg('paged');
-		  for ($i=1; $i<=$pages; $i++) {
-			$url = esc_url( add_query_arg('paged', $i, $base) );
+		if ( $rows ) :
+			foreach ( $rows as $r ) :
+				?>
+		<tr>
+			<td><?php echo (int) $r->id; ?></td>
+			<td><strong><a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-hunts-edit&id=' . (int) $r->id ) ); ?>"><?php echo esc_html( $r->title ); ?></a></strong></td>
+			<td><?php echo esc_html( number_format_i18n( (float) $r->start_balance, 2 ) ); ?></td>
+					<td><?php echo ( $r->final_balance !== null ) ? esc_html( number_format_i18n( (float) $r->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+			<td><?php echo esc_html( $r->status ); ?></td>
+			<td><?php echo (int) $r->winners_limit; ?></td>
+					<td><?php echo $r->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+			<td>
+							<?php
+							$results_url = wp_nonce_url( admin_url( 'admin.php?page=bhg-hunt-results&id=' . (int) $r->id ), 'bhg_view_results_' . (int) $r->id, 'bhg_nonce' );
+							$edit_url    = wp_nonce_url( admin_url( 'admin.php?page=bhg-hunts-edit&id=' . (int) $r->id ), 'bhg_edit_hunt_' . (int) $r->id, 'bhg_nonce' );
+							?>
+			<a class="button" href="<?php echo esc_url( $results_url ); ?>"><?php esc_html_e( 'Results', 'bonus-hunt-guesser' ); ?></a>
+			<a class="button" href="<?php echo esc_url( $edit_url ); ?>"><?php esc_html_e( 'Edit', 'bonus-hunt-guesser' ); ?></a>
+			</td>
+		</tr>
+					<?php endforeach; else : ?>
+		<tr><td colspan="8"><?php esc_html_e( 'No hunts found.', 'bonus-hunt-guesser' ); ?></td></tr>
+		<?php endif; ?>
+	</tbody>
+	</table>
+
+	<?php if ( $pages > 1 ) : ?>
+	<div class="tablenav">
+		<div class="tablenav-pages">
+		<?php
+			$base = remove_query_arg( 'paged' );
+		for ( $i = 1; $i <= $pages; $i++ ) {
+			$url   = esc_url( add_query_arg( 'paged', $i, $base ) );
 			$class = $i === $paged ? ' class="page-numbers current"' : ' class="page-numbers"';
-			echo '<a'.$class.' href="'.$url.'">'.$i.'</a> ';
-		  }
+			echo '<a' . $class . ' href="' . $url . '">' . $i . '</a> ';
+		}
 		?>
-	  </div>
+		</div>
 	</div>
-  <?php endif; ?>
+	<?php endif; ?>
 </div>

--- a/admin/views/page-template.php
+++ b/admin/views/page-template.php
@@ -1,4 +1,3 @@
 <?php
 // Pre-made WordPress page template for demo
 // Usage: [bhg_bonus_hunt] [bhg_leaderboard] [bhg_tournament_leaderboard]
-?>

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -1,84 +1,87 @@
 <?php
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 // Check user capabilities
-if (!current_user_can('manage_options')) {
-	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
 // Get current settings
-$current_settings = get_option('bhg_plugin_settings', array(
-	'default_tournament_period' => 'monthly',
-	'max_guess_amount' => 100000,
-	'min_guess_amount' => 0,
-	'allow_guess_changes' => 'yes'
-));
+$current_settings = get_option(
+	'bhg_plugin_settings',
+	array(
+		'default_tournament_period' => 'monthly',
+		'max_guess_amount'          => 100000,
+		'min_guess_amount'          => 0,
+		'allow_guess_changes'       => 'yes',
+	)
+);
 
 // Handle settings save via admin-post.php
-$message = isset($_GET['message']) ? sanitize_text_field(wp_unslash($_GET['message'])) : '';
-if ('saved' === $message) {
+$message = isset( $_GET['message'] ) ? sanitize_text_field( wp_unslash( $_GET['message'] ) ) : '';
+if ( 'saved' === $message ) {
 	echo '<div class="notice notice-success is-dismissible"><p>' .
-		 esc_html__('Settings saved successfully.', 'bonus-hunt-guesser') .
-		 '</p></div>';
+		esc_html__( 'Settings saved successfully.', 'bonus-hunt-guesser' ) .
+		'</p></div>';
 }
 
 // Handle error messages
-$error = isset($_GET['error']) ? sanitize_text_field(wp_unslash($_GET['error'])) : '';
-if (!empty($error)) {
+$error = isset( $_GET['error'] ) ? sanitize_text_field( wp_unslash( $_GET['error'] ) ) : '';
+if ( ! empty( $error ) ) {
 	$error_message = '';
-	switch ($error) {
-                case 'nonce_failed':
-                        $error_message = esc_html__('Security check failed. Please try again.', 'bonus-hunt-guesser');
-                        break;
-                case 'invalid_data':
-                        $error_message = esc_html__('Invalid data submitted. Please check your inputs.', 'bonus-hunt-guesser');
-                        break;
-                default:
-                        $error_message = esc_html__('An error occurred while saving settings.', 'bonus-hunt-guesser');
-        }
+	switch ( $error ) {
+		case 'nonce_failed':
+				$error_message = esc_html__( 'Security check failed. Please try again.', 'bonus-hunt-guesser' );
+			break;
+		case 'invalid_data':
+				$error_message = esc_html__( 'Invalid data submitted. Please check your inputs.', 'bonus-hunt-guesser' );
+			break;
+		default:
+				$error_message = esc_html__( 'An error occurred while saving settings.', 'bonus-hunt-guesser' );
+	}
 
-	if (!empty($error_message)) {
-                echo '<div class="notice notice-error is-dismissible"><p>' . $error_message . '</p></div>';
-        }
+	if ( ! empty( $error_message ) ) {
+				echo '<div class="notice notice-error is-dismissible"><p>' . $error_message . '</p></div>';
+	}
 }
 ?>
 
 <div class="wrap">
-    <h1><?php esc_html_e('Bonus Hunt Guesser Settings', 'bonus-hunt-guesser'); ?></h1>
+	<h1><?php esc_html_e( 'Bonus Hunt Guesser Settings', 'bonus-hunt-guesser' ); ?></h1>
 	
-	<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 		<input type="hidden" name="action" value="bhg_save_settings">
-		<?php wp_nonce_field('bhg_save_settings_nonce', 'bhg_settings_nonce'); ?>
+		<?php wp_nonce_field( 'bhg_save_settings_nonce', 'bhg_settings_nonce' ); ?>
 
 		<table class="form-table">
 			<tr>
 				<th scope="row">
 					<label for="bhg_default_tournament_period">
-                                                <?php esc_html_e('Default Tournament Period', 'bonus-hunt-guesser'); ?>
+												<?php esc_html_e( 'Default Tournament Period', 'bonus-hunt-guesser' ); ?>
 					</label>
 				</th>
 				<td>
 					<select name="bhg_default_tournament_period" id="bhg_default_tournament_period" class="regular-text">
-						<option value="weekly" <?php selected($current_settings['default_tournament_period'], 'weekly'); ?>>
-                                                        <?php esc_html_e('Weekly', 'bonus-hunt-guesser'); ?>
+						<option value="weekly" <?php selected( $current_settings['default_tournament_period'], 'weekly' ); ?>>
+														<?php esc_html_e( 'Weekly', 'bonus-hunt-guesser' ); ?>
 						</option>
-						<option value="monthly" <?php selected($current_settings['default_tournament_period'], 'monthly'); ?>>
-                                                        <?php esc_html_e('Monthly', 'bonus-hunt-guesser'); ?>
+						<option value="monthly" <?php selected( $current_settings['default_tournament_period'], 'monthly' ); ?>>
+														<?php esc_html_e( 'Monthly', 'bonus-hunt-guesser' ); ?>
 						</option>
-						<option value="quarterly" <?php selected($current_settings['default_tournament_period'], 'quarterly'); ?>>
-                                                        <?php esc_html_e('Quarterly', 'bonus-hunt-guesser'); ?>
+						<option value="quarterly" <?php selected( $current_settings['default_tournament_period'], 'quarterly' ); ?>>
+														<?php esc_html_e( 'Quarterly', 'bonus-hunt-guesser' ); ?>
 						</option>
-						<option value="yearly" <?php selected($current_settings['default_tournament_period'], 'yearly'); ?>>
-                                                        <?php esc_html_e('Yearly', 'bonus-hunt-guesser'); ?>
+						<option value="yearly" <?php selected( $current_settings['default_tournament_period'], 'yearly' ); ?>>
+														<?php esc_html_e( 'Yearly', 'bonus-hunt-guesser' ); ?>
 						</option>
-						<option value="alltime" <?php selected($current_settings['default_tournament_period'], 'alltime'); ?>>
-                                                        <?php esc_html_e('All-Time', 'bonus-hunt-guesser'); ?>
+						<option value="alltime" <?php selected( $current_settings['default_tournament_period'], 'alltime' ); ?>>
+														<?php esc_html_e( 'All-Time', 'bonus-hunt-guesser' ); ?>
 						</option>
 					</select>
 					<p class="description">
-                                                <?php esc_html_e('Default period for tournament calculations.', 'bonus-hunt-guesser'); ?>
+												<?php esc_html_e( 'Default period for tournament calculations.', 'bonus-hunt-guesser' ); ?>
 					</p>
 				</td>
 			</tr>
@@ -86,15 +89,15 @@ if (!empty($error)) {
 			<tr>
 				<th scope="row">
 					<label for="bhg_min_guess_amount">
-                                                <?php esc_html_e('Minimum Guess Amount', 'bonus-hunt-guesser'); ?>
+												<?php esc_html_e( 'Minimum Guess Amount', 'bonus-hunt-guesser' ); ?>
 					</label>
 				</th>
 				<td>
 					<input type="number" name="bhg_min_guess_amount" id="bhg_min_guess_amount" 
-						   value="<?php echo esc_attr($current_settings['min_guess_amount']); ?>" 
-						   class="regular-text" step="0.01" min="0" required>
+							value="<?php echo esc_attr( $current_settings['min_guess_amount'] ); ?>" 
+							class="regular-text" step="0.01" min="0" required>
 					<p class="description">
-                                                <?php esc_html_e('Minimum amount users can guess for a bonus hunt.', 'bonus-hunt-guesser'); ?>
+												<?php esc_html_e( 'Minimum amount users can guess for a bonus hunt.', 'bonus-hunt-guesser' ); ?>
 					</p>
 				</td>
 			</tr>
@@ -102,15 +105,15 @@ if (!empty($error)) {
 			<tr>
 				<th scope="row">
 					<label for="bhg_max_guess_amount">
-                                                <?php esc_html_e('Maximum Guess Amount', 'bonus-hunt-guesser'); ?>
+												<?php esc_html_e( 'Maximum Guess Amount', 'bonus-hunt-guesser' ); ?>
 					</label>
 				</th>
 				<td>
 					<input type="number" name="bhg_max_guess_amount" id="bhg_max_guess_amount" 
-						   value="<?php echo esc_attr($current_settings['max_guess_amount']); ?>" 
-						   class="regular-text" step="0.01" min="0" required>
+							value="<?php echo esc_attr( $current_settings['max_guess_amount'] ); ?>" 
+							class="regular-text" step="0.01" min="0" required>
 					<p class="description">
-                                                <?php esc_html_e('Maximum amount users can guess for a bonus hunt.', 'bonus-hunt-guesser'); ?>
+												<?php esc_html_e( 'Maximum amount users can guess for a bonus hunt.', 'bonus-hunt-guesser' ); ?>
 					</p>
 				</td>
 			</tr>
@@ -118,20 +121,20 @@ if (!empty($error)) {
 			<tr>
 				<th scope="row">
 					<label for="bhg_allow_guess_changes">
-                                                <?php esc_html_e('Allow Guess Changes', 'bonus-hunt-guesser'); ?>
+												<?php esc_html_e( 'Allow Guess Changes', 'bonus-hunt-guesser' ); ?>
 					</label>
 				</th>
 				<td>
 					<select name="bhg_allow_guess_changes" id="bhg_allow_guess_changes" class="regular-text">
-						<option value="yes" <?php selected($current_settings['allow_guess_changes'], 'yes'); ?>>
-                                                        <?php esc_html_e('Yes', 'bonus-hunt-guesser'); ?>
+						<option value="yes" <?php selected( $current_settings['allow_guess_changes'], 'yes' ); ?>>
+														<?php esc_html_e( 'Yes', 'bonus-hunt-guesser' ); ?>
 						</option>
-						<option value="no" <?php selected($current_settings['allow_guess_changes'], 'no'); ?>>
-                                                        <?php esc_html_e('No', 'bonus-hunt-guesser'); ?>
+						<option value="no" <?php selected( $current_settings['allow_guess_changes'], 'no' ); ?>>
+														<?php esc_html_e( 'No', 'bonus-hunt-guesser' ); ?>
 						</option>
 					</select>
 					<p class="description">
-                                                <?php esc_html_e('Allow users to change their guesses before a bonus hunt closes.', 'bonus-hunt-guesser'); ?>
+												<?php esc_html_e( 'Allow users to change their guesses before a bonus hunt closes.', 'bonus-hunt-guesser' ); ?>
 					</p>
 				</td>
 			</tr>
@@ -139,7 +142,7 @@ if (!empty($error)) {
 		
 		<p class="submit">
 			<input type="submit" name="bhg_settings_submit" id="submit" 
-                               class="button button-primary" value="<?php esc_html_e('Save Changes', 'bonus-hunt-guesser'); ?>">
+								class="button button-primary" value="<?php esc_html_e( 'Save Changes', 'bonus-hunt-guesser' ); ?>">
 		</p>
 	</form>
 </div>

--- a/admin/views/tools.php
+++ b/admin/views/tools.php
@@ -1,30 +1,31 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 ?>
 <div class="wrap">
-  <h1><?php echo esc_html__('BHG Tools', 'bonus-hunt-guesser'); ?></h1>
+	<h1><?php echo esc_html__( 'BHG Tools', 'bonus-hunt-guesser' ); ?></h1>
 
-  <?php
-  global $wpdb;
-  $hunts = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_bonus_hunts" );
-  $guesses = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_guesses" );
-  $users = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->users}" );
-  $ads = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_ads" );
-  $tournaments = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_tournaments" );
-  ?>
+	<?php
+	global $wpdb;
+	$hunts       = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_bonus_hunts" );
+	$guesses     = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_guesses" );
+	$users       = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->users}" );
+	$ads         = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_ads" );
+	$tournaments = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_tournaments" );
+	?>
 
-  <div class="card" style="max-width:900px;padding:16px;margin-top:12px;">
-	<h2><?php echo esc_html__('Diagnostics', 'bonus-hunt-guesser'); ?></h2>
-	<?php if (($hunts + $guesses + $users + $ads + $tournaments) > 0): ?>
-	  <ul>
-		<li><?php echo esc_html__('Hunts:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($hunts); ?></li>
-		<li><?php echo esc_html__('Guesses:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($guesses); ?></li>
-		<li><?php echo esc_html__('Users:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($users); ?></li>
-		<li><?php echo esc_html__('Ads:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($ads); ?></li>
-		<li><?php echo esc_html__('Tournaments:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($tournaments); ?></li>
-	  </ul>
-	<?php else: ?>
-	  <p><?php echo esc_html__('Nothing to show yet. Start by creating a hunt or a test user.', 'bonus-hunt-guesser'); ?></p>
+	<div class="card" style="max-width:900px;padding:16px;margin-top:12px;">
+	<h2><?php echo esc_html__( 'Diagnostics', 'bonus-hunt-guesser' ); ?></h2>
+	<?php if ( ( $hunts + $guesses + $users + $ads + $tournaments ) > 0 ) : ?>
+		<ul>
+		<li><?php echo esc_html__( 'Hunts:', 'bonus-hunt-guesser' ); ?> <?php echo number_format_i18n( $hunts ); ?></li>
+		<li><?php echo esc_html__( 'Guesses:', 'bonus-hunt-guesser' ); ?> <?php echo number_format_i18n( $guesses ); ?></li>
+		<li><?php echo esc_html__( 'Users:', 'bonus-hunt-guesser' ); ?> <?php echo number_format_i18n( $users ); ?></li>
+		<li><?php echo esc_html__( 'Ads:', 'bonus-hunt-guesser' ); ?> <?php echo number_format_i18n( $ads ); ?></li>
+		<li><?php echo esc_html__( 'Tournaments:', 'bonus-hunt-guesser' ); ?> <?php echo number_format_i18n( $tournaments ); ?></li>
+		</ul>
+	<?php else : ?>
+		<p><?php echo esc_html__( 'Nothing to show yet. Start by creating a hunt or a test user.', 'bonus-hunt-guesser' ); ?></p>
 	<?php endif; ?>
-  </div>
+	</div>
 </div>

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -1,15 +1,16 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
-if (!current_user_can('manage_options')) {
-	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 global $wpdb;
-$table = $wpdb->prefix . 'bhg_tournaments';
-$allowed_tables = [ $wpdb->prefix . 'bhg_tournaments' ];
+$table          = $wpdb->prefix . 'bhg_tournaments';
+$allowed_tables = array( $wpdb->prefix . 'bhg_tournaments' );
 if ( ! in_array( $table, $allowed_tables, true ) ) {
 	wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
-$table   = esc_sql( $table );
+$table = esc_sql( $table );
 
 $edit_id = isset( $_GET['edit'] ) ? (int) wp_unslash( $_GET['edit'] ) : 0;
 $row     = $edit_id
@@ -18,97 +19,109 @@ $row     = $edit_id
 
 $rows = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY id DESC" );
 
-$labels = [
+$labels = array(
 	'weekly'    => __( 'Weekly', 'bonus-hunt-guesser' ),
 	'monthly'   => __( 'Monthly', 'bonus-hunt-guesser' ),
 	'quarterly' => __( 'Quarterly', 'bonus-hunt-guesser' ),
 	'yearly'    => __( 'Yearly', 'bonus-hunt-guesser' ),
 	'alltime'   => __( 'Alltime', 'bonus-hunt-guesser' ),
-];
+);
 ?>
 <div class="wrap">
-  <h1 class="wp-heading-inline"><?php esc_html_e('Tournaments', 'bonus-hunt-guesser'); ?></h1>
+	<h1 class="wp-heading-inline"><?php esc_html_e( 'Tournaments', 'bonus-hunt-guesser' ); ?></h1>
 
-  <h2 class="bhg-margin-top-small"><?php esc_html_e('All Tournaments', 'bonus-hunt-guesser'); ?></h2>
-  <table class="widefat striped">
+	<h2 class="bhg-margin-top-small"><?php esc_html_e( 'All Tournaments', 'bonus-hunt-guesser' ); ?></h2>
+	<table class="widefat striped">
 	<thead>
-	  <tr>
-		<th><?php esc_html_e('ID', 'bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Title', 'bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Type', 'bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Start', 'bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('End', 'bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Status', 'bonus-hunt-guesser'); ?></th>
-		<th><?php esc_html_e('Actions', 'bonus-hunt-guesser'); ?></th>
-	  </tr>
+		<tr>
+		<th><?php esc_html_e( 'ID', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Title', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Type', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Start', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'End', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Actions', 'bonus-hunt-guesser' ); ?></th>
+		</tr>
 	</thead>
 	<tbody>
-	  <?php if (empty($rows)) : ?>
-		<tr><td colspan="7"><em><?php esc_html_e('No tournaments yet.', 'bonus-hunt-guesser'); ?></em></td></tr>
-	  <?php else : foreach ($rows as $r) : ?>
+		<?php if ( empty( $rows ) ) : ?>
+		<tr><td colspan="7"><em><?php esc_html_e( 'No tournaments yet.', 'bonus-hunt-guesser' ); ?></em></td></tr>
+			<?php
+		else :
+			foreach ( $rows as $r ) :
+				?>
 		<tr>
-		  <td><?php echo (int)$r->id; ?></td>
-		  <td><?php echo esc_html($r->title); ?></td>
-		  <td><?php echo esc_html( $labels[ $r->type ] ?? $r->type ); ?></td>
-		  <td><?php echo esc_html($r->start_date); ?></td>
-		  <td><?php echo esc_html($r->end_date); ?></td>
-		  <td><?php echo esc_html($r->status); ?></td>
-		  <td>
-			<a class="button" href="<?php echo esc_url(add_query_arg(['edit' => (int)$r->id])); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
-		  </td>
+			<td><?php echo (int) $r->id; ?></td>
+			<td><?php echo esc_html( $r->title ); ?></td>
+			<td><?php echo esc_html( $labels[ $r->type ] ?? $r->type ); ?></td>
+			<td><?php echo esc_html( $r->start_date ); ?></td>
+			<td><?php echo esc_html( $r->end_date ); ?></td>
+			<td><?php echo esc_html( $r->status ); ?></td>
+			<td>
+			<a class="button" href="<?php echo esc_url( add_query_arg( array( 'edit' => (int) $r->id ) ) ); ?>"><?php esc_html_e( 'Edit', 'bonus-hunt-guesser' ); ?></a>
+			</td>
 		</tr>
-	  <?php endforeach; endif; ?>
+					<?php
+		endforeach;
+endif;
+		?>
 	</tbody>
-  </table>
-
-  <h2 class="bhg-margin-top-large"><?php echo $row ? esc_html__('Edit Tournament', 'bonus-hunt-guesser') : esc_html__('Add Tournament', 'bonus-hunt-guesser'); ?></h2>
-  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="bhg-max-width-900">
-	<?php wp_nonce_field('bhg_tournament_save_action'); ?>
-	<input type="hidden" name="action" value="bhg_tournament_save" />
-	<?php if ($row): ?><input type="hidden" name="id" value="<?php echo (int)$row->id; ?>" /><?php endif; ?>
-	<table class="form-table">
-	  <tr>
-		<th><label for="bhg_t_title"><?php esc_html_e('Title','bonus-hunt-guesser'); ?></label></th>
-		<td><input id="bhg_t_title" class="regular-text" name="title" value="<?php echo esc_attr($row->title ?? ''); ?>" required /></td>
-	  </tr>
-	  <tr>
-		<th><label for="bhg_t_desc"><?php esc_html_e('Description','bonus-hunt-guesser'); ?></label></th>
-		<td><textarea id="bhg_t_desc" class="large-text" rows="4" name="description"><?php echo esc_textarea($row->description ?? ''); ?></textarea></td>
-	  </tr>
-	  <tr>
-		<th><label for="bhg_t_type"><?php esc_html_e('Type','bonus-hunt-guesser'); ?></label></th>
-		<td>
-		  <?php
-		  $types = [ 'weekly', 'monthly', 'quarterly', 'yearly', 'alltime' ];
-		  $cur   = $row->type ?? 'weekly';
-		  ?>
-		  <select id="bhg_t_type" name="type">
-			<?php foreach ( $types as $t ) : ?>
-			  <option value="<?php echo esc_attr( $t ); ?>" <?php selected( $cur, $t ); ?>><?php echo esc_html( $labels[ $t ] ); ?></option>
-			<?php endforeach; ?>
-		  </select>
-		</td>
-	  </tr>
-	  <tr>
-		<th><label for="bhg_t_start"><?php esc_html_e('Start Date','bonus-hunt-guesser'); ?></label></th>
-		<td><input id="bhg_t_start" type="date" name="start_date" value="<?php echo esc_attr($row->start_date ?? ''); ?>" /></td>
-	  </tr>
-	  <tr>
-		<th><label for="bhg_t_end"><?php esc_html_e('End Date','bonus-hunt-guesser'); ?></label></th>
-		<td><input id="bhg_t_end" type="date" name="end_date" value="<?php echo esc_attr($row->end_date ?? ''); ?>" /></td>
-	  </tr>
-	  <tr>
-		<th><label for="bhg_t_status"><?php esc_html_e('Status','bonus-hunt-guesser'); ?></label></th>
-		<td>
-		  <?php $st = ['active','archived']; $cur = $row->status ?? 'active'; ?>
-		  <select id="bhg_t_status" name="status">
-			<?php foreach ($st as $v): ?>
-			  <option value="<?php echo esc_attr($v); ?>" <?php selected($cur, $v); ?>><?php echo esc_html(ucfirst($v)); ?></option>
-			<?php endforeach; ?>
-		  </select>
-		</td>
-	  </tr>
 	</table>
-	<?php submit_button($row ? __('Update Tournament','bonus-hunt-guesser') : __('Create Tournament','bonus-hunt-guesser')); ?>
-  </form>
+
+	<h2 class="bhg-margin-top-large"><?php echo $row ? esc_html__( 'Edit Tournament', 'bonus-hunt-guesser' ) : esc_html__( 'Add Tournament', 'bonus-hunt-guesser' ); ?></h2>
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900">
+	<?php wp_nonce_field( 'bhg_tournament_save_action' ); ?>
+	<input type="hidden" name="action" value="bhg_tournament_save" />
+	<?php
+	if ( $row ) :
+		?>
+		<input type="hidden" name="id" value="<?php echo (int) $row->id; ?>" /><?php endif; ?>
+	<table class="form-table">
+		<tr>
+		<th><label for="bhg_t_title"><?php esc_html_e( 'Title', 'bonus-hunt-guesser' ); ?></label></th>
+		<td><input id="bhg_t_title" class="regular-text" name="title" value="<?php echo esc_attr( $row->title ?? '' ); ?>" required /></td>
+		</tr>
+		<tr>
+		<th><label for="bhg_t_desc"><?php esc_html_e( 'Description', 'bonus-hunt-guesser' ); ?></label></th>
+		<td><textarea id="bhg_t_desc" class="large-text" rows="4" name="description"><?php echo esc_textarea( $row->description ?? '' ); ?></textarea></td>
+		</tr>
+		<tr>
+		<th><label for="bhg_t_type"><?php esc_html_e( 'Type', 'bonus-hunt-guesser' ); ?></label></th>
+		<td>
+			<?php
+			$types = array( 'weekly', 'monthly', 'quarterly', 'yearly', 'alltime' );
+			$cur   = $row->type ?? 'weekly';
+			?>
+			<select id="bhg_t_type" name="type">
+			<?php foreach ( $types as $t ) : ?>
+				<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $cur, $t ); ?>><?php echo esc_html( $labels[ $t ] ); ?></option>
+			<?php endforeach; ?>
+			</select>
+		</td>
+		</tr>
+		<tr>
+		<th><label for="bhg_t_start"><?php esc_html_e( 'Start Date', 'bonus-hunt-guesser' ); ?></label></th>
+		<td><input id="bhg_t_start" type="date" name="start_date" value="<?php echo esc_attr( $row->start_date ?? '' ); ?>" /></td>
+		</tr>
+		<tr>
+		<th><label for="bhg_t_end"><?php esc_html_e( 'End Date', 'bonus-hunt-guesser' ); ?></label></th>
+		<td><input id="bhg_t_end" type="date" name="end_date" value="<?php echo esc_attr( $row->end_date ?? '' ); ?>" /></td>
+		</tr>
+		<tr>
+		<th><label for="bhg_t_status"><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></label></th>
+		<td>
+			<?php
+			$st  = array( 'active', 'archived' );
+			$cur = $row->status ?? 'active';
+			?>
+			<select id="bhg_t_status" name="status">
+			<?php foreach ( $st as $v ) : ?>
+				<option value="<?php echo esc_attr( $v ); ?>" <?php selected( $cur, $v ); ?>><?php echo esc_html( ucfirst( $v ) ); ?></option>
+			<?php endforeach; ?>
+			</select>
+		</td>
+		</tr>
+	</table>
+	<?php submit_button( $row ? __( 'Update Tournament', 'bonus-hunt-guesser' ) : __( 'Create Tournament', 'bonus-hunt-guesser' ) ); ?>
+	</form>
 </div>

--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -1,8 +1,9 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
-if (!current_user_can('manage_options')) {
-	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
 global $wpdb;
@@ -13,29 +14,32 @@ if ( function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
 }
 
 $default_translations = function_exists( 'bhg_get_default_translations' ) ? bhg_get_default_translations() : array();
-$default_keys        = array_keys( $default_translations );
+$default_keys         = array_keys( $default_translations );
 
 // Handle form submission
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bhg_save_translation'])) {
+if ( $_SERVER['REQUEST_METHOD'] === 'POST' && isset( $_POST['bhg_save_translation'] ) ) {
 	// Verify nonce
-	if (!isset($_POST['bhg_nonce']) || !wp_verify_nonce($_POST['bhg_nonce'], 'bhg_save_translation_action')) {
-		wp_die(esc_html__('Security check failed.', 'bonus-hunt-guesser'));
+	if ( ! isset( $_POST['bhg_nonce'] ) || ! wp_verify_nonce( $_POST['bhg_nonce'], 'bhg_save_translation_action' ) ) {
+		wp_die( esc_html__( 'Security check failed.', 'bonus-hunt-guesser' ) );
 	}
 
 	// Sanitize input
-	$tkey   = isset($_POST['tkey']) ? sanitize_text_field(wp_unslash($_POST['tkey'])) : '';
-	$tvalue = isset($_POST['tvalue']) ? sanitize_textarea_field(wp_unslash($_POST['tvalue'])) : '';
+	$tkey   = isset( $_POST['tkey'] ) ? sanitize_text_field( wp_unslash( $_POST['tkey'] ) ) : '';
+	$tvalue = isset( $_POST['tvalue'] ) ? sanitize_textarea_field( wp_unslash( $_POST['tvalue'] ) ) : '';
 
 	// Validate input
-	if ($tkey === '') {
-		$error = __('Key field is required.', 'bonus-hunt-guesser');
+	if ( $tkey === '' ) {
+		$error = __( 'Key field is required.', 'bonus-hunt-guesser' );
 	} else {
 		$wpdb->replace(
 			$table,
-			array('tkey' => $tkey, 'tvalue' => $tvalue),
-			array('%s', '%s')
+			array(
+				'tkey'   => $tkey,
+				'tvalue' => $tvalue,
+			),
+			array( '%s', '%s' )
 		);
-		$notice = __('Translation saved.', 'bonus-hunt-guesser');
+		$notice = __( 'Translation saved.', 'bonus-hunt-guesser' );
 	}
 }
 
@@ -43,48 +47,51 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bhg_save_translation'
 $rows = $wpdb->get_results( "SELECT tkey, tvalue FROM {$table} ORDER BY tkey ASC" );
 ?>
 <div class="wrap">
-  <h1><?php esc_html_e('Translations', 'bonus-hunt-guesser'); ?></h1>
+	<h1><?php esc_html_e( 'Translations', 'bonus-hunt-guesser' ); ?></h1>
 
-  <style>
+	<style>
 	.bhg-default-row td { background-color: #fffbcc; }
-  </style>
+	</style>
 
-  <?php if (!empty($notice)): ?>
-	<div class="notice notice-success"><p><?php echo esc_html($notice); ?></p></div>
-  <?php endif; ?>
-  <?php if (!empty($error)): ?>
-	<div class="notice notice-error"><p><?php echo esc_html($error); ?></p></div>
-  <?php endif; ?>
+	<?php if ( ! empty( $notice ) ) : ?>
+	<div class="notice notice-success"><p><?php echo esc_html( $notice ); ?></p></div>
+	<?php endif; ?>
+	<?php if ( ! empty( $error ) ) : ?>
+	<div class="notice notice-error"><p><?php echo esc_html( $error ); ?></p></div>
+	<?php endif; ?>
 
-  <form method="post">
-	<?php wp_nonce_field('bhg_save_translation_action', 'bhg_nonce'); ?>
+	<form method="post">
+	<?php wp_nonce_field( 'bhg_save_translation_action', 'bhg_nonce' ); ?>
 	<table class="form-table" role="presentation">
-	  <tbody>
+		<tbody>
 		<tr>
-		  <th scope="row"><label for="tkey"><?php esc_html_e('Key','bonus-hunt-guesser'); ?></label></th>
-		  <td><input name="tkey" id="tkey" type="text" class="regular-text" required></td>
+			<th scope="row"><label for="tkey"><?php esc_html_e( 'Key', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><input name="tkey" id="tkey" type="text" class="regular-text" required></td>
 		</tr>
 		<tr>
-		  <th scope="row"><label for="tvalue"><?php esc_html_e('Value','bonus-hunt-guesser'); ?></label></th>
-		  <td><textarea name="tvalue" id="tvalue" class="large-text" rows="4"></textarea></td>
+			<th scope="row"><label for="tvalue"><?php esc_html_e( 'Value', 'bonus-hunt-guesser' ); ?></label></th>
+			<td><textarea name="tvalue" id="tvalue" class="large-text" rows="4"></textarea></td>
 		</tr>
-	  </tbody>
+		</tbody>
 	</table>
-		  <p class="submit"><button type="submit" name="bhg_save_translation" class="button button-primary"><?php esc_html_e('Save', 'bonus-hunt-guesser'); ?></button></p>
-  </form>
+			<p class="submit"><button type="submit" name="bhg_save_translation" class="button button-primary"><?php esc_html_e( 'Save', 'bonus-hunt-guesser' ); ?></button></p>
+	</form>
 
-  <h2><?php esc_html_e('Existing keys', 'bonus-hunt-guesser'); ?></h2>
-  <table class="widefat striped">
-	<thead><tr><th><?php esc_html_e('Key', 'bonus-hunt-guesser'); ?></th><th><?php esc_html_e('Value', 'bonus-hunt-guesser'); ?></th></tr></thead>
+	<h2><?php esc_html_e( 'Existing keys', 'bonus-hunt-guesser' ); ?></h2>
+	<table class="widefat striped">
+	<thead><tr><th><?php esc_html_e( 'Key', 'bonus-hunt-guesser' ); ?></th><th><?php esc_html_e( 'Value', 'bonus-hunt-guesser' ); ?></th></tr></thead>
 	<tbody>
-	  <?php if ($rows): foreach ($rows as $r): ?>
+		<?php
+		if ( $rows ) :
+			foreach ( $rows as $r ) :
+				?>
 		<tr<?php echo in_array( $r->tkey, $default_keys, true ) ? ' class="bhg-default-row"' : ''; ?>>
-		  <td><code><?php echo esc_html($r->tkey); ?></code></td>
-		  <td><?php echo esc_html($r->tvalue); ?></td>
+			<td><code><?php echo esc_html( $r->tkey ); ?></code></td>
+			<td><?php echo esc_html( $r->tvalue ); ?></td>
 		</tr>
-	  <?php endforeach; else: ?>
-		<tr><td colspan="2"><?php esc_html_e('No translations yet.','bonus-hunt-guesser'); ?></td></tr>
-	  <?php endif; ?>
+					<?php endforeach; else : ?>
+		<tr><td colspan="2"><?php esc_html_e( 'No translations yet.', 'bonus-hunt-guesser' ); ?></td></tr>
+		<?php endif; ?>
 	</tbody>
-  </table>
+	</table>
 </div>

--- a/admin/views/users.php
+++ b/admin/views/users.php
@@ -1,98 +1,142 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
-if (!current_user_can('manage_options')) {
-	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
-$paged    = max(1, isset($_GET['paged']) ? (int) $_GET['paged'] : 1);
-$per_page = 30;
-$search   = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
-$allowed_orderby = ['user_login', 'display_name', 'user_email'];
+$paged           = max( 1, isset( $_GET['paged'] ) ? (int) $_GET['paged'] : 1 );
+$per_page        = 30;
+$search          = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+$allowed_orderby = array( 'user_login', 'display_name', 'user_email' );
 $orderby         = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'user_login';
 if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
 	$orderby = 'user_login';
 }
 $order = ( isset( $_GET['order'] ) && 'desc' === strtolower( sanitize_key( wp_unslash( $_GET['order'] ) ) ) ) ? 'DESC' : 'ASC';
 
-$args = [
-	'number'   => $per_page,
-	'offset'   => ($paged - 1) * $per_page,
-	'orderby'  => $orderby,
-	'order'    => $order,
-	'search'   => $search ? '*' . $search . '*' : '',
-	'search_columns' => ['user_login','user_email','display_name'],
-];
+$args = array(
+	'number'         => $per_page,
+	'offset'         => ( $paged - 1 ) * $per_page,
+	'orderby'        => $orderby,
+	'order'          => $order,
+	'search'         => $search ? '*' . $search . '*' : '',
+	'search_columns' => array( 'user_login', 'user_email', 'display_name' ),
+);
 
-$user_query = new WP_User_Query($args);
-$users = $user_query->get_results();
-$total = $user_query->get_total();
+$user_query = new WP_User_Query( $args );
+$users      = $user_query->get_results();
+$total      = $user_query->get_total();
 
-$base_url = remove_query_arg(['paged']);
+$base_url = remove_query_arg( array( 'paged' ) );
 ?>
 <div class="wrap">
-  <h1 class="wp-heading-inline"><?php echo esc_html__('Users', 'bonus-hunt-guesser'); ?></h1>
+	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Users', 'bonus-hunt-guesser' ); ?></h1>
 
-  <form method="get" class="bhg-margin-top-small">
+	<form method="get" class="bhg-margin-top-small">
 	<input type="hidden" name="page" value="bhg-users" />
 	<p class="search-box">
-	  <label class="screen-reader-text" for="user-search-input"><?php echo esc_html__('Search Users', 'bonus-hunt-guesser'); ?></label>
-	  <input type="search" id="user-search-input" name="s" value="<?php echo esc_attr($search); ?>" />
-	  <input type="submit" id="search-submit" class="button" value="<?php echo esc_attr__('Search', 'bonus-hunt-guesser'); ?>" />
+		<label class="screen-reader-text" for="user-search-input"><?php echo esc_html__( 'Search Users', 'bonus-hunt-guesser' ); ?></label>
+		<input type="search" id="user-search-input" name="s" value="<?php echo esc_attr( $search ); ?>" />
+		<input type="submit" id="search-submit" class="button" value="<?php echo esc_attr__( 'Search', 'bonus-hunt-guesser' ); ?>" />
 	</p>
-  </form>
+	</form>
 
-  <table class="widefat striped">
+	<table class="widefat striped">
 	<thead>
-	  <tr>
-		<th><a href="<?php echo esc_url(add_query_arg(['orderby'=>'user_login','order'=> $order==='ASC'?'desc':'asc'], $base_url)); ?>"><?php echo esc_html__('Username', 'bonus-hunt-guesser'); ?></a></th>
-		<th><a href="<?php echo esc_url(add_query_arg(['orderby'=>'display_name','order'=> $order==='ASC'?'desc':'asc'], $base_url)); ?>"><?php echo esc_html__('Name', 'bonus-hunt-guesser'); ?></a></th>
-		<th><?php echo esc_html__('Real Name', 'bonus-hunt-guesser'); ?></th>
-		<th><a href="<?php echo esc_url(add_query_arg(['orderby'=>'user_email','order'=> $order==='ASC'?'desc':'asc'], $base_url)); ?>"><?php echo esc_html__('Email', 'bonus-hunt-guesser'); ?></a></th>
-		<th><?php echo esc_html__('Affiliate', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
-	  </tr>
+		<tr>
+		<th><a href="
+		<?php
+		echo esc_url(
+			add_query_arg(
+				array(
+					'orderby' => 'user_login',
+					'order'   => $order === 'ASC' ? 'desc' : 'asc',
+				),
+				$base_url
+			)
+		);
+		?>
+		"><?php echo esc_html__( 'Username', 'bonus-hunt-guesser' ); ?></a></th>
+		<th><a href="
+		<?php
+		echo esc_url(
+			add_query_arg(
+				array(
+					'orderby' => 'display_name',
+					'order'   => $order === 'ASC' ? 'desc' : 'asc',
+				),
+				$base_url
+			)
+		);
+		?>
+		"><?php echo esc_html__( 'Name', 'bonus-hunt-guesser' ); ?></a></th>
+		<th><?php echo esc_html__( 'Real Name', 'bonus-hunt-guesser' ); ?></th>
+		<th><a href="
+		<?php
+		echo esc_url(
+			add_query_arg(
+				array(
+					'orderby' => 'user_email',
+					'order'   => $order === 'ASC' ? 'desc' : 'asc',
+				),
+				$base_url
+			)
+		);
+		?>
+		"><?php echo esc_html__( 'Email', 'bonus-hunt-guesser' ); ?></a></th>
+		<th><?php echo esc_html__( 'Affiliate', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php echo esc_html__( 'Actions', 'bonus-hunt-guesser' ); ?></th>
+		</tr>
 	</thead>
 	<tbody>
-	  <?php if (empty($users)) : ?>
-		<tr><td colspan="6"><?php echo esc_html__('No users found.', 'bonus-hunt-guesser'); ?></td></tr>
-	  <?php else : foreach ($users as $u) :
-		  $form_id    = 'bhg-user-' . (int) $u->ID;
-		  $real_name  = get_user_meta($u->ID, 'bhg_real_name', true);
-		  $is_aff     = get_user_meta($u->ID, 'bhg_is_affiliate', true);
-	  ?>
+		<?php if ( empty( $users ) ) : ?>
+		<tr><td colspan="6"><?php echo esc_html__( 'No users found.', 'bonus-hunt-guesser' ); ?></td></tr>
+			<?php
+		else :
+			foreach ( $users as $u ) :
+				$form_id   = 'bhg-user-' . (int) $u->ID;
+				$real_name = get_user_meta( $u->ID, 'bhg_real_name', true );
+				$is_aff    = get_user_meta( $u->ID, 'bhg_is_affiliate', true );
+				?>
 		<tr>
-		  <td><?php echo esc_html($u->user_login); ?></td>
-		  <td><?php echo esc_html($u->display_name); ?></td>
-		  <td><input type="text" name="bhg_real_name" form="<?php echo esc_attr($form_id); ?>" value="<?php echo esc_attr($real_name); ?>" /></td>
-		  <td><?php echo esc_html($u->user_email); ?></td>
-		  <td class="bhg-text-center"><input type="checkbox" name="bhg_is_affiliate" value="1" form="<?php echo esc_attr($form_id); ?>" <?php checked( $is_aff, 1 ); ?> /></td>
-		  <td>
-			<form id="<?php echo esc_attr($form_id); ?>" method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
-			  <input type="hidden" name="action" value="bhg_save_user_meta" />
-			  <input type="hidden" name="user_id" value="<?php echo (int) $u->ID; ?>" />
-			  <?php wp_nonce_field('bhg_save_user_meta'); ?>
-			  <button type="submit" class="button button-primary"><?php echo esc_html__('Save', 'bonus-hunt-guesser'); ?></button>
+			<td><?php echo esc_html( $u->user_login ); ?></td>
+			<td><?php echo esc_html( $u->display_name ); ?></td>
+			<td><input type="text" name="bhg_real_name" form="<?php echo esc_attr( $form_id ); ?>" value="<?php echo esc_attr( $real_name ); ?>" /></td>
+			<td><?php echo esc_html( $u->user_email ); ?></td>
+			<td class="bhg-text-center"><input type="checkbox" name="bhg_is_affiliate" value="1" form="<?php echo esc_attr( $form_id ); ?>" <?php checked( $is_aff, 1 ); ?> /></td>
+			<td>
+			<form id="<?php echo esc_attr( $form_id ); ?>" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<input type="hidden" name="action" value="bhg_save_user_meta" />
+				<input type="hidden" name="user_id" value="<?php echo (int) $u->ID; ?>" />
+				<?php wp_nonce_field( 'bhg_save_user_meta' ); ?>
+				<button type="submit" class="button button-primary"><?php echo esc_html__( 'Save', 'bonus-hunt-guesser' ); ?></button>
 			</form>
-			<a class="button" href="<?php echo esc_url(admin_url('user-edit.php?user_id='.(int)$u->ID)); ?>"><?php echo esc_html__('View / Edit', 'bonus-hunt-guesser'); ?></a>
-		  </td>
+			<a class="button" href="<?php echo esc_url( admin_url( 'user-edit.php?user_id=' . (int) $u->ID ) ); ?>"><?php echo esc_html__( 'View / Edit', 'bonus-hunt-guesser' ); ?></a>
+			</td>
 		</tr>
-	  <?php endforeach; endif; ?>
+					<?php
+		endforeach;
+endif;
+		?>
 	</tbody>
-  </table>
+	</table>
 
-  <?php
-	$total_pages = ceil($total / $per_page);
-	if ($total_pages > 1) {
+	<?php
+	$total_pages = ceil( $total / $per_page );
+	if ( $total_pages > 1 ) {
 		echo '<div class="tablenav"><div class="tablenav-pages">';
-		echo paginate_links([
-			'base'      => add_query_arg('paged', '%#%', $base_url),
-			'format'    => '',
-			'prev_text' => '&laquo;',
-			'next_text' => '&raquo;',
-			'total'     => $total_pages,
-			'current'   => $paged,
-		]);
+		echo paginate_links(
+			array(
+				'base'      => add_query_arg( 'paged', '%#%', $base_url ),
+				'format'    => '',
+				'prev_text' => '&laquo;',
+				'next_text' => '&raquo;',
+				'total'     => $total_pages,
+				'current'   => $paged,
+			)
+		);
 		echo '</div></div>';
 	}
-  ?>
+	?>
 </div>

--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -1,110 +1,134 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
 class BHG_Ads {
 
 	/** Initialize front-end hooks for ads */
 	public static function init() {
-		add_action( 'wp_footer', [ 'BHG_Ads', 'render_footer' ] );
-		add_shortcode( 'bhg_ad', [ 'BHG_Ads', 'shortcode' ] );
-		add_shortcode( 'bhg_advertising', [ 'BHG_Ads', 'shortcode' ] );
+		add_action( 'wp_footer', array( 'BHG_Ads', 'render_footer' ) );
+		add_shortcode( 'bhg_ad', array( 'BHG_Ads', 'shortcode' ) );
+		add_shortcode( 'bhg_advertising', array( 'BHG_Ads', 'shortcode' ) );
 	}
 
 
 	/** Checks if front-end ads are enabled in plugin settings. */
 	protected static function ads_enabled() {
-		$settings = get_option('bhg_plugin_settings', []);
-		$enabled = isset($settings['ads_enabled']) ? (int)$settings['ads_enabled'] : 0;
+		$settings = get_option( 'bhg_plugin_settings', array() );
+		$enabled  = isset( $settings['ads_enabled'] ) ? (int) $settings['ads_enabled'] : 0;
 		return $enabled === 1;
 	}
 
 	/** Determine current user's affiliate status (global toggle). */
 	protected static function user_is_affiliate() {
-		if (!is_user_logged_in()) return false;
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
 		$uid = get_current_user_id();
-		return (bool) get_user_meta($uid, 'bhg_is_affiliate', true);
+		return (bool) get_user_meta( $uid, 'bhg_is_affiliate', true );
 	}
 
 	/** Whether current visitor matches the ad's visibility setting. */
-	protected static function visibility_ok($visibility) {
-		$visibility = is_string($visibility) ? strtolower($visibility) : 'all';
-		switch ($visibility) {
+	protected static function visibility_ok( $visibility ) {
+		$visibility = is_string( $visibility ) ? strtolower( $visibility ) : 'all';
+		switch ( $visibility ) {
 			case 'logged_in':
-		return is_user_logged_in();
+				return is_user_logged_in();
 			case 'guests':
-		return !is_user_logged_in();
+				return ! is_user_logged_in();
 			case 'affiliates':
-		return self::user_is_affiliate();
+				return self::user_is_affiliate();
 			case 'non_affiliates':
-		return is_user_logged_in() ? ! self::user_is_affiliate() : false;
+				return is_user_logged_in() ? ! self::user_is_affiliate() : false;
 			case 'all':
 			default:
-		return true;
+				return true;
 		}
 	}
 
 	/** Whether the current page is one of the targeted pages (by slug), if any are set. */
-	protected static function page_target_ok($target_pages) {
-		$target_pages = is_string($target_pages) ? trim($target_pages) : '';
-		if ($target_pages === '') return true; // no restriction
+	protected static function page_target_ok( $target_pages ) {
+		$target_pages = is_string( $target_pages ) ? trim( $target_pages ) : '';
+		if ( $target_pages === '' ) {
+			return true; // no restriction
+		}
 
 		// Normalize list of slugs
-		$slugs = array_filter(array_map(function($s){
-			return sanitize_title(wp_unslash(trim($s)));
-		}, explode(',', $target_pages)));
+		$slugs = array_filter(
+			array_map(
+				function ( $s ) {
+					return sanitize_title( wp_unslash( trim( $s ) ) );
+				},
+				explode( ',', $target_pages )
+			)
+		);
 
-		if (empty($slugs)) return true;
+		if ( empty( $slugs ) ) {
+			return true;
+		}
 
 		// On singular pages, check post_name; otherwise, do not show
-		if (is_singular()) {
+		if ( is_singular() ) {
 			$post = get_post();
-			if (!$post) return false;
+			if ( ! $post ) {
+				return false;
+			}
 			$slug = $post->post_name;
-			return in_array($slug, $slugs, true);
+			return in_array( $slug, $slugs, true );
 		}
 		return false;
 	}
 
 	/** Render a single ad row to HTML */
-	protected static function render_ad_row($row) {
-		$msg = isset($row->content) ? $row->content : '';
-		$msg = wp_kses_post($msg);
-		$link = isset($row->link_url) ? esc_url($row->link_url) : '';
+	protected static function render_ad_row( $row ) {
+		$msg  = isset( $row->content ) ? $row->content : '';
+		$msg  = wp_kses_post( $msg );
+		$link = isset( $row->link_url ) ? esc_url( $row->link_url ) : '';
 
-		if ($link) {
+		if ( $link ) {
 			$msg = '<a href="' . $link . '">' . $msg . '</a>';
 		}
-		return '<div class="bhg-ad bhg-ad-' . esc_attr($row->placement) . '">' . $msg . '</div>';
+		return '<div class="bhg-ad bhg-ad-' . esc_attr( $row->placement ) . '">' . $msg . '</div>';
 	}
 
 	/** Fetch active ads for a placement */
-	protected static function get_ads_for_placement($placement = 'footer') {
+	protected static function get_ads_for_placement( $placement = 'footer' ) {
 		global $wpdb;
-		$table = $wpdb->prefix . 'bhg_ads';
-		$placement = sanitize_text_field($placement);
+		$table     = $wpdb->prefix . 'bhg_ads';
+		$placement = sanitize_text_field( $placement );
 		// Active ads ordered newest first
 		$sql = "SELECT id, content, link_url, placement, visible_to, target_pages FROM {$table} WHERE active=1 AND placement=%s ORDER BY id DESC";
-		return $wpdb->get_results($wpdb->prepare($sql, $placement));
+		return $wpdb->get_results( $wpdb->prepare( $sql, $placement ) );
 	}
 
 	/** Render footer-placed ads */
 	public static function render_footer() {
-		if (is_admin()) return;
-		if (!self::ads_enabled()) return;
-
-		$ads = self::get_ads_for_placement('footer');
-		if (empty($ads)) return;
-
-		$out = [];
-		foreach ($ads as $row) {
-			if (!self::visibility_ok($row->visible_to)) continue;
-			if (!self::page_target_ok($row->target_pages)) continue;
-			$out[] = self::render_ad_row($row);
+		if ( is_admin() ) {
+			return;
+		}
+		if ( ! self::ads_enabled() ) {
+			return;
 		}
 
-		if (!empty($out)) {
+		$ads = self::get_ads_for_placement( 'footer' );
+		if ( empty( $ads ) ) {
+			return;
+		}
+
+		$out = array();
+		foreach ( $ads as $row ) {
+			if ( ! self::visibility_ok( $row->visible_to ) ) {
+				continue;
+			}
+			if ( ! self::page_target_ok( $row->target_pages ) ) {
+				continue;
+			}
+			$out[] = self::render_ad_row( $row );
+		}
+
+		if ( ! empty( $out ) ) {
 			echo '<div class="bhg-ads bhg-ads-footer" style="margin:16px 0;text-align:center;">';
-			echo implode("\n", $out);
+			echo implode( "\n", $out );
 			echo '</div>';
 		}
 	}
@@ -122,47 +146,45 @@ class BHG_Ads {
 	 *
 	 * @return string
 	 */
-	public static function shortcode( $atts = [], $content = '', $tag = '' ) {
+	public static function shortcode( $atts = array(), $content = '', $tag = '' ) {
 		$a = shortcode_atts(
-		[
-		'id'     => 0,
-		'ad'     => 0,
-		'status' => 'active',
-		],
-		$atts,
-		$tag
+			array(
+				'id'     => 0,
+				'ad'     => 0,
+				'status' => 'active',
+			),
+			$atts,
+			$tag
 		);
-		
+
 		$id = $a['id'] ? (int) $a['id'] : (int) $a['ad'];
 		if ( $id <= 0 ) {
-		return '';
+			return '';
 		}
-		
+
 		$status = strtolower( trim( $a['status'] ) );
-		
+
 		global $wpdb;
 		$table = $wpdb->prefix . 'bhg_ads';
 		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT id, content, placement, visible_to, target_pages, active, link_url FROM `$table` WHERE id=%d", $id ) );
 		if ( ! $row ) {
-		return '';
+			return '';
 		}
-		
+
 		if ( 'all' !== $status ) {
-		$expected = ( 'inactive' === $status ) ? 0 : 1;
-		if ( (int) $row->active !== $expected ) {
-		return '';
+			$expected = ( 'inactive' === $status ) ? 0 : 1;
+			if ( (int) $row->active !== $expected ) {
+				return '';
+			}
 		}
-		}
-		
+
 		if ( ! self::visibility_ok( $row->visible_to ) ) {
-		return '';
+			return '';
 		}
 		if ( ! self::page_target_ok( $row->target_pages ) ) {
-		return '';
+			return '';
 		}
-		
+
 		return self::render_ad_row( $row );
 	}
-
 }
-

--- a/includes/class-bhg-bonus-hunts-helpers.php
+++ b/includes/class-bhg-bonus-hunts-helpers.php
@@ -1,5 +1,6 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
 /**
  * Helper functions for hunts and guesses used by admin dashboard, list and results.
@@ -8,35 +9,41 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
  *  - {$wpdb->prefix}bhg_guesses (id, hunt_id, user_id, guess, created_at)
  */
 
-if (!function_exists('bhg_get_hunt')) {
-	function bhg_get_hunt($hunt_id){
+if ( ! function_exists( 'bhg_get_hunt' ) ) {
+	function bhg_get_hunt( $hunt_id ) {
 		global $wpdb;
 		$t = $wpdb->prefix . 'bhg_bonus_hunts';
-		return $wpdb->get_row($wpdb->prepare("SELECT * FROM $t WHERE id=%d", (int)$hunt_id));
+		return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $t WHERE id=%d", (int) $hunt_id ) );
 	}
 }
 
-if (!function_exists('bhg_get_latest_closed_hunts')) {
-	function bhg_get_latest_closed_hunts($limit = 3){
+if ( ! function_exists( 'bhg_get_latest_closed_hunts' ) ) {
+	function bhg_get_latest_closed_hunts( $limit = 3 ) {
 		global $wpdb;
-		$t = $wpdb->prefix . 'bhg_bonus_hunts';
-		$sql = $wpdb->prepare("SELECT id, title, starting_balance, final_balance, winners_count, closed_at
+		$t   = $wpdb->prefix . 'bhg_bonus_hunts';
+		$sql = $wpdb->prepare(
+			"SELECT id, title, starting_balance, final_balance, winners_count, closed_at
 							   FROM $t
 							   WHERE status = %s
 							   ORDER BY closed_at DESC
-							   LIMIT %d", 'closed', (int)$limit);
-		return $wpdb->get_results($sql);
+							   LIMIT %d",
+			'closed',
+			(int) $limit
+		);
+		return $wpdb->get_results( $sql );
 	}
 }
 
-if (!function_exists('bhg_get_top_winners_for_hunt')) {
-	function bhg_get_top_winners_for_hunt($hunt_id, $winners_limit = 3){
+if ( ! function_exists( 'bhg_get_top_winners_for_hunt' ) ) {
+	function bhg_get_top_winners_for_hunt( $hunt_id, $winners_limit = 3 ) {
 		global $wpdb;
 		$t_g = $wpdb->prefix . 'bhg_guesses';
 		$t_h = $wpdb->prefix . 'bhg_bonus_hunts';
 
-		$hunt = $wpdb->get_row($wpdb->prepare("SELECT final_balance, winners_count FROM $t_h WHERE id=%d", (int)$hunt_id));
-		if (!$hunt || $hunt->final_balance === null) return array();
+		$hunt = $wpdb->get_row( $wpdb->prepare( "SELECT final_balance, winners_count FROM $t_h WHERE id=%d", (int) $hunt_id ) );
+		if ( ! $hunt || $hunt->final_balance === null ) {
+			return array();
+		}
 		$limit = $winners_limit ?: (int) $hunt->winners_count ?: 3;
 
 		$sql = $wpdb->prepare(
@@ -45,38 +52,43 @@ if (!function_exists('bhg_get_top_winners_for_hunt')) {
 			 WHERE g.hunt_id = %d
 			 ORDER BY diff ASC
 			 LIMIT %d",
-			(float)$hunt->final_balance, (int)$hunt_id, (int)$limit
+			(float) $hunt->final_balance,
+			(int) $hunt_id,
+			(int) $limit
 		);
-		return $wpdb->get_results($sql);
+		return $wpdb->get_results( $sql );
 	}
 }
 
-if (!function_exists('bhg_get_all_ranked_guesses')) {
-	function bhg_get_all_ranked_guesses($hunt_id){
+if ( ! function_exists( 'bhg_get_all_ranked_guesses' ) ) {
+	function bhg_get_all_ranked_guesses( $hunt_id ) {
 		global $wpdb;
-		$t_g = $wpdb->prefix . 'bhg_guesses';
-		$t_h = $wpdb->prefix . 'bhg_bonus_hunts';
-		$hunt = $wpdb->get_row($wpdb->prepare("SELECT final_balance FROM $t_h WHERE id=%d", (int)$hunt_id));
-		if (!$hunt || $hunt->final_balance === null) return array();
+		$t_g  = $wpdb->prefix . 'bhg_guesses';
+		$t_h  = $wpdb->prefix . 'bhg_bonus_hunts';
+		$hunt = $wpdb->get_row( $wpdb->prepare( "SELECT final_balance FROM $t_h WHERE id=%d", (int) $hunt_id ) );
+		if ( ! $hunt || $hunt->final_balance === null ) {
+			return array();
+		}
 
 		$sql = $wpdb->prepare(
 			"SELECT g.id, g.user_id, g.guess, ABS(g.guess - %f) AS diff
 			 FROM $t_g g
 			 WHERE g.hunt_id = %d
 			 ORDER BY diff ASC",
-			(float)$hunt->final_balance, (int)$hunt_id
+			(float) $hunt->final_balance,
+			(int) $hunt_id
 		);
-		return $wpdb->get_results($sql);
+		return $wpdb->get_results( $sql );
 	}
 }
 
-if (!function_exists('bhg_get_hunt_participants')) {
-	function bhg_get_hunt_participants($hunt_id, $paged = 1, $per_page = 30){
+if ( ! function_exists( 'bhg_get_hunt_participants' ) ) {
+	function bhg_get_hunt_participants( $hunt_id, $paged = 1, $per_page = 30 ) {
 		global $wpdb;
-		$t_g = $wpdb->prefix . 'bhg_guesses';
-		$offset = max(0, ((int)$paged - 1) * (int)$per_page);
+		$t_g    = $wpdb->prefix . 'bhg_guesses';
+		$offset = max( 0, ( (int) $paged - 1 ) * (int) $per_page );
 
-			$rows = $wpdb->get_results(
+			$rows  = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT id, user_id, guess, created_at
 					 FROM $t_g
@@ -94,14 +106,17 @@ if (!function_exists('bhg_get_hunt_participants')) {
 					(int) $hunt_id
 				)
 			);
-			return array( 'rows' => $rows, 'total' => $total );
+			return array(
+				'rows'  => $rows,
+				'total' => $total,
+			);
 	}
 }
 
-if (!function_exists('bhg_remove_guess')) {
-	function bhg_remove_guess($guess_id){
+if ( ! function_exists( 'bhg_remove_guess' ) ) {
+	function bhg_remove_guess( $guess_id ) {
 		global $wpdb;
 		$t_g = $wpdb->prefix . 'bhg_guesses';
-		return $wpdb->delete($t_g, array('id' => (int)$guess_id), array('%d'));
+		return $wpdb->delete( $t_g, array( 'id' => (int) $guess_id ), array( '%d' ) );
 	}
 }

--- a/includes/class-bhg-bonus-hunts.php
+++ b/includes/class-bhg-bonus-hunts.php
@@ -1,5 +1,6 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
 /**
  * Bonus hunt data helpers.
@@ -83,7 +84,8 @@ class BHG_Bonus_Hunts {
 		$guesses_table = $wpdb->prefix . 'bhg_guesses';
 		$hunt          = self::get_hunt( $hunt_id );
 
-		if ( ! $hunt ) { return array(); }
+		if ( ! $hunt ) {
+			return array(); }
 
 		if ( null !== $hunt->final_balance ) {
 			return $wpdb->get_results(

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -1,5 +1,6 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
 class BHG_DB {
 
@@ -28,7 +29,7 @@ class BHG_DB {
 
 		$charset_collate = $wpdb->get_charset_collate();
 
-		$hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
+		$hunts_table           = $wpdb->prefix . 'bhg_bonus_hunts';
 				$guesses_table = $wpdb->prefix . 'bhg_guesses';
 				$tours_table   = $wpdb->prefix . 'bhg_tournaments';
 				$tres_table    = $wpdb->prefix . 'bhg_tournament_results';
@@ -36,7 +37,7 @@ class BHG_DB {
 				$trans_table   = $wpdb->prefix . 'bhg_translations';
 				$aff_table     = $wpdb->prefix . 'bhg_affiliates';
 
-		$sql = [];
+		$sql = array();
 
 		// Bonus Hunts
 		$sql[] = "CREATE TABLE {$hunts_table} (
@@ -137,19 +138,19 @@ class BHG_DB {
 			UNIQUE KEY name_unique (name)
 		) {$charset_collate};";
 
-		foreach ($sql as $statement) {
-			dbDelta($statement);
+		foreach ( $sql as $statement ) {
+			dbDelta( $statement );
 		}
 
 		// Idempotent ensure for columns/indexes
 		try {
 			// Hunts: winners_count, affiliate_site_id
-			$need = [
-				'winners_count'    => "ALTER TABLE `{$hunts_table}` ADD COLUMN winners_count INT UNSIGNED NOT NULL DEFAULT 3",
-				'affiliate_site_id'=> "ALTER TABLE `{$hunts_table}` ADD COLUMN affiliate_site_id BIGINT UNSIGNED NULL",
-				'final_balance'    => "ALTER TABLE `{$hunts_table}` ADD COLUMN final_balance DECIMAL(12,2) NULL",
-				'status'           => "ALTER TABLE `{$hunts_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'",
-			];
+			$need = array(
+				'winners_count'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN winners_count INT UNSIGNED NOT NULL DEFAULT 3",
+				'affiliate_site_id' => "ALTER TABLE `{$hunts_table}` ADD COLUMN affiliate_site_id BIGINT UNSIGNED NULL",
+				'final_balance'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN final_balance DECIMAL(12,2) NULL",
+				'status'            => "ALTER TABLE `{$hunts_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'",
+			);
 			foreach ( $need as $c => $alter ) {
 				if ( ! $this->column_exists( $hunts_table, $c ) ) {
 					$wpdb->query( $alter );
@@ -157,31 +158,31 @@ class BHG_DB {
 			}
 
 			// Tournaments: make sure common columns exist
-			$tneed = [
+			$tneed = array(
 				'title'       => "ALTER TABLE `{$tours_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
 				'description' => "ALTER TABLE `{$tours_table}` ADD COLUMN description TEXT NULL",
 				'type'        => "ALTER TABLE `{$tours_table}` ADD COLUMN type VARCHAR(20) NOT NULL",
 				'start_date'  => "ALTER TABLE `{$tours_table}` ADD COLUMN start_date DATE NULL",
 				'end_date'    => "ALTER TABLE `{$tours_table}` ADD COLUMN end_date DATE NULL",
 				'status'      => "ALTER TABLE `{$tours_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
-			];
-						foreach ( $tneed as $c => $alter ) {
-								if ( ! $this->column_exists( $tours_table, $c ) ) {
-										$wpdb->query( $alter );
-								}
-						}
+			);
+			foreach ( $tneed as $c => $alter ) {
+				if ( ! $this->column_exists( $tours_table, $c ) ) {
+								$wpdb->query( $alter );
+				}
+			}
 
 						// Tournament results columns
-						$trrneed = [
-								'tournament_id' => "ALTER TABLE `{$tres_table}` ADD COLUMN tournament_id BIGINT UNSIGNED NOT NULL",
-								'user_id'       => "ALTER TABLE `{$tres_table}` ADD COLUMN user_id BIGINT UNSIGNED NOT NULL",
-								'wins'          => "ALTER TABLE `{$tres_table}` ADD COLUMN wins INT UNSIGNED NOT NULL DEFAULT 0",
-								'last_win_date' => "ALTER TABLE `{$tres_table}` ADD COLUMN last_win_date DATETIME NULL",
-						];
+						$trrneed = array(
+							'tournament_id' => "ALTER TABLE `{$tres_table}` ADD COLUMN tournament_id BIGINT UNSIGNED NOT NULL",
+							'user_id'       => "ALTER TABLE `{$tres_table}` ADD COLUMN user_id BIGINT UNSIGNED NOT NULL",
+							'wins'          => "ALTER TABLE `{$tres_table}` ADD COLUMN wins INT UNSIGNED NOT NULL DEFAULT 0",
+							'last_win_date' => "ALTER TABLE `{$tres_table}` ADD COLUMN last_win_date DATETIME NULL",
+						);
 						foreach ( $trrneed as $c => $alter ) {
-								if ( ! $this->column_exists( $tres_table, $c ) ) {
-										$wpdb->query( $alter );
-								}
+							if ( ! $this->column_exists( $tres_table, $c ) ) {
+									$wpdb->query( $alter );
+							}
 						}
 						if ( ! $this->index_exists( $tres_table, 'tournament_id' ) ) {
 								$wpdb->query( "ALTER TABLE `{$tres_table}` ADD KEY tournament_id (tournament_id)" );
@@ -191,60 +192,61 @@ class BHG_DB {
 						}
 
 						// Ads columns
-						$aneed = [
-								'title'        => "ALTER TABLE `{$ads_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
-								'content'      => "ALTER TABLE `{$ads_table}` ADD COLUMN content TEXT NULL",
-				'link_url'     => "ALTER TABLE `{$ads_table}` ADD COLUMN link_url VARCHAR(255) NULL",
-				'placement'    => "ALTER TABLE `{$ads_table}` ADD COLUMN placement VARCHAR(50) NOT NULL DEFAULT 'none'",
-				'visible_to'   => "ALTER TABLE `{$ads_table}` ADD COLUMN visible_to VARCHAR(30) NOT NULL DEFAULT 'all'",
-				'target_pages' => "ALTER TABLE `{$ads_table}` ADD COLUMN target_pages TEXT NULL",
-				'active'       => "ALTER TABLE `{$ads_table}` ADD COLUMN active TINYINT(1) NOT NULL DEFAULT 1",
-				'created_at'   => "ALTER TABLE `{$ads_table}` ADD COLUMN created_at DATETIME NULL",
-				'updated_at'   => "ALTER TABLE `{$ads_table}` ADD COLUMN updated_at DATETIME NULL",
-			];
-			foreach ( $aneed as $c => $alter ) {
-				if ( ! $this->column_exists( $ads_table, $c ) ) {
-					$wpdb->query( $alter );
-				}
-			}
+						$aneed = array(
+							'title'        => "ALTER TABLE `{$ads_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
+							'content'      => "ALTER TABLE `{$ads_table}` ADD COLUMN content TEXT NULL",
+							'link_url'     => "ALTER TABLE `{$ads_table}` ADD COLUMN link_url VARCHAR(255) NULL",
+							'placement'    => "ALTER TABLE `{$ads_table}` ADD COLUMN placement VARCHAR(50) NOT NULL DEFAULT 'none'",
+							'visible_to'   => "ALTER TABLE `{$ads_table}` ADD COLUMN visible_to VARCHAR(30) NOT NULL DEFAULT 'all'",
+							'target_pages' => "ALTER TABLE `{$ads_table}` ADD COLUMN target_pages TEXT NULL",
+							'active'       => "ALTER TABLE `{$ads_table}` ADD COLUMN active TINYINT(1) NOT NULL DEFAULT 1",
+							'created_at'   => "ALTER TABLE `{$ads_table}` ADD COLUMN created_at DATETIME NULL",
+							'updated_at'   => "ALTER TABLE `{$ads_table}` ADD COLUMN updated_at DATETIME NULL",
+						);
+						foreach ( $aneed as $c => $alter ) {
+							if ( ! $this->column_exists( $ads_table, $c ) ) {
+								$wpdb->query( $alter );
+							}
+						}
 
-			// Translations columns
-			$trneed = [
-				'tkey'       => "ALTER TABLE `{$trans_table}` ADD COLUMN tkey VARCHAR(190) NOT NULL",
-				'tvalue'     => "ALTER TABLE `{$trans_table}` ADD COLUMN tvalue LONGTEXT NULL",
-				'locale'     => "ALTER TABLE `{$trans_table}` ADD COLUMN locale VARCHAR(20) NOT NULL DEFAULT 'en_US'",
-				'created_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN created_at DATETIME NULL",
-				'updated_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN updated_at DATETIME NULL",
-			];
-			foreach ( $trneed as $c => $alter ) {
-				if ( ! $this->column_exists( $trans_table, $c ) ) {
-					$wpdb->query( $alter );
-				}
-			}
-			// Ensure unique index
-			if ( ! $this->index_exists( $trans_table, 'tkey_locale' ) ) {
-				$wpdb->query( "ALTER TABLE `{$trans_table}` ADD UNIQUE KEY tkey_locale (tkey, locale)" );
-			}
+						// Translations columns
+						$trneed = array(
+							'tkey'       => "ALTER TABLE `{$trans_table}` ADD COLUMN tkey VARCHAR(190) NOT NULL",
+							'tvalue'     => "ALTER TABLE `{$trans_table}` ADD COLUMN tvalue LONGTEXT NULL",
+							'locale'     => "ALTER TABLE `{$trans_table}` ADD COLUMN locale VARCHAR(20) NOT NULL DEFAULT 'en_US'",
+							'created_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN created_at DATETIME NULL",
+							'updated_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN updated_at DATETIME NULL",
+						);
+						foreach ( $trneed as $c => $alter ) {
+							if ( ! $this->column_exists( $trans_table, $c ) ) {
+								$wpdb->query( $alter );
+							}
+						}
+						// Ensure unique index
+						if ( ! $this->index_exists( $trans_table, 'tkey_locale' ) ) {
+							$wpdb->query( "ALTER TABLE `{$trans_table}` ADD UNIQUE KEY tkey_locale (tkey, locale)" );
+						}
 
-			// Affiliates columns / unique index
-			$afneed = [
-				'name'       => "ALTER TABLE `{$aff_table}` ADD COLUMN name VARCHAR(190) NOT NULL",
-				'url'        => "ALTER TABLE `{$aff_table}` ADD COLUMN url VARCHAR(255) NULL",
-				'status'     => "ALTER TABLE `{$aff_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
-				'created_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN created_at DATETIME NULL",
-				'updated_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN updated_at DATETIME NULL",
-			];
-			foreach ( $afneed as $c => $alter ) {
-				if ( ! $this->column_exists( $aff_table, $c ) ) {
-					$wpdb->query( $alter );
-				}
+						// Affiliates columns / unique index
+						$afneed = array(
+							'name'       => "ALTER TABLE `{$aff_table}` ADD COLUMN name VARCHAR(190) NOT NULL",
+							'url'        => "ALTER TABLE `{$aff_table}` ADD COLUMN url VARCHAR(255) NULL",
+							'status'     => "ALTER TABLE `{$aff_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
+							'created_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN created_at DATETIME NULL",
+							'updated_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN updated_at DATETIME NULL",
+						);
+						foreach ( $afneed as $c => $alter ) {
+							if ( ! $this->column_exists( $aff_table, $c ) ) {
+								$wpdb->query( $alter );
+							}
+						}
+						if ( ! $this->index_exists( $aff_table, 'name_unique' ) ) {
+							$wpdb->query( "ALTER TABLE `{$aff_table}` ADD UNIQUE KEY name_unique (name)" );
+						}
+		} catch ( Throwable $e ) {
+			if ( function_exists( 'error_log' ) ) {
+				error_log( '[BHG] Schema ensure error: ' . $e->getMessage() );
 			}
-			if ( ! $this->index_exists( $aff_table, 'name_unique' ) ) {
-				$wpdb->query( "ALTER TABLE `{$aff_table}` ADD UNIQUE KEY name_unique (name)" );
-			}
-
-		} catch (Throwable $e) {
-			if (function_exists('error_log')) error_log('[BHG] Schema ensure error: ' . $e->getMessage());
 		}
 	}
 
@@ -262,13 +264,13 @@ class BHG_DB {
 		$column = esc_sql( $column );
 
 		$wpdb->last_error = '';
-		$sql    = $wpdb->prepare(
-			"SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=%s AND TABLE_NAME=%s AND COLUMN_NAME=%s",
+		$sql              = $wpdb->prepare(
+			'SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=%s AND TABLE_NAME=%s AND COLUMN_NAME=%s',
 			DB_NAME,
 			$table,
 			$column
 		);
-		$exists = $wpdb->get_var( $sql );
+		$exists           = $wpdb->get_var( $sql );
 
 		if ( $wpdb->last_error ) {
 			$wpdb->last_error = '';
@@ -292,13 +294,13 @@ class BHG_DB {
 		$index = esc_sql( $index );
 
 		$wpdb->last_error = '';
-		$sql    = $wpdb->prepare(
-			"SELECT INDEX_NAME FROM information_schema.STATISTICS WHERE TABLE_SCHEMA=%s AND TABLE_NAME=%s AND INDEX_NAME=%s",
+		$sql              = $wpdb->prepare(
+			'SELECT INDEX_NAME FROM information_schema.STATISTICS WHERE TABLE_SCHEMA=%s AND TABLE_NAME=%s AND INDEX_NAME=%s',
 			DB_NAME,
 			$table,
 			$index
 		);
-		$exists = $wpdb->get_var( $sql );
+		$exists           = $wpdb->get_var( $sql );
 
 		if ( $wpdb->last_error ) {
 			$wpdb->last_error = '';

--- a/includes/class-bhg-logger.php
+++ b/includes/class-bhg-logger.php
@@ -1,6 +1,9 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 class BHG_Logger {
-	public static function info($msg){ bhg_log($msg); }
-	public static function error($msg){ bhg_log('ERROR: ' . $msg); }
+	public static function info( $msg ) {
+		bhg_log( $msg ); }
+	public static function error( $msg ) {
+		bhg_log( 'ERROR: ' . $msg ); }
 }

--- a/includes/class-bhg-menus.php
+++ b/includes/class-bhg-menus.php
@@ -1,116 +1,132 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
-if (!class_exists('BHG_Menus')) {
-class BHG_Menus {
-    private static $instance = null;
-    private $initialized = false;
+if ( ! class_exists( 'BHG_Menus' ) ) {
+	class BHG_Menus {
+		private static $instance = null;
+		private $initialized     = false;
 
-    public static function get_instance() {
-        if (self::$instance === null) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
+		public static function get_instance() {
+			if ( self::$instance === null ) {
+				self::$instance = new self();
+			}
+			return self::$instance;
+		}
 
-    private function __construct() {}
+		private function __construct() {}
 
-    public function init() {
-        if ($this->initialized) { return; }
-        $this->initialized = true;
+		public function init() {
+			if ( $this->initialized ) {
+				return; }
+			$this->initialized = true;
 
-        add_action('admin_menu', array($this, 'admin_menu'));
-        add_action('admin_enqueue_scripts', array($this, 'assets'));
-        add_action('init', array($this, 'register_locations'), 5);
-    }
+			add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'assets' ) );
+			add_action( 'init', array( $this, 'register_locations' ), 5 );
+		}
 
-    public function assets($hook) {
-        if (strpos($hook, 'bhg') !== false) {
-            wp_enqueue_style('bhg-admin', BHG_PLUGIN_URL . 'assets/css/admin.css', array(), defined('BHG_VERSION') ? BHG_VERSION : null);
-            wp_enqueue_script('bhg-admin', BHG_PLUGIN_URL . 'assets/js/admin.js', array('jquery'), defined('BHG_VERSION') ? BHG_VERSION : null, true);
-        }
-    }
+		public function assets( $hook ) {
+			if ( strpos( $hook, 'bhg' ) !== false ) {
+				wp_enqueue_style( 'bhg-admin', BHG_PLUGIN_URL . 'assets/css/admin.css', array(), defined( 'BHG_VERSION' ) ? BHG_VERSION : null );
+				wp_enqueue_script( 'bhg-admin', BHG_PLUGIN_URL . 'assets/js/admin.js', array( 'jquery' ), defined( 'BHG_VERSION' ) ? BHG_VERSION : null, true );
+			}
+		}
 
-    public function admin_menu() {
-        // Prevent duplicate top-level menu
-        global $menu;
-        foreach ((array)$menu as $item) {
-            if (isset($item[2]) && $item[2] === 'bhg') {
-                return;
-            }
-        }
+		public function admin_menu() {
+			// Prevent duplicate top-level menu
+			global $menu;
+			foreach ( (array) $menu as $item ) {
+				if ( isset( $item[2] ) && $item[2] === 'bhg' ) {
+					return;
+				}
+			}
 
-        $cap  = $this->admin_capability();
-        $slug = 'bhg';
+			$cap  = $this->admin_capability();
+			$slug = 'bhg';
 
-        add_menu_page(
-            __('Bonus Hunt', 'bonus-hunt-guesser'),
-            __('Bonus Hunt', 'bonus-hunt-guesser'),
-            $cap,
-            $slug,
-            array($this, 'render_dashboard'),
-            'dashicons-awards',
-            26
-        );
+			add_menu_page(
+				__( 'Bonus Hunt', 'bonus-hunt-guesser' ),
+				__( 'Bonus Hunt', 'bonus-hunt-guesser' ),
+				$cap,
+				$slug,
+				array( $this, 'render_dashboard' ),
+				'dashicons-awards',
+				26
+			);
 
-        add_submenu_page($slug, __('Dashboard', 'bonus-hunt-guesser'), __('Dashboard', 'bonus-hunt-guesser'), $cap, $slug, array($this, 'render_dashboard'));
-        add_submenu_page($slug, __('Bonus Hunts', 'bonus-hunt-guesser'), __('Bonus Hunts', 'bonus-hunt-guesser'), $cap, 'bhg-bonus-hunts', array($this, 'render_bonus_hunts'));
-        add_submenu_page($slug, __('Users', 'bonus-hunt-guesser'), __('Users', 'bonus-hunt-guesser'), $cap, 'bhg-users', array($this, 'render_users'));
-        add_submenu_page($slug, __('Affiliate Websites', 'bonus-hunt-guesser'), __('Affiliate Websites', 'bonus-hunt-guesser'), $cap, 'bhg-affiliate-websites', array($this, 'render_affiliates'));
-        add_submenu_page($slug, __('Tournaments', 'bonus-hunt-guesser'), __('Tournaments', 'bonus-hunt-guesser'), $cap, 'bhg-tournaments', array($this, 'render_tournaments'));
-        add_submenu_page($slug, __('Translations', 'bonus-hunt-guesser'), __('Translations', 'bonus-hunt-guesser'), $cap, 'bhg-translations', array($this, 'render_translations'));
-        add_submenu_page($slug, __('Settings', 'bonus-hunt-guesser'), __('Settings', 'bonus-hunt-guesser'), $cap, 'bhg-settings', array($this, 'render_settings'));
-        add_submenu_page($slug, __('Database', 'bonus-hunt-guesser'), __('Database', 'bonus-hunt-guesser'), $cap, 'bhg-database', array($this, 'render_database'));
-        add_submenu_page($slug, __('Tools', 'bonus-hunt-guesser'), __('Tools', 'bonus-hunt-guesser'), $cap, 'bhg-tools', array($this, 'render_tools'));
-    }
+			add_submenu_page( $slug, __( 'Dashboard', 'bonus-hunt-guesser' ), __( 'Dashboard', 'bonus-hunt-guesser' ), $cap, $slug, array( $this, 'render_dashboard' ) );
+			add_submenu_page( $slug, __( 'Bonus Hunts', 'bonus-hunt-guesser' ), __( 'Bonus Hunts', 'bonus-hunt-guesser' ), $cap, 'bhg-bonus-hunts', array( $this, 'render_bonus_hunts' ) );
+			add_submenu_page( $slug, __( 'Users', 'bonus-hunt-guesser' ), __( 'Users', 'bonus-hunt-guesser' ), $cap, 'bhg-users', array( $this, 'render_users' ) );
+			add_submenu_page( $slug, __( 'Affiliate Websites', 'bonus-hunt-guesser' ), __( 'Affiliate Websites', 'bonus-hunt-guesser' ), $cap, 'bhg-affiliate-websites', array( $this, 'render_affiliates' ) );
+			add_submenu_page( $slug, __( 'Tournaments', 'bonus-hunt-guesser' ), __( 'Tournaments', 'bonus-hunt-guesser' ), $cap, 'bhg-tournaments', array( $this, 'render_tournaments' ) );
+			add_submenu_page( $slug, __( 'Translations', 'bonus-hunt-guesser' ), __( 'Translations', 'bonus-hunt-guesser' ), $cap, 'bhg-translations', array( $this, 'render_translations' ) );
+			add_submenu_page( $slug, __( 'Settings', 'bonus-hunt-guesser' ), __( 'Settings', 'bonus-hunt-guesser' ), $cap, 'bhg-settings', array( $this, 'render_settings' ) );
+			add_submenu_page( $slug, __( 'Database', 'bonus-hunt-guesser' ), __( 'Database', 'bonus-hunt-guesser' ), $cap, 'bhg-database', array( $this, 'render_database' ) );
+			add_submenu_page( $slug, __( 'Tools', 'bonus-hunt-guesser' ), __( 'Tools', 'bonus-hunt-guesser' ), $cap, 'bhg-tools', array( $this, 'render_tools' ) );
+		}
 
-    private function admin_capability() {
-        return apply_filters('bhg_admin_capability', 'manage_options');
-    }
+		private function admin_capability() {
+			return apply_filters( 'bhg_admin_capability', 'manage_options' );
+		}
 
-    public function view($view, $vars = array()) {
-        if (!current_user_can($this->admin_capability())) {
-            wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
-        }
-        if (is_array($vars)) { extract($vars); }
+		public function view( $view, $vars = array() ) {
+			if ( ! current_user_can( $this->admin_capability() ) ) {
+				wp_die( __( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
+			}
+			if ( is_array( $vars ) ) {
+				extract( $vars ); }
 
-        $header_path = BHG_PLUGIN_DIR . 'admin/views/header.php';
-        if (file_exists($header_path)) {
-            include $header_path;
-        }
+			$header_path = BHG_PLUGIN_DIR . 'admin/views/header.php';
+			if ( file_exists( $header_path ) ) {
+				include $header_path;
+			}
 
-        $view_path = BHG_PLUGIN_DIR . 'admin/views/' . $view . '.php';
-        if (file_exists($view_path)) {
-            include $view_path;
-        } else {
-            echo '<div class="wrap"><h2>' . esc_html__('View Not Found', 'bonus-hunt-guesser') . '</h2>';
-            echo '<p>' . sprintf(esc_html__('The requested view "%s" was not found.', 'bonus-hunt-guesser'), esc_html($view)) . '</p></div>';
-        }
-    }
+			$view_path = BHG_PLUGIN_DIR . 'admin/views/' . $view . '.php';
+			if ( file_exists( $view_path ) ) {
+				include $view_path;
+			} else {
+				echo '<div class="wrap"><h2>' . esc_html__( 'View Not Found', 'bonus-hunt-guesser' ) . '</h2>';
+				echo '<p>' . sprintf( esc_html__( 'The requested view "%s" was not found.', 'bonus-hunt-guesser' ), esc_html( $view ) ) . '</p></div>';
+			}
+		}
 
-    public function render_dashboard()      { $this->view('dashboard'); }
-    public function render_bonus_hunts()    { $this->view('bonus-hunts'); }
-    public function render_users()          { $this->view('users'); }
-    public function render_affiliates()     { $this->view('affiliate-websites'); }
-    public function render_tournaments()    { $this->view('tournaments'); }
-    public function render_translations()   { $this->view('translations'); }
-    public function render_settings()       { $this->view('settings'); }
-    public function render_database()       { $this->view('database'); }
-    public function render_tools()          { $this->view('tools'); }
+		public function render_dashboard() {
+			$this->view( 'dashboard' ); }
+		public function render_bonus_hunts() {
+			$this->view( 'bonus-hunts' ); }
+		public function render_users() {
+			$this->view( 'users' ); }
+		public function render_affiliates() {
+			$this->view( 'affiliate-websites' ); }
+		public function render_tournaments() {
+			$this->view( 'tournaments' ); }
+		public function render_translations() {
+			$this->view( 'translations' ); }
+		public function render_settings() {
+			$this->view( 'settings' ); }
+		public function render_database() {
+			$this->view( 'database' ); }
+		public function render_tools() {
+			$this->view( 'tools' ); }
 
-    public function register_locations() {
-        static $done = false;
-        if ($done) return;
-        $done = true;
-        register_nav_menus(array(
-            'bhg_menu_admin'    => __('BHG Menu — Admin/Moderators', 'bonus-hunt-guesser'),
-            'bhg_menu_loggedin' => __('BHG Menu — Logged-in Users', 'bonus-hunt-guesser'),
-            'bhg_menu_guests'   => __('BHG Menu — Guests', 'bonus-hunt-guesser'),
-        ));
-    }
-}}
+		public function register_locations() {
+			static $done = false;
+			if ( $done ) {
+				return;
+			}
+			$done = true;
+			register_nav_menus(
+				array(
+					'bhg_menu_admin'    => __( 'BHG Menu — Admin/Moderators', 'bonus-hunt-guesser' ),
+					'bhg_menu_loggedin' => __( 'BHG Menu — Logged-in Users', 'bonus-hunt-guesser' ),
+					'bhg_menu_guests'   => __( 'BHG Menu — Guests', 'bonus-hunt-guesser' ),
+				)
+			);
+		}
+	}}
 
 // Bootstrap once
-if (class_exists('BHG_Menus')) {
-    BHG_Menus::get_instance()->init();
+if ( class_exists( 'BHG_Menus' ) ) {
+	BHG_Menus::get_instance()->init();
 }

--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -1,6 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
-
 /**
  * Data layer utilities for Bonus Hunt Guesser.
  *
@@ -9,6 +7,16 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
  * `bonus-hunt-guesser.php`. The methods related to form handling and request
  * routing were removed to avoid duplication and ensure a single canonical
  * implementation.
+ *
+ * @package BonusHuntGuesser
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+}
+
+/**
+ * Class providing data layer utilities for Bonus Hunt Guesser.
  */
 class BHG_Models {
 
@@ -34,12 +42,13 @@ class BHG_Models {
 		$guesses_tbl = $wpdb->prefix . 'bhg_guesses';
 
 		// Determine number of winners for this hunt.
-		$winners_count = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT winners_count FROM {$hunts_tbl} WHERE id = %d",
-				$hunt_id
-			)
-		);
+				$winners_count = (int) $wpdb->get_var(
+					$wpdb->prepare(
+                                // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is safe.
+						"SELECT winners_count FROM {$hunts_tbl} WHERE id = %d",
+						$hunt_id
+					)
+				);
 		if ( $winners_count <= 0 ) {
 			$winners_count = 1;
 		}
@@ -60,14 +69,15 @@ class BHG_Models {
 		);
 
 		// Fetch winners based on proximity to final balance.
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT user_id FROM {$guesses_tbl} WHERE hunt_id = %d ORDER BY ABS(guess - %f) ASC, id ASC LIMIT %d",
-				$hunt_id,
-				$final_balance,
-				$winners_count
-			)
-		);
+				$rows = $wpdb->get_results(
+					$wpdb->prepare(
+                                // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is safe.
+						"SELECT user_id FROM {$guesses_tbl} WHERE hunt_id = %d ORDER BY ABS(guess - %f) ASC, id ASC LIMIT %d",
+						$hunt_id,
+						$final_balance,
+						$winners_count
+					)
+				);
 
 		if ( empty( $rows ) ) {
 			return array();

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -5,848 +5,891 @@
  * This file is self-contained and safe on PHP 7.4.
  * It registers the required shortcodes on `init` and avoids "public function outside class" parse errors.
  */
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
-if (!class_exists('BHG_Shortcodes')) {
+if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 
-class BHG_Shortcodes {
+	class BHG_Shortcodes {
 
-	/**
-	 * Register plugin shortcodes.
-	 */
-	public function __construct() {
-		// Register shortcodes once.
-		add_shortcode( 'bhg_active_hunt', array( $this, 'active_hunt_shortcode' ) );
-		add_shortcode( 'bhg_guess_form', array( $this, 'guess_form_shortcode' ) );
-		add_shortcode( 'bhg_leaderboard', array( $this, 'leaderboard_shortcode' ) );
-		add_shortcode( 'bhg_tournaments', array( $this, 'tournaments_shortcode' ) );
+		/**
+		 * Register plugin shortcodes.
+		 */
+		public function __construct() {
+			// Register shortcodes once.
+			add_shortcode( 'bhg_active_hunt', array( $this, 'active_hunt_shortcode' ) );
+			add_shortcode( 'bhg_guess_form', array( $this, 'guess_form_shortcode' ) );
+			add_shortcode( 'bhg_leaderboard', array( $this, 'leaderboard_shortcode' ) );
+			add_shortcode( 'bhg_tournaments', array( $this, 'tournaments_shortcode' ) );
 				add_shortcode( 'bhg_winner_notifications', array( $this, 'winner_notifications_shortcode' ) );
 				add_shortcode( 'bhg_user_profile', array( $this, 'user_profile_shortcode' ) );
 				add_shortcode( 'bhg_best_guessers', array( $this, 'best_guessers_shortcode' ) );
-			   add_shortcode( 'bhg_user_guesses', array( $this, 'user_guesses_shortcode' ) );
-			   add_shortcode( 'bhg_hunts', array( $this, 'hunts_shortcode' ) );
-			   add_shortcode( 'bhg_leaderboards', array( $this, 'leaderboards_shortcode' ) );
+				add_shortcode( 'bhg_user_guesses', array( $this, 'user_guesses_shortcode' ) );
+				add_shortcode( 'bhg_hunts', array( $this, 'hunts_shortcode' ) );
+				add_shortcode( 'bhg_leaderboards', array( $this, 'leaderboards_shortcode' ) );
 
 				// Legacy/alias tags if your site used alternatives.
 				add_shortcode( 'bonus_hunt_leaderboard', array( $this, 'leaderboard_shortcode' ) );
 				add_shortcode( 'bonus_hunt_login', array( $this, 'login_hint_shortcode' ) );
 				add_shortcode( 'bhg_active', array( $this, 'active_hunt_shortcode' ) );
-	}
-
-	/** Minimal login hint used by some themes */
-	public function login_hint_shortcode($atts = array()) {
-		if ( is_user_logged_in() ) {
-			return '';
 		}
 
-                $base     = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
-                $redirect = esc_url_raw( add_query_arg( array(), $base ) );
+		/** Minimal login hint used by some themes */
+		public function login_hint_shortcode( $atts = array() ) {
+			if ( is_user_logged_in() ) {
+				return '';
+			}
 
-		return '<p>' . esc_html__( 'Please log in to continue.', 'bonus-hunt-guesser' ) . '</p>'
-			 . '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
-	}
+				$base     = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
+				$redirect = esc_url_raw( add_query_arg( array(), $base ) );
 
-	/** [bhg_active_hunt] — list all open hunts */
-        public function active_hunt_shortcode($atts) {
-                global $wpdb;
-                $hunts = $wpdb->get_results(
-                        $wpdb->prepare(
-                                "SELECT * FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status = %s ORDER BY created_at DESC",
-                                'open'
-                        )
-                );
-                if (!$hunts) {
-                        return '<div class="bhg-active-hunt"><p>' . esc_html__('No active bonus hunts at the moment.', 'bonus-hunt-guesser') . '</p></div>';
-                }
+			return '<p>' . esc_html__( 'Please log in to continue.', 'bonus-hunt-guesser' ) . '</p>'
+			. '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
+		}
 
-               wp_enqueue_style(
-                       'bhg-shortcodes',
-                       BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-                       array(),
-                       defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-               );
+		/** [bhg_active_hunt] — list all open hunts */
+		public function active_hunt_shortcode( $atts ) {
+				global $wpdb;
+				$hunts = $wpdb->get_results(
+					$wpdb->prepare(
+						"SELECT * FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status = %s ORDER BY created_at DESC",
+						'open'
+					)
+				);
+			if ( ! $hunts ) {
+					return '<div class="bhg-active-hunt"><p>' . esc_html__( 'No active bonus hunts at the moment.', 'bonus-hunt-guesser' ) . '</p></div>';
+			}
 
-               ob_start();
-               echo '<div class="bhg-active-hunts">';
-               foreach ($hunts as $hunt) {
-                       echo '<div class="bhg-hunt-card">';
-                       echo '<h3>' . esc_html($hunt->title) . '</h3>';
-                       echo '<ul class="bhg-hunt-meta">';
-                       echo '<li><strong>' . esc_html__('Starting Balance', 'bonus-hunt-guesser') . ':</strong> ' . esc_html(number_format_i18n((float)$hunt->starting_balance, 2)) . '</li>';
-                       echo '<li><strong>' . esc_html__('Number of Bonuses', 'bonus-hunt-guesser') . ':</strong> ' . (int)$hunt->num_bonuses . '</li>';
-                       if (!empty($hunt->prizes)) {
-                               echo '<li><strong>' . esc_html__('Prizes', 'bonus-hunt-guesser') . ':</strong> ' . wp_kses_post($hunt->prizes) . '</li>';
-                       }
-			echo '</ul>';
+				wp_enqueue_style(
+					'bhg-shortcodes',
+					BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+					array(),
+					defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+				);
+
+				ob_start();
+				echo '<div class="bhg-active-hunts">';
+			foreach ( $hunts as $hunt ) {
+					echo '<div class="bhg-hunt-card">';
+					echo '<h3>' . esc_html( $hunt->title ) . '</h3>';
+					echo '<ul class="bhg-hunt-meta">';
+					echo '<li><strong>' . esc_html__( 'Starting Balance', 'bonus-hunt-guesser' ) . ':</strong> ' . esc_html( number_format_i18n( (float) $hunt->starting_balance, 2 ) ) . '</li>';
+					echo '<li><strong>' . esc_html__( 'Number of Bonuses', 'bonus-hunt-guesser' ) . ':</strong> ' . (int) $hunt->num_bonuses . '</li>';
+				if ( ! empty( $hunt->prizes ) ) {
+						echo '<li><strong>' . esc_html__( 'Prizes', 'bonus-hunt-guesser' ) . ':</strong> ' . wp_kses_post( $hunt->prizes ) . '</li>';
+				}
+					echo '</ul>';
+					echo '</div>';
+			}
 			echo '</div>';
-		}
-		echo '</div>';
-		return ob_get_clean();
-	}
-
-	/** [bhg_guess_form hunt_id=""] */
-	public function guess_form_shortcode($atts) {
-		$atts = shortcode_atts(array('hunt_id' => 0), $atts, 'bhg_guess_form');
-		$hunt_id = (int) $atts['hunt_id'];
-
-		if ( ! is_user_logged_in() ) {
-                        $base     = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
-                        $redirect = esc_url_raw( add_query_arg( array(), $base ) );
-
-			return '<p>' . esc_html__( 'Please log in to submit your guess.', 'bonus-hunt-guesser' ) . '</p>'
-				 . '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
+			return ob_get_clean();
 		}
 
-		global $wpdb;
-		$open_hunts = $wpdb->get_results( "SELECT id, title FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status='open' ORDER BY created_at DESC" );
+		/** [bhg_guess_form hunt_id=""] */
+		public function guess_form_shortcode( $atts ) {
+			$atts    = shortcode_atts( array( 'hunt_id' => 0 ), $atts, 'bhg_guess_form' );
+			$hunt_id = (int) $atts['hunt_id'];
 
-		if ($hunt_id <= 0) {
-			if (!$open_hunts) {
-				return '<p>' . esc_html__('No open hunt found to guess.', 'bonus-hunt-guesser') . '</p>';
+			if ( ! is_user_logged_in() ) {
+						$base     = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
+						$redirect = esc_url_raw( add_query_arg( array(), $base ) );
+
+				return '<p>' . esc_html__( 'Please log in to submit your guess.', 'bonus-hunt-guesser' ) . '</p>'
+				. '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
 			}
-			if (count($open_hunts) === 1) {
-				$hunt_id = (int)$open_hunts[0]->id;
+
+			global $wpdb;
+			$open_hunts = $wpdb->get_results( "SELECT id, title FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status='open' ORDER BY created_at DESC" );
+
+			if ( $hunt_id <= 0 ) {
+				if ( ! $open_hunts ) {
+					return '<p>' . esc_html__( 'No open hunt found to guess.', 'bonus-hunt-guesser' ) . '</p>';
+				}
+				if ( count( $open_hunts ) === 1 ) {
+					$hunt_id = (int) $open_hunts[0]->id;
+				}
 			}
-		}
 
-		$user_id = get_current_user_id();
-		$table = $wpdb->prefix . 'bhg_guesses';
-		$existing_id = $hunt_id > 0 ? (int)$wpdb->get_var($wpdb->prepare("SELECT id FROM {$table} WHERE user_id=%d AND hunt_id=%d", $user_id, $hunt_id)) : 0;
-		$existing_guess = $existing_id ? (float) $wpdb->get_var($wpdb->prepare("SELECT guess FROM {$table} WHERE id=%d", $existing_id)) : '';
+			$user_id        = get_current_user_id();
+			$table          = $wpdb->prefix . 'bhg_guesses';
+			$existing_id    = $hunt_id > 0 ? (int) $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$table} WHERE user_id=%d AND hunt_id=%d", $user_id, $hunt_id ) ) : 0;
+			$existing_guess = $existing_id ? (float) $wpdb->get_var( $wpdb->prepare( "SELECT guess FROM {$table} WHERE id=%d", $existing_id ) ) : '';
 
-               $settings = get_option('bhg_plugin_settings');
-               $min = isset($settings['min_guess_amount']) ? (float)$settings['min_guess_amount'] : 0;
-               $max = isset($settings['max_guess_amount']) ? (float)$settings['max_guess_amount'] : 100000;
+				$settings = get_option( 'bhg_plugin_settings' );
+				$min      = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
+				$max      = isset( $settings['max_guess_amount'] ) ? (float) $settings['max_guess_amount'] : 100000;
 
-               wp_enqueue_style(
-                       'bhg-shortcodes',
-                       BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-                       array(),
-                       defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-               );
+				wp_enqueue_style(
+					'bhg-shortcodes',
+					BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+					array(),
+					defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+				);
 
-               ob_start(); ?>
-               <form class="bhg-guess-form" method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+				ob_start(); ?>
+				<form class="bhg-guess-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 			<input type="hidden" name="action" value="bhg_submit_guess">
-			<?php wp_nonce_field('bhg_submit_guess', 'bhg_nonce'); ?>
+				<?php wp_nonce_field( 'bhg_submit_guess', 'bhg_nonce' ); ?>
 
-			<?php if ($open_hunts && count($open_hunts) > 1) : ?>
-				<label for="bhg-hunt-select"><?php esc_html_e('Choose a hunt:', 'bonus-hunt-guesser'); ?></label>
+				<?php if ( $open_hunts && count( $open_hunts ) > 1 ) : ?>
+				<label for="bhg-hunt-select"><?php esc_html_e( 'Choose a hunt:', 'bonus-hunt-guesser' ); ?></label>
 				<select id="bhg-hunt-select" name="hunt_id" required>
-					<option value=""><?php esc_html_e('Select a hunt', 'bonus-hunt-guesser'); ?></option>
-					<?php foreach ($open_hunts as $oh) : ?>
-						<option value="<?php echo (int)$oh->id; ?>" <?php if ($hunt_id === (int)$oh->id) echo 'selected'; ?>>
-							<?php echo esc_html($oh->title); ?>
+					<option value=""><?php esc_html_e( 'Select a hunt', 'bonus-hunt-guesser' ); ?></option>
+					<?php foreach ( $open_hunts as $oh ) : ?>
+						<option value="<?php echo (int) $oh->id; ?>" 
+						<?php
+						if ( $hunt_id === (int) $oh->id ) {
+							echo 'selected';}
+						?>
+							>
+							<?php echo esc_html( $oh->title ); ?>
 						</option>
 					<?php endforeach; ?>
 				</select>
 			<?php else : ?>
-				<input type="hidden" name="hunt_id" value="<?php echo esc_attr($hunt_id); ?>">
+				<input type="hidden" name="hunt_id" value="<?php echo esc_attr( $hunt_id ); ?>">
 			<?php endif; ?>
 
-			<label for="bhg-guess" class="bhg-guess-label"><?php esc_html_e('Your guess (final balance):', 'bonus-hunt-guesser'); ?></label>
-			<input type="number" step="0.01" min="<?php echo esc_attr($min); ?>" max="<?php echo esc_attr($max); ?>"
-				   id="bhg-guess" name="guess" value="<?php echo esc_attr($existing_guess); ?>" required>
+			<label for="bhg-guess" class="bhg-guess-label"><?php esc_html_e( 'Your guess (final balance):', 'bonus-hunt-guesser' ); ?></label>
+			<input type="number" step="0.01" min="<?php echo esc_attr( $min ); ?>" max="<?php echo esc_attr( $max ); ?>"
+					id="bhg-guess" name="guess" value="<?php echo esc_attr( $existing_guess ); ?>" required>
 			<div class="bhg-error-message"></div>
 			<button type="submit" class="bhg-submit-btn button button-primary">
-				<?php echo esc_html__('Submit Guess', 'bonus-hunt-guesser'); ?></button>
+					<?php echo esc_html__( 'Submit Guess', 'bonus-hunt-guesser' ); ?></button>
 		</form>
-		<?php
-		return ob_get_clean();
-	}
+			<?php
+			return ob_get_clean();
+		}
 
-	/** [bhg_leaderboard] */
-	public function leaderboard_shortcode($atts) {
-		$a = shortcode_atts(array(
-			'hunt_id' => 0,
-			'orderby' => 'guess',
-			'order'   => 'ASC',
-			'page'    => 1,
-			'per_page'=> 20,
-		), $atts, 'bhg_leaderboard');
+		/** [bhg_leaderboard] */
+		public function leaderboard_shortcode( $atts ) {
+			$a = shortcode_atts(
+				array(
+					'hunt_id'  => 0,
+					'orderby'  => 'guess',
+					'order'    => 'ASC',
+					'page'     => 1,
+					'per_page' => 20,
+				),
+				$atts,
+				'bhg_leaderboard'
+			);
 
-		global $wpdb;
-		$hunt_id = (int)$a['hunt_id'];
-		if ($hunt_id <= 0) {
-			$hunt_id = (int)$wpdb->get_var( "SELECT id FROM {$wpdb->prefix}bhg_bonus_hunts ORDER BY created_at DESC LIMIT 1" );
-			if ($hunt_id <= 0) {
-				return '<p>' . esc_html__('No hunts found.', 'bonus-hunt-guesser') . '</p>';
+			global $wpdb;
+			$hunt_id = (int) $a['hunt_id'];
+			if ( $hunt_id <= 0 ) {
+				$hunt_id = (int) $wpdb->get_var( "SELECT id FROM {$wpdb->prefix}bhg_bonus_hunts ORDER BY created_at DESC LIMIT 1" );
+				if ( $hunt_id <= 0 ) {
+					return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
+				}
 			}
-		}
 
-		$g = $wpdb->prefix . 'bhg_guesses';
-		$u = $wpdb->users;
+			$g = $wpdb->prefix . 'bhg_guesses';
+			$u = $wpdb->users;
 
-		$order = strtoupper($a['order']) === 'DESC' ? 'DESC' : 'ASC';
-		$map = array(
-			'guess'      => 'g.guess',
-			'user'       => 'u.user_login',
-			'position'   => 'g.id', // stable proxy
-		);
-		$orderby_key = array_key_exists($a['orderby'], $map) ? $a['orderby'] : 'guess';
-		$orderby = $map[$orderby_key];
-		$page    = max(1, (int)$a['page']);
-		$per     = max(1, (int)$a['per_page']);
-		$offset  = ($page - 1) * $per;
+			$order       = strtoupper( $a['order'] ) === 'DESC' ? 'DESC' : 'ASC';
+			$map         = array(
+				'guess'    => 'g.guess',
+				'user'     => 'u.user_login',
+				'position' => 'g.id', // stable proxy
+			);
+			$orderby_key = array_key_exists( $a['orderby'], $map ) ? $a['orderby'] : 'guess';
+			$orderby     = $map[ $orderby_key ];
+			$page        = max( 1, (int) $a['page'] );
+			$per         = max( 1, (int) $a['per_page'] );
+			$offset      = ( $page - 1 ) * $per;
 
-		$total = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$g} WHERE hunt_id=%d", $hunt_id));
-		if ($total < 1) {
-			return '<p>' . esc_html__('No guesses yet.', 'bonus-hunt-guesser') . '</p>';
-		}
+			$total = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$g} WHERE hunt_id=%d", $hunt_id ) );
+			if ( $total < 1 ) {
+				return '<p>' . esc_html__( 'No guesses yet.', 'bonus-hunt-guesser' ) . '</p>';
+			}
 
-		$rows = $wpdb->get_results($wpdb->prepare(
-			"SELECT g.*, u.user_login, h.affiliate_site_id
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT g.*, u.user_login, h.affiliate_site_id
 			 FROM {$g} g
 			 LEFT JOIN {$u} u ON u.ID = g.user_id
 			 LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id
 			 WHERE g.hunt_id=%d
 			 ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d",
-			$hunt_id, $per, $offset
-		));
+					$hunt_id,
+					$per,
+					$offset
+				)
+			);
 
-		wp_enqueue_style(
-			'bhg-shortcodes',
-			BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-			array(),
-			defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-		);
+			wp_enqueue_style(
+				'bhg-shortcodes',
+				BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+				array(),
+				defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+			);
 
-		ob_start();
-		echo '<table class="bhg-leaderboard">';
-		echo '<thead><tr>';
-		echo '<th class="sortable" data-column="position">' . esc_html__('Position', 'bonus-hunt-guesser') . '</th>';
-		echo '<th class="sortable" data-column="user">' . esc_html__('User', 'bonus-hunt-guesser') . '</th>';
-		echo '<th class="sortable" data-column="guess">' . esc_html__('Guess', 'bonus-hunt-guesser') . '</th>';
-		echo '</tr></thead><tbody>';
+			ob_start();
+			echo '<table class="bhg-leaderboard">';
+			echo '<thead><tr>';
+			echo '<th class="sortable" data-column="position">' . esc_html__( 'Position', 'bonus-hunt-guesser' ) . '</th>';
+			echo '<th class="sortable" data-column="user">' . esc_html__( 'User', 'bonus-hunt-guesser' ) . '</th>';
+			echo '<th class="sortable" data-column="guess">' . esc_html__( 'Guess', 'bonus-hunt-guesser' ) . '</th>';
+			echo '</tr></thead><tbody>';
 
-		$pos = $offset + 1;
-		foreach ($rows as $r) {
-			$site_id = isset($r->affiliate_site_id) ? (int)$r->affiliate_site_id : 0;
-			$is_aff  = $site_id > 0
-				? (int)get_user_meta((int)$r->user_id, 'bhg_affiliate_website_' . $site_id, true)
-				: (int)get_user_meta((int)$r->user_id, 'bhg_is_affiliate', true);
-			$aff = $is_aff ? 'green' : 'red';
-                       /* translators: %d: user ID. */
-                       $user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
+			$pos = $offset + 1;
+			foreach ( $rows as $r ) {
+				$site_id = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
+				$is_aff  = $site_id > 0
+				? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
+				: (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
+				$aff     = $is_aff ? 'green' : 'red';
+						/* translators: %d: user ID. */
+						$user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
 
-			echo '<tr>';
-			echo '<td data-column="position">' . (int)$pos++ . '</td>';
-			echo '<td data-column="user">' . esc_html($user_label) . ' <span class="bhg-aff-dot bhg-aff-' . esc_attr($aff) . '" aria-hidden="true"></span></td>';
-			echo '<td data-column="guess">' . esc_html(number_format_i18n((float) $r->guess, 2)) . '</td>';
-			echo '</tr>';
-		}
-		echo '</tbody></table>';
-
-		$pages = (int) ceil( $total / $per );
-		if ( $pages > 1 ) {
-                        $base = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
-                        $base = esc_url_raw( remove_query_arg( 'page', $base ) );
-			echo '<div class="bhg-pagination">';
-			for ( $p = 1; $p <= $pages; $p++ ) {
-$class = $p == $page ? ' class="bhg-current-page"' : '';
-echo '<a' . $class . ' href="' . esc_url( add_query_arg( array( 'page' => $p ), $base ) ) . '">' . (int) $p . '</a> ';
+				echo '<tr>';
+				echo '<td data-column="position">' . (int) $pos++ . '</td>';
+				echo '<td data-column="user">' . esc_html( $user_label ) . ' <span class="bhg-aff-dot bhg-aff-' . esc_attr( $aff ) . '" aria-hidden="true"></span></td>';
+				echo '<td data-column="guess">' . esc_html( number_format_i18n( (float) $r->guess, 2 ) ) . '</td>';
+				echo '</tr>';
 			}
-			echo '</div>';
+			echo '</tbody></table>';
+
+			$pages = (int) ceil( $total / $per );
+			if ( $pages > 1 ) {
+						$base = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
+						$base = esc_url_raw( remove_query_arg( 'page', $base ) );
+				echo '<div class="bhg-pagination">';
+				for ( $p = 1; $p <= $pages; $p++ ) {
+					$class = $p == $page ? ' class="bhg-current-page"' : '';
+					echo '<a' . $class . ' href="' . esc_url( add_query_arg( array( 'page' => $p ), $base ) ) . '">' . (int) $p . '</a> ';
+				}
+				echo '</div>';
+			}
+
+				return ob_get_clean();
 		}
 
-			   return ob_get_clean();
-	   }
+			/**
+			 * Display guesses submitted by a user.
+			 *
+			 * @param array $atts Shortcode attributes.
+			 * @return string HTML output.
+			 */
+		public function user_guesses_shortcode( $atts ) {
+			$a = shortcode_atts(
+				array(
+					'id'       => 0,
+					'aff'      => 'yes',
+					'website'  => 0,
+					'status'   => '',
+					'timeline' => '',
+					'orderby'  => 'hunt',
+					'order'    => 'DESC',
+				),
+				$atts,
+				'bhg_user_guesses'
+			);
 
-	   /**
-		* Display guesses submitted by a user.
-		*
-		* @param array $atts Shortcode attributes.
-		* @return string HTML output.
-		*/
-	   public function user_guesses_shortcode( $atts ) {
-			   $a = shortcode_atts(
-					   array(
-							   'id'       => 0,
-							   'aff'      => 'yes',
-							   'website'  => 0,
-							   'status'   => '',
-							   'timeline' => '',
-							   'orderby'  => 'hunt',
-							   'order'    => 'DESC',
-					   ),
-					   $atts,
-					   'bhg_user_guesses'
-			   );
+			global $wpdb;
 
-			   global $wpdb;
+			$user_id = (int) $a['id'];
+			if ( $user_id <= 0 ) {
+					$user_id = get_current_user_id();
+			}
+			if ( $user_id <= 0 ) {
+					return '<p>' . esc_html__( 'No user specified.', 'bonus-hunt-guesser' ) . '</p>';
+			}
 
-			   $user_id = (int) $a['id'];
-			   if ( $user_id <= 0 ) {
-					   $user_id = get_current_user_id();
-			   }
-			   if ( $user_id <= 0 ) {
-					   return '<p>' . esc_html__( 'No user specified.', 'bonus-hunt-guesser' ) . '</p>';
-			   }
+			$g = $wpdb->prefix . 'bhg_guesses';
+			$h = $wpdb->prefix . 'bhg_bonus_hunts';
 
-			   $g = $wpdb->prefix . 'bhg_guesses';
-			   $h = $wpdb->prefix . 'bhg_bonus_hunts';
+			$where  = array( 'g.user_id = %d' );
+			$params = array( $user_id );
 
-			   $where  = array( 'g.user_id = %d' );
-			   $params = array( $user_id );
+			if ( in_array( $a['status'], array( 'open', 'closed' ), true ) ) {
+					$where[]  = 'h.status = %s';
+					$params[] = $a['status'];
+			}
 
-			   if ( in_array( $a['status'], array( 'open', 'closed' ), true ) ) {
-					   $where[]  = 'h.status = %s';
-					   $params[] = $a['status'];
-			   }
+			$website = (int) $a['website'];
+			if ( $website > 0 ) {
+					$where[]  = 'h.affiliate_site_id = %d';
+					$params[] = $website;
+			}
 
-			   $website = (int) $a['website'];
-			   if ( $website > 0 ) {
-					   $where[]  = 'h.affiliate_site_id = %d';
-					   $params[] = $website;
-			   }
+			$order       = strtoupper( $a['order'] ) === 'ASC' ? 'ASC' : 'DESC';
+			$orderby_map = array(
+				'guess' => 'g.guess',
+				'hunt'  => 'h.created_at',
+			);
+			$orderby_key = isset( $orderby_map[ $a['orderby'] ] ) ? $a['orderby'] : 'hunt';
+			$orderby     = $orderby_map[ $orderby_key ];
 
-			   $order = strtoupper( $a['order'] ) === 'ASC' ? 'ASC' : 'DESC';
-			   $orderby_map = array(
-					   'guess' => 'g.guess',
-					   'hunt'  => 'h.created_at',
-			   );
-			   $orderby_key = isset( $orderby_map[ $a['orderby'] ] ) ? $a['orderby'] : 'hunt';
-			   $orderby     = $orderby_map[ $orderby_key ];
+			$limit_sql = '';
+			if ( 'recent' === strtolower( $a['timeline'] ) ) {
+					$limit_sql = ' LIMIT 10';
+			}
 
-			   $limit_sql = '';
-			   if ( 'recent' === strtolower( $a['timeline'] ) ) {
-					   $limit_sql = ' LIMIT 10';
-			   }
-
-			   $sql = "SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id
+			$sql = "SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id
 					   FROM {$g} g INNER JOIN {$h} h ON h.id = g.hunt_id
 					   WHERE " . implode( ' AND ', $where ) . "
 					   ORDER BY {$orderby} {$order}{$limit_sql}";
 
-			   $rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ) );
-			   if ( ! $rows ) {
-					   return '<p>' . esc_html__( 'No guesses found.', 'bonus-hunt-guesser' ) . '</p>';
-			   }
-
-			   $show_aff = filter_var( $a['aff'], FILTER_VALIDATE_BOOLEAN );
-
-			   ob_start();
-			   echo '<table class="bhg-user-guesses"><thead><tr>';
-			   echo '<th>' . esc_html__( 'Hunt', 'bonus-hunt-guesser' ) . '</th>';
-			   echo '<th>' . esc_html__( 'Guess', 'bonus-hunt-guesser' ) . '</th>';
-			   echo '<th>' . esc_html__( 'Final', 'bonus-hunt-guesser' ) . '</th>';
-			   echo '</tr></thead><tbody>';
-
-			   foreach ( $rows as $row ) {
-					   echo '<tr>';
-					   echo '<td>' . esc_html( $row->title ) . '</td>';
-					   $guess_cell = esc_html( number_format_i18n( (float) $row->guess, 2 ) );
-					   if ( $show_aff ) {
-							   $guess_cell = bhg_render_affiliate_dot( $user_id, (int) $row->affiliate_site_id ) . $guess_cell;
-					   }
-					   echo '<td>' . $guess_cell . '</td>';
-					   echo '<td>';
-                                           echo isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html__( '&mdash;', 'bonus-hunt-guesser' );
-					   echo '</td>';
-					   echo '</tr>';
-			   }
-			   echo '</tbody></table>';
-			   return ob_get_clean();
-	   }
-
-	   /**
-		* Display a list of bonus hunts.
-		*
-		* @param array $atts Shortcode attributes.
-		* @return string HTML output.
-		*/
-	   public function hunts_shortcode( $atts ) {
-			   $a = shortcode_atts(
-					   array(
-							   'id'       => 0,
-							   'aff'      => 'no',
-							   'website'  => 0,
-							   'status'   => '',
-							   'timeline' => '',
-					   ),
-					   $atts,
-					   'bhg_hunts'
-			   );
-
-			   global $wpdb;
-			   $h = $wpdb->prefix . 'bhg_bonus_hunts';
-			   $aff_table = $wpdb->prefix . 'bhg_affiliates';
-
-			   $where  = array();
-			   $params = array();
-
-			   $id = (int) $a['id'];
-			   if ( $id > 0 ) {
-					   $where[]  = 'h.id = %d';
-					   $params[] = $id;
-			   }
-
-			   if ( in_array( $a['status'], array( 'open', 'closed' ), true ) ) {
-					   $where[]  = 'h.status = %s';
-					   $params[] = $a['status'];
-			   }
-
-			   $website = (int) $a['website'];
-			   if ( $website > 0 ) {
-					   $where[]  = 'h.affiliate_site_id = %d';
-					   $params[] = $website;
-			   }
-
-			   $sql = "SELECT h.id, h.title, h.starting_balance, h.final_balance, h.status, h.created_at, h.closed_at, a.name AS aff_name
-					   FROM {$h} h
-					   LEFT JOIN {$aff_table} a ON a.id = h.affiliate_site_id";
-			   if ( $where ) {
-					   $sql .= ' WHERE ' . implode( ' AND ', $where );
-			   }
-			   $sql .= ' ORDER BY h.created_at DESC';
-
-			   if ( 'recent' === strtolower( $a['timeline'] ) ) {
-					   $sql .= ' LIMIT 10';
-			   }
-
-			   $rows = $params ? $wpdb->get_results( $wpdb->prepare( $sql, $params ) ) : $wpdb->get_results( $sql );
-			   if ( ! $rows ) {
-					   return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
-			   }
-
-			   $show_aff = filter_var( $a['aff'], FILTER_VALIDATE_BOOLEAN );
-
-			   ob_start();
-			   echo '<table class="bhg-hunts"><thead><tr>';
-			   echo '<th>' . esc_html__( 'Title', 'bonus-hunt-guesser' ) . '</th>';
-			   echo '<th>' . esc_html__( 'Start Balance', 'bonus-hunt-guesser' ) . '</th>';
-			   echo '<th>' . esc_html__( 'Final Balance', 'bonus-hunt-guesser' ) . '</th>';
-			   echo '<th>' . esc_html__( 'Status', 'bonus-hunt-guesser' ) . '</th>';
-			   if ( $show_aff ) {
-					   echo '<th>' . esc_html__( 'Affiliate', 'bonus-hunt-guesser' ) . '</th>';
-			   }
-			   echo '</tr></thead><tbody>';
-
-			   foreach ( $rows as $row ) {
-					   echo '<tr>';
-					   echo '<td>' . esc_html( $row->title ) . '</td>';
-					   echo '<td>' . esc_html( number_format_i18n( (float) $row->starting_balance, 2 ) ) . '</td>';
-					   echo '<td>';
-                                           echo isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html__( '&mdash;', 'bonus-hunt-guesser' );
-                                           echo '</td>';
-                                           echo '<td>' . esc_html( $row->status ) . '</td>';
-                                           if ( $show_aff ) {
-                                                           echo '<td>' . ( $row->aff_name ? esc_html( $row->aff_name ) : esc_html__( '—', 'bonus-hunt-guesser' ) ) . '</td>';
-                                           }
-					   echo '</tr>';
-			   }
-			   echo '</tbody></table>';
-			   return ob_get_clean();
-	   }
-
-	   /**
-		* Display leaderboards for multiple hunts.
-		*
-		* @param array $atts Shortcode attributes.
-		* @return string HTML output.
-		*/
-	   public function leaderboards_shortcode( $atts ) {
-			   $a = shortcode_atts(
-					   array(
-							   'id'       => 0,
-							   'aff'      => 'yes',
-							   'website'  => 0,
-							   'status'   => '',
-							   'timeline' => '',
-					   ),
-					   $atts,
-					   'bhg_leaderboards'
-			   );
-
-			   global $wpdb;
-			   $h = $wpdb->prefix . 'bhg_bonus_hunts';
-
-			   $where  = array();
-			   $params = array();
-
-			   $id = (int) $a['id'];
-			   if ( $id > 0 ) {
-					   $where[]  = 'id = %d';
-					   $params[] = $id;
-			   }
-
-			   if ( in_array( $a['status'], array( 'open', 'closed' ), true ) ) {
-					   $where[]  = 'status = %s';
-					   $params[] = $a['status'];
-			   }
-
-			   $website = (int) $a['website'];
-			   if ( $website > 0 ) {
-					   $where[]  = 'affiliate_site_id = %d';
-					   $params[] = $website;
-			   }
-
-			   $sql = "SELECT id, title FROM {$h}";
-			   if ( $where ) {
-					   $sql .= ' WHERE ' . implode( ' AND ', $where );
-			   }
-			   $sql .= ' ORDER BY created_at DESC';
-
-			   if ( 'recent' === strtolower( $a['timeline'] ) ) {
-					   $sql .= ' LIMIT 5';
-			   }
-
-			   $hunts = $params ? $wpdb->get_results( $wpdb->prepare( $sql, $params ) ) : $wpdb->get_results( $sql );
-			   if ( ! $hunts ) {
-					   return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
-			   }
-
-			   $show_aff = filter_var( $a['aff'], FILTER_VALIDATE_BOOLEAN );
-
-			   ob_start();
-			   foreach ( $hunts as $hunt ) {
-					   echo '<div class="bhg-leaderboard-wrap">';
-					   echo '<h3>' . esc_html( $hunt->title ) . '</h3>';
-					   $html = $this->leaderboard_shortcode( array( 'hunt_id' => (int) $hunt->id ) );
-					   if ( ! $show_aff ) {
-							   $html = preg_replace( '/<span class="bhg-aff-dot[^>]*><\/span>/', '', $html );
-					   }
-					   echo $html;
-					   echo '</div>';
-			   }
-			   return ob_get_clean();
-	   }
-
-	   /**
-		* [bhg_tournaments] List tournaments or show details.
-		*
-		* Attributes:
-		* - status    (string) Filter by tournament status (active|closed).
-		* - tournament(int)    Specific tournament ID.
-		* - website   (int)    Affiliate website ID.
-		* - timeline  (string) Tournament type (weekly|monthly|yearly|quarterly|alltime).
-		*
-		* Details view is available via ?bhg_tournament_id=ID.
-		*
-		* @param array $atts Shortcode attributes.
-		* @return string HTML output.
-		*/
-       public function tournaments_shortcode($atts) {
-                          global $wpdb;
-
-               wp_enqueue_style(
-                       'bhg-shortcodes',
-                       BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-                       array(),
-                       defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-               );
-
-		// If a specific tournament ID is requested, render details
-               $details_id = isset( $_GET['bhg_tournament_id'] ) ? absint( wp_unslash( $_GET['bhg_tournament_id'] ) ) : 0;
-		if ($details_id > 0) {
-			$t = $wpdb->prefix . 'bhg_tournaments';
-			$r = $wpdb->prefix . 'bhg_tournament_results';
-			$u = $wpdb->users;
-
-			$tournament = $wpdb->get_row($wpdb->prepare(
-				"SELECT id, type, start_date, end_date, status FROM {$t} WHERE id=%d",
-				$details_id
-			));
-			if (!$tournament) {
-				return '<p>' . esc_html__('Tournament not found.', 'bonus-hunt-guesser') . '</p>';
+			$rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ) );
+			if ( ! $rows ) {
+					return '<p>' . esc_html__( 'No guesses found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
 
-			// Sortable results (whitelisted)
-                       $orderby = isset( $_GET['orderby'] ) ? strtolower( sanitize_key( wp_unslash( $_GET['orderby'] ) ) ) : 'wins';
-                       $order   = isset( $_GET['order'] )   ? strtolower( sanitize_key( wp_unslash( $_GET['order'] ) ) )   : 'desc';
+			$show_aff = filter_var( $a['aff'], FILTER_VALIDATE_BOOLEAN );
 
-			$allowed = array(
-				'wins'        => 'r.wins',
-				'username'    => 'u.user_login',
-				'last_win_at' => 'r.last_win_date',
+			ob_start();
+			echo '<table class="bhg-user-guesses"><thead><tr>';
+			echo '<th>' . esc_html__( 'Hunt', 'bonus-hunt-guesser' ) . '</th>';
+			echo '<th>' . esc_html__( 'Guess', 'bonus-hunt-guesser' ) . '</th>';
+			echo '<th>' . esc_html__( 'Final', 'bonus-hunt-guesser' ) . '</th>';
+			echo '</tr></thead><tbody>';
+
+			foreach ( $rows as $row ) {
+					echo '<tr>';
+					echo '<td>' . esc_html( $row->title ) . '</td>';
+					$guess_cell = esc_html( number_format_i18n( (float) $row->guess, 2 ) );
+				if ( $show_aff ) {
+						$guess_cell = bhg_render_affiliate_dot( $user_id, (int) $row->affiliate_site_id ) . $guess_cell;
+				}
+					echo '<td>' . $guess_cell . '</td>';
+					echo '<td>';
+										echo isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html__( '&mdash;', 'bonus-hunt-guesser' );
+					echo '</td>';
+					echo '</tr>';
+			}
+			echo '</tbody></table>';
+			return ob_get_clean();
+		}
+
+		/**
+		 * Display a list of bonus hunts.
+		 *
+		 * @param array $atts Shortcode attributes.
+		 * @return string HTML output.
+		 */
+		public function hunts_shortcode( $atts ) {
+			$a = shortcode_atts(
+				array(
+					'id'       => 0,
+					'aff'      => 'no',
+					'website'  => 0,
+					'status'   => '',
+					'timeline' => '',
+				),
+				$atts,
+				'bhg_hunts'
 			);
-			if (!isset($allowed[$orderby])) { $orderby = 'wins'; }
-			if ($order !== 'asc' && $order !== 'desc') { $order = 'desc'; }
-			$order_by_sql = $allowed[$orderby] . ' ' . strtoupper($order);
 
-			$rows = $wpdb->get_results($wpdb->prepare(
-				"SELECT r.user_id, r.wins, r.last_win_date, u.user_login
+			global $wpdb;
+			$h         = $wpdb->prefix . 'bhg_bonus_hunts';
+			$aff_table = $wpdb->prefix . 'bhg_affiliates';
+
+			$where  = array();
+			$params = array();
+
+			$id = (int) $a['id'];
+			if ( $id > 0 ) {
+					$where[]  = 'h.id = %d';
+					$params[] = $id;
+			}
+
+			if ( in_array( $a['status'], array( 'open', 'closed' ), true ) ) {
+						$where[]  = 'h.status = %s';
+						$params[] = $a['status'];
+			}
+
+			$website = (int) $a['website'];
+			if ( $website > 0 ) {
+						$where[]  = 'h.affiliate_site_id = %d';
+						$params[] = $website;
+			}
+
+				$sql = "SELECT h.id, h.title, h.starting_balance, h.final_balance, h.status, h.created_at, h.closed_at, a.name AS aff_name
+					   FROM {$h} h
+					   LEFT JOIN {$aff_table} a ON a.id = h.affiliate_site_id";
+			if ( $where ) {
+					$sql .= ' WHERE ' . implode( ' AND ', $where );
+			}
+				$sql .= ' ORDER BY h.created_at DESC';
+
+			if ( 'recent' === strtolower( $a['timeline'] ) ) {
+					$sql .= ' LIMIT 10';
+			}
+
+				$rows = $params ? $wpdb->get_results( $wpdb->prepare( $sql, $params ) ) : $wpdb->get_results( $sql );
+			if ( ! $rows ) {
+					return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
+			}
+
+				$show_aff = filter_var( $a['aff'], FILTER_VALIDATE_BOOLEAN );
+
+				ob_start();
+				echo '<table class="bhg-hunts"><thead><tr>';
+				echo '<th>' . esc_html__( 'Title', 'bonus-hunt-guesser' ) . '</th>';
+				echo '<th>' . esc_html__( 'Start Balance', 'bonus-hunt-guesser' ) . '</th>';
+				echo '<th>' . esc_html__( 'Final Balance', 'bonus-hunt-guesser' ) . '</th>';
+				echo '<th>' . esc_html__( 'Status', 'bonus-hunt-guesser' ) . '</th>';
+			if ( $show_aff ) {
+					echo '<th>' . esc_html__( 'Affiliate', 'bonus-hunt-guesser' ) . '</th>';
+			}
+				echo '</tr></thead><tbody>';
+
+			foreach ( $rows as $row ) {
+					echo '<tr>';
+					echo '<td>' . esc_html( $row->title ) . '</td>';
+					echo '<td>' . esc_html( number_format_i18n( (float) $row->starting_balance, 2 ) ) . '</td>';
+					echo '<td>';
+										echo isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html__( '&mdash;', 'bonus-hunt-guesser' );
+										echo '</td>';
+										echo '<td>' . esc_html( $row->status ) . '</td>';
+				if ( $show_aff ) {
+								echo '<td>' . ( $row->aff_name ? esc_html( $row->aff_name ) : esc_html__( '—', 'bonus-hunt-guesser' ) ) . '</td>';
+				}
+					echo '</tr>';
+			}
+				echo '</tbody></table>';
+				return ob_get_clean();
+		}
+
+		/**
+		 * Display leaderboards for multiple hunts.
+		 *
+		 * @param array $atts Shortcode attributes.
+		 * @return string HTML output.
+		 */
+		public function leaderboards_shortcode( $atts ) {
+			$a = shortcode_atts(
+				array(
+					'id'       => 0,
+					'aff'      => 'yes',
+					'website'  => 0,
+					'status'   => '',
+					'timeline' => '',
+				),
+				$atts,
+				'bhg_leaderboards'
+			);
+
+			global $wpdb;
+			$h = $wpdb->prefix . 'bhg_bonus_hunts';
+
+			$where  = array();
+			$params = array();
+
+			$id = (int) $a['id'];
+			if ( $id > 0 ) {
+					$where[]  = 'id = %d';
+					$params[] = $id;
+			}
+
+			if ( in_array( $a['status'], array( 'open', 'closed' ), true ) ) {
+						$where[]  = 'status = %s';
+						$params[] = $a['status'];
+			}
+
+			$website = (int) $a['website'];
+			if ( $website > 0 ) {
+						$where[]  = 'affiliate_site_id = %d';
+						$params[] = $website;
+			}
+
+				$sql = "SELECT id, title FROM {$h}";
+			if ( $where ) {
+					$sql .= ' WHERE ' . implode( ' AND ', $where );
+			}
+				$sql .= ' ORDER BY created_at DESC';
+
+			if ( 'recent' === strtolower( $a['timeline'] ) ) {
+					$sql .= ' LIMIT 5';
+			}
+
+				$hunts = $params ? $wpdb->get_results( $wpdb->prepare( $sql, $params ) ) : $wpdb->get_results( $sql );
+			if ( ! $hunts ) {
+					return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
+			}
+
+				$show_aff = filter_var( $a['aff'], FILTER_VALIDATE_BOOLEAN );
+
+				ob_start();
+			foreach ( $hunts as $hunt ) {
+					echo '<div class="bhg-leaderboard-wrap">';
+					echo '<h3>' . esc_html( $hunt->title ) . '</h3>';
+					$html = $this->leaderboard_shortcode( array( 'hunt_id' => (int) $hunt->id ) );
+				if ( ! $show_aff ) {
+						$html = preg_replace( '/<span class="bhg-aff-dot[^>]*><\/span>/', '', $html );
+				}
+					echo $html;
+					echo '</div>';
+			}
+				return ob_get_clean();
+		}
+
+		/**
+		 * [bhg_tournaments] List tournaments or show details.
+		 *
+		 * Attributes:
+		 * - status    (string) Filter by tournament status (active|closed).
+		 * - tournament(int)    Specific tournament ID.
+		 * - website   (int)    Affiliate website ID.
+		 * - timeline  (string) Tournament type (weekly|monthly|yearly|quarterly|alltime).
+		 *
+		 * Details view is available via ?bhg_tournament_id=ID.
+		 *
+		 * @param array $atts Shortcode attributes.
+		 * @return string HTML output.
+		 */
+		public function tournaments_shortcode( $atts ) {
+						global $wpdb;
+
+			wp_enqueue_style(
+				'bhg-shortcodes',
+				BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+				array(),
+				defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+			);
+
+			// If a specific tournament ID is requested, render details
+			$details_id = isset( $_GET['bhg_tournament_id'] ) ? absint( wp_unslash( $_GET['bhg_tournament_id'] ) ) : 0;
+			if ( $details_id > 0 ) {
+				$t = $wpdb->prefix . 'bhg_tournaments';
+				$r = $wpdb->prefix . 'bhg_tournament_results';
+				$u = $wpdb->users;
+
+				$tournament = $wpdb->get_row(
+					$wpdb->prepare(
+						"SELECT id, type, start_date, end_date, status FROM {$t} WHERE id=%d",
+						$details_id
+					)
+				);
+				if ( ! $tournament ) {
+					return '<p>' . esc_html__( 'Tournament not found.', 'bonus-hunt-guesser' ) . '</p>';
+				}
+
+				// Sortable results (whitelisted)
+						$orderby = isset( $_GET['orderby'] ) ? strtolower( sanitize_key( wp_unslash( $_GET['orderby'] ) ) ) : 'wins';
+						$order   = isset( $_GET['order'] ) ? strtolower( sanitize_key( wp_unslash( $_GET['order'] ) ) ) : 'desc';
+
+				$allowed = array(
+					'wins'        => 'r.wins',
+					'username'    => 'u.user_login',
+					'last_win_at' => 'r.last_win_date',
+				);
+				if ( ! isset( $allowed[ $orderby ] ) ) {
+					$orderby = 'wins'; }
+				if ( $order !== 'asc' && $order !== 'desc' ) {
+					$order = 'desc'; }
+				$order_by_sql = $allowed[ $orderby ] . ' ' . strtoupper( $order );
+
+				$rows = $wpdb->get_results(
+					$wpdb->prepare(
+						"SELECT r.user_id, r.wins, r.last_win_date, u.user_login
 				 FROM {$r} r
 				 INNER JOIN {$u} u ON u.ID = r.user_id
 				 WHERE r.tournament_id=%d
 				 ORDER BY {$order_by_sql}, r.user_id ASC",
-				$tournament->id
-			));
+						$tournament->id
+					)
+				);
 
-			$base = remove_query_arg(array('orderby','order'));
-			$toggle = function($key) use ($orderby, $order, $base) {
-				$next = ($orderby === $key && strtolower($order) === 'asc') ? 'desc' : 'asc';
-				return esc_url(add_query_arg(array('orderby'=>$key,'order'=>$next), $base));
-			};
+				$base   = remove_query_arg( array( 'orderby', 'order' ) );
+				$toggle = function ( $key ) use ( $orderby, $order, $base ) {
+					$next = ( $orderby === $key && strtolower( $order ) === 'asc' ) ? 'desc' : 'asc';
+					return esc_url(
+						add_query_arg(
+							array(
+								'orderby' => $key,
+								'order'   => $next,
+							),
+							$base
+						)
+					);
+				};
 
-ob_start();
-echo '<div class="bhg-tournament-details">';
-			echo '<p><a href="' . esc_url(remove_query_arg('bhg_tournament_id')) . '">&larr; ' . esc_html__('Back to tournaments', 'bonus-hunt-guesser') . '</a></p>';
-echo '<h3>' . esc_html(ucfirst($tournament->type)) . '</h3>';
-			echo '<p><strong>' . esc_html__('Start', 'bonus-hunt-guesser') . ':</strong> ' . esc_html(mysql2date(get_option('date_format'), $tournament->start_date)) . ' &nbsp; ';
-			echo '<strong>' . esc_html__('End', 'bonus-hunt-guesser') . ':</strong> ' . esc_html(mysql2date(get_option('date_format'), $tournament->end_date)) . ' &nbsp; ';
-			echo '<strong>' . esc_html__('Status', 'bonus-hunt-guesser') . ':</strong> ' . esc_html($tournament->status) . '</p>';
+				ob_start();
+				echo '<div class="bhg-tournament-details">';
+				echo '<p><a href="' . esc_url( remove_query_arg( 'bhg_tournament_id' ) ) . '">&larr; ' . esc_html__( 'Back to tournaments', 'bonus-hunt-guesser' ) . '</a></p>';
+				echo '<h3>' . esc_html( ucfirst( $tournament->type ) ) . '</h3>';
+				echo '<p><strong>' . esc_html__( 'Start', 'bonus-hunt-guesser' ) . ':</strong> ' . esc_html( mysql2date( get_option( 'date_format' ), $tournament->start_date ) ) . ' &nbsp; ';
+				echo '<strong>' . esc_html__( 'End', 'bonus-hunt-guesser' ) . ':</strong> ' . esc_html( mysql2date( get_option( 'date_format' ), $tournament->end_date ) ) . ' &nbsp; ';
+				echo '<strong>' . esc_html__( 'Status', 'bonus-hunt-guesser' ) . ':</strong> ' . esc_html( $tournament->status ) . '</p>';
 
-			if (!$rows) {
-				echo '<p>' . esc_html__('No results yet.', 'bonus-hunt-guesser') . '</p>';
+				if ( ! $rows ) {
+					echo '<p>' . esc_html__( 'No results yet.', 'bonus-hunt-guesser' ) . '</p>';
+					echo '</div>';
+					return ob_get_clean();
+				}
+
+				echo '<table class="bhg-leaderboard">';
+				echo '<thead><tr>';
+				echo '<th>#</th>';
+				echo '<th><a href="' . $toggle( 'username' ) . '">' . esc_html__( 'Username', 'bonus-hunt-guesser' ) . '</a></th>';
+				echo '<th><a href="' . $toggle( 'wins' ) . '">' . esc_html__( 'Wins', 'bonus-hunt-guesser' ) . '</a></th>';
+				echo '<th><a href="' . $toggle( 'last_win_at' ) . '">' . esc_html__( 'Last win', 'bonus-hunt-guesser' ) . '</a></th>';
+				echo '</tr></thead><tbody>';
+
+				$pos = 1;
+				foreach ( $rows as $row ) {
+					echo '<tr>';
+					echo '<td>' . (int) $pos++ . '</td>';
+					echo '<td>' . esc_html(
+						$row->user_login ?: sprintf(
+										/* translators: %d: user ID. */
+							__( 'user#%d', 'bonus-hunt-guesser' ),
+							(int) $row->user_id
+						)
+					) . '</td>';
+					echo '<td>' . (int) $row->wins . '</td>';
+					echo '<td>' . ( $row->last_win_date ? esc_html( mysql2date( get_option( 'date_format' ), $row->last_win_date ) ) : esc_html__( '—', 'bonus-hunt-guesser' ) ) . '</td>';
+							echo '</tr>';
+				}
+				echo '</tbody></table>';
 				echo '</div>';
+
 				return ob_get_clean();
 			}
 
-echo '<table class="bhg-leaderboard">';
-echo '<thead><tr>';
-echo '<th>#</th>';
-echo '<th><a href="' . $toggle('username') . '">' . esc_html__('Username', 'bonus-hunt-guesser') . '</a></th>';
-echo '<th><a href="' . $toggle('wins') . '">' . esc_html__('Wins', 'bonus-hunt-guesser') . '</a></th>';
-echo '<th><a href="' . $toggle('last_win_at') . '">' . esc_html__('Last win', 'bonus-hunt-guesser') . '</a></th>';
-echo '</tr></thead><tbody>';
+			// Otherwise list tournaments with filters
+			$a = shortcode_atts(
+				array(
+					'status'     => 'active',
+					'tournament' => 0,
+					'website'    => 0,
+					'timeline'   => '',
+				),
+				$atts,
+				'bhg_tournaments'
+			);
 
-			$pos = 1;
-foreach ($rows as $row) {
-echo '<tr>';
-echo '<td>' . (int)$pos++ . '</td>';
-echo '<td>' . esc_html( $row->user_login ?: sprintf(
-                                       /* translators: %d: user ID. */
-                                       __( 'user#%d', 'bonus-hunt-guesser' ),
-                                       (int) $row->user_id
-                               ) ) . '</td>';
-echo '<td>' . (int)$row->wins . '</td>';
-echo '<td>' . ( $row->last_win_date ? esc_html( mysql2date( get_option( 'date_format' ), $row->last_win_date ) ) : esc_html__( '—', 'bonus-hunt-guesser' ) ) . '</td>';
-				echo '</tr>';
+			$t                    = $wpdb->prefix . 'bhg_tournaments';
+			$where                = array();
+			$args                 = array();
+						$status   = isset( $_GET['bhg_status'] ) ? sanitize_key( wp_unslash( $_GET['bhg_status'] ) ) : sanitize_key( $a['status'] );
+						$timeline = isset( $_GET['bhg_timeline'] ) ? sanitize_key( wp_unslash( $_GET['bhg_timeline'] ) ) : sanitize_key( $a['timeline'] );
+			$tournament           = absint( $a['tournament'] );
+			$website              = absint( $a['website'] );
+
+			if ( $tournament > 0 ) {
+					$where[] = 'id = %d';
+					$args[]  = $tournament;
 			}
-			echo '</tbody></table>';
-			echo '</div>';
+			if ( in_array( $status, array( 'active', 'closed' ), true ) ) {
+						$where[] = 'status = %s';
+						$args[]  = $status;
+			}
+			if ( in_array( $timeline, array( 'weekly', 'monthly', 'yearly', 'quarterly', 'alltime' ), true ) ) {
+						$where[] = 'type = %s';
+						$args[]  = $timeline;
+			}
+			if ( $website > 0 ) {
+					$where[] = 'affiliate_site_id = %d';
+					$args[]  = $website;
+			}
 
+				$sql = "SELECT * FROM {$t}";
+			if ( $where ) {
+					$sql .= ' WHERE ' . implode( ' AND ', $where );
+			}
+				$sql .= ' ORDER BY start_date DESC, id DESC';
+
+				$rows = $args ? $wpdb->get_results( $wpdb->prepare( $sql, $args ) ) : $wpdb->get_results( $sql );
+			if ( ! $rows ) {
+					return '<p>' . esc_html__( 'No tournaments found.', 'bonus-hunt-guesser' ) . '</p>';
+			}
+							$current_url = isset( $_SERVER['REQUEST_URI'] )
+									? esc_url_raw( wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) ) )
+									: home_url( '/' );
+
+				ob_start();
+				echo '<form method="get" class="bhg-tournament-filters">';
+			foreach ( $_GET as $raw_key => $v ) {
+					$key = sanitize_key( wp_unslash( $raw_key ) );
+				if ( $key === 'bhg_timeline' || $key === 'bhg_status' || $key === 'bhg_tournament_id' ) {
+								continue;
+				}
+					echo '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( is_array( $v ) ? reset( $v ) : wp_unslash( $v ) ) . '">';
+			}
+					echo '<label class="bhg-tournament-label">' . esc_html__( 'Timeline:', 'bonus-hunt-guesser' ) . ' ';
+					echo '<select name="bhg_timeline">';
+					$timelines            = array(
+						'all'       => __( 'All', 'bonus-hunt-guesser' ),
+						'weekly'    => __( 'Weekly', 'bonus-hunt-guesser' ),
+						'monthly'   => __( 'Monthly', 'bonus-hunt-guesser' ),
+						'yearly'    => __( 'Yearly', 'bonus-hunt-guesser' ),
+						'quarterly' => __( 'Quarterly', 'bonus-hunt-guesser' ),
+						'alltime'   => __( 'All-Time', 'bonus-hunt-guesser' ),
+					);
+							$timeline_key = isset( $_GET['bhg_timeline'] ) ? sanitize_key( wp_unslash( $_GET['bhg_timeline'] ) ) : $timeline;
+					foreach ( $timelines as $key => $label ) {
+						echo '<option value="' . esc_attr( $key ) . '"' . selected( $timeline_key, $key, false ) . '>' . esc_html( $label ) . '</option>';
+					}
+					echo '</select></label>';
+
+					echo '<label>' . esc_html__( 'Status:', 'bonus-hunt-guesser' ) . ' ';
+					echo '<select name="bhg_status">';
+					$statuses           = array(
+						'active' => __( 'Active', 'bonus-hunt-guesser' ),
+						'closed' => __( 'Closed', 'bonus-hunt-guesser' ),
+						'all'    => __( 'All', 'bonus-hunt-guesser' ),
+					);
+							$status_key = isset( $_GET['bhg_status'] ) ? sanitize_key( wp_unslash( $_GET['bhg_status'] ) ) : $status;
+					foreach ( $statuses as $key => $label ) {
+						echo '<option value="' . esc_attr( $key ) . '"' . selected( $status_key, $key, false ) . '>' . esc_html( $label ) . '</option>';
+					}
+					echo '</select></label> ';
+
+					echo '<button class="button bhg-filter-button" type="submit">' . esc_html__( 'Filter', 'bonus-hunt-guesser' ) . '</button>';
+					echo '</form>';
+
+					echo '<table class="bhg-tournaments">';
+					echo '<thead><tr>';
+					echo '<th>' . esc_html__( 'Type', 'bonus-hunt-guesser' ) . '</th>';
+					echo '<th>' . esc_html__( 'Start', 'bonus-hunt-guesser' ) . '</th>';
+					echo '<th>' . esc_html__( 'End', 'bonus-hunt-guesser' ) . '</th>';
+					echo '<th>' . esc_html__( 'Status', 'bonus-hunt-guesser' ) . '</th>';
+					echo '<th>' . esc_html__( 'Details', 'bonus-hunt-guesser' ) . '</th>';
+					echo '</tr></thead><tbody>';
+
+					foreach ( $rows as $row ) {
+						$detail_url = esc_url( add_query_arg( 'bhg_tournament_id', (int) $row->id, remove_query_arg( array( 'orderby', 'order' ), $current_url ) ) );
+						echo '<tr>';
+						echo '<td>' . esc_html( ucfirst( $row->type ) ) . '</td>';
+						echo '<td>' . esc_html( mysql2date( get_option( 'date_format' ), $row->start_date ) ) . '</td>';
+						echo '<td>' . esc_html( mysql2date( get_option( 'date_format' ), $row->end_date ) ) . '</td>';
+						echo '<td>' . esc_html( $row->status ) . '</td>';
+						echo '<td><a href="' . $detail_url . '">' . esc_html__( 'Show details', 'bonus-hunt-guesser' ) . '</a></td>';
+						echo '</tr>';
+					}
+
+					echo '</tbody></table>';
+					return ob_get_clean();
+		}
+
+		/** Minimal winners widget: latest closed hunts */
+		public function winner_notifications_shortcode( $atts ) {
+			global $wpdb;
+
+			$a = shortcode_atts(
+				array( 'limit' => 5 ),
+				$atts,
+				'bhg_winner_notifications'
+			);
+
+			$hunts = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT id, title, final_balance, winners_count, closed_at FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status='closed' ORDER BY closed_at DESC LIMIT %d",
+					(int) $a['limit']
+				)
+			);
+
+			if ( ! $hunts ) {
+				return '<p>' . esc_html__( 'No closed hunts yet.', 'bonus-hunt-guesser' ) . '</p>';
+			}
+
+				wp_enqueue_style(
+					'bhg-shortcodes',
+					BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+					array(),
+					defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+				);
+
+				ob_start();
+				echo '<div class="bhg-winner-notifications">';
+			foreach ( $hunts as $hunt ) {
+				$winners = function_exists( 'bhg_get_top_winners_for_hunt' )
+						? bhg_get_top_winners_for_hunt( $hunt->id, (int) $hunt->winners_count )
+						: array();
+
+				echo '<div class="bhg-winner">';
+				echo '<p><strong>' . esc_html( $hunt->title ) . '</strong></p>';
+				if ( $hunt->final_balance !== null ) {
+					echo '<p><em>' . esc_html__( 'Final', 'bonus-hunt-guesser' ) . ':</em> ' . esc_html( number_format_i18n( (float) $hunt->final_balance, 2 ) ) . '</p>';
+				}
+
+				if ( $winners ) {
+					echo '<ul class="bhg-winner-list">';
+					foreach ( $winners as $w ) {
+						$u  = get_userdata( (int) $w->user_id );
+						$nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
+										echo '<li>' . esc_html( $nm ) . ' ' . esc_html__( '—', 'bonus-hunt-guesser' ) . ' ' . esc_html( number_format_i18n( (float) $w->guess, 2 ) ) . ' (' . esc_html( number_format_i18n( (float) $w->diff, 2 ) ) . ')</li>';
+					}
+					echo '</ul>';
+				}
+
+				echo '</div>';
+			}
+			echo '</div>';
 			return ob_get_clean();
 		}
 
-			   // Otherwise list tournaments with filters
-			   $a = shortcode_atts(
-					   array(
-							   'status'    => 'active',
-							   'tournament'=> 0,
-							   'website'   => 0,
-							   'timeline'  => '',
-					   ),
-					   $atts,
-					   'bhg_tournaments'
-			   );
-
-			   $t          = $wpdb->prefix . 'bhg_tournaments';
-			   $where      = array();
-			   $args       = array();
-                          $status     = isset( $_GET['bhg_status'] ) ? sanitize_key( wp_unslash( $_GET['bhg_status'] ) ) : sanitize_key( $a['status'] );
-                          $timeline   = isset( $_GET['bhg_timeline'] ) ? sanitize_key( wp_unslash( $_GET['bhg_timeline'] ) ) : sanitize_key( $a['timeline'] );
-			   $tournament = absint( $a['tournament'] );
-			   $website    = absint( $a['website'] );
-
-			   if ( $tournament > 0 ) {
-					   $where[] = 'id = %d';
-					   $args[]  = $tournament;
-			   }
-			   if ( in_array( $status, array( 'active', 'closed' ), true ) ) {
-					   $where[] = 'status = %s';
-					   $args[]  = $status;
-			   }
-			   if ( in_array( $timeline, array( 'weekly', 'monthly', 'yearly', 'quarterly', 'alltime' ), true ) ) {
-					   $where[] = 'type = %s';
-					   $args[]  = $timeline;
-			   }
-			   if ( $website > 0 ) {
-					   $where[] = 'affiliate_site_id = %d';
-					   $args[]  = $website;
-			   }
-
-			   $sql = "SELECT * FROM {$t}";
-			   if ( $where ) {
-					   $sql .= ' WHERE ' . implode( ' AND ', $where );
-			   }
-			   $sql .= ' ORDER BY start_date DESC, id DESC';
-
-			   $rows = $args ? $wpdb->get_results( $wpdb->prepare( $sql, $args ) ) : $wpdb->get_results( $sql );
-			   if (!$rows) {
-					   return '<p>' . esc_html__('No tournaments found.', 'bonus-hunt-guesser') . '</p>';
-			   }
-                               $current_url = isset( $_SERVER['REQUEST_URI'] )
-                                       ? esc_url_raw( wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) ) )
-                                       : home_url( '/' );
-
-				ob_start();
-echo '<form method="get" class="bhg-tournament-filters">';
-                               foreach ( $_GET as $raw_key => $v ) {
-                                               $key = sanitize_key( wp_unslash( $raw_key ) );
-						if ( $key === 'bhg_timeline' || $key === 'bhg_status' || $key === 'bhg_tournament_id' ) {
-								continue;
-						}
-                                               echo '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( is_array( $v ) ? reset( $v ) : wp_unslash( $v ) ) . '">';
-				}
-echo '<label class="bhg-tournament-label">' . esc_html__( 'Timeline:', 'bonus-hunt-guesser' ) . ' ';
-				echo '<select name="bhg_timeline">';
-				$timelines = array( 'all' => __( 'All', 'bonus-hunt-guesser' ), 'weekly' => __( 'Weekly', 'bonus-hunt-guesser' ), 'monthly' => __( 'Monthly', 'bonus-hunt-guesser' ), 'yearly' => __( 'Yearly', 'bonus-hunt-guesser' ), 'quarterly' => __( 'Quarterly', 'bonus-hunt-guesser' ), 'alltime' => __( 'All-Time', 'bonus-hunt-guesser' ) );
-                               $timeline_key = isset( $_GET['bhg_timeline'] ) ? sanitize_key( wp_unslash( $_GET['bhg_timeline'] ) ) : $timeline;
-				foreach ( $timelines as $key => $label ) {
-						echo '<option value="' . esc_attr( $key ) . '"' . selected( $timeline_key, $key, false ) . '>' . esc_html( $label ) . '</option>';
-				}
-				echo '</select></label>';
-
-				echo '<label>' . esc_html__( 'Status:', 'bonus-hunt-guesser' ) . ' ';
-				echo '<select name="bhg_status">';
-				$statuses = array( 'active' => __( 'Active', 'bonus-hunt-guesser' ), 'closed' => __( 'Closed', 'bonus-hunt-guesser' ), 'all' => __( 'All', 'bonus-hunt-guesser' ) );
-                               $status_key = isset( $_GET['bhg_status'] ) ? sanitize_key( wp_unslash( $_GET['bhg_status'] ) ) : $status;
-				foreach ( $statuses as $key => $label ) {
-						echo '<option value="' . esc_attr( $key ) . '"' . selected( $status_key, $key, false ) . '>' . esc_html( $label ) . '</option>';
-				}
-				echo '</select></label> ';
-
-echo '<button class="button bhg-filter-button" type="submit">'.esc_html__('Filter','bonus-hunt-guesser').'</button>';
-echo '</form>';
-
-echo '<table class="bhg-tournaments">';
-		echo '<thead><tr>';
-echo '<th>' . esc_html__('Type', 'bonus-hunt-guesser') . '</th>';
-echo '<th>' . esc_html__('Start', 'bonus-hunt-guesser') . '</th>';
-echo '<th>' . esc_html__('End', 'bonus-hunt-guesser') . '</th>';
-echo '<th>' . esc_html__('Status', 'bonus-hunt-guesser') . '</th>';
-echo '<th>' . esc_html__('Details', 'bonus-hunt-guesser') . '</th>';
-		echo '</tr></thead><tbody>';
-
-		foreach ($rows as $row) {
-			$detail_url = esc_url(add_query_arg('bhg_tournament_id', (int)$row->id, remove_query_arg(array('orderby','order'), $current_url)));
-			echo '<tr>';
-echo '<td>' . esc_html(ucfirst($row->type)) . '</td>';
-echo '<td>' . esc_html(mysql2date(get_option('date_format'), $row->start_date)) . '</td>';
-echo '<td>' . esc_html(mysql2date(get_option('date_format'), $row->end_date)) . '</td>';
-echo '<td>' . esc_html($row->status) . '</td>';
-echo '<td><a href="' . $detail_url . '">' . esc_html__('Show details','bonus-hunt-guesser') . '</a></td>';
-			echo '</tr>';
+		/** Minimal profile view: affiliate status badge */
+		public function user_profile_shortcode( $atts ) {
+			if ( ! is_user_logged_in() ) {
+				return '<p>' . esc_html__( 'Please log in to view this content.', 'bonus-hunt-guesser' ) . '</p>';
+			}
+			wp_enqueue_style(
+				'bhg-shortcodes',
+				BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+				array(),
+				defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+			);
+			$user_id      = get_current_user_id();
+			$is_affiliate = (int) get_user_meta( $user_id, 'bhg_is_affiliate', true );
+			$badge        = $is_affiliate ? '<span class="bhg-aff-green" aria-hidden="true"></span>' : '<span class="bhg-aff-red" aria-hidden="true"></span>';
+			return '<div class="bhg-user-profile">' . $badge . ' ' . esc_html( wp_get_current_user()->display_name ) . '</div>';
 		}
 
-		echo '</tbody></table>';
-		return ob_get_clean();
-	}
+		/** [bhg_best_guessers] — simple wins leaderboard */
+		public function best_guessers_shortcode( $atts ) {
+			global $wpdb;
 
-	/** Minimal winners widget: latest closed hunts */
-	public function winner_notifications_shortcode($atts) {
-		global $wpdb;
+			$wins_tbl  = $wpdb->prefix . 'bhg_tournament_results';
+			$tours_tbl = $wpdb->prefix . 'bhg_tournaments';
+			$users_tbl = $wpdb->users;
 
-		$a = shortcode_atts(
-			array('limit' => 5),
-			$atts,
-			'bhg_winner_notifications'
-		);
+			$now_ts        = current_time( 'timestamp' );
+			$current_month = wp_date( 'Y-m', $now_ts );
+			$current_year  = wp_date( 'Y', $now_ts );
 
-		$hunts = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT id, title, final_balance, winners_count, closed_at FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status='closed' ORDER BY closed_at DESC LIMIT %d",
-				(int) $a['limit']
-			)
-		);
+			$periods = array(
+				'overall' => array(
+					'label' => esc_html__( 'Overall', 'bonus-hunt-guesser' ),
+					'type'  => '',
+					'start' => '',
+					'end'   => '',
+				),
+				'monthly' => array(
+					'label' => esc_html__( 'Monthly', 'bonus-hunt-guesser' ),
+					'type'  => 'monthly',
+					'start' => $current_month . '-01',
+					'end'   => wp_date( 'Y-m-t', strtotime( $current_month . '-01', $now_ts ) ),
+				),
+				'yearly'  => array(
+					'label' => esc_html__( 'Yearly', 'bonus-hunt-guesser' ),
+					'type'  => 'yearly',
+					'start' => $current_year . '-01-01',
+					'end'   => $current_year . '-12-31',
+				),
+				'alltime' => array(
+					'label' => esc_html__( 'All-Time', 'bonus-hunt-guesser' ),
+					'type'  => 'alltime',
+					'start' => '',
+					'end'   => '',
+				),
+			);
 
-               if ( ! $hunts ) {
-                       return '<p>' . esc_html__( 'No closed hunts yet.', 'bonus-hunt-guesser' ) . '</p>';
-               }
-
-               wp_enqueue_style(
-                       'bhg-shortcodes',
-                       BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-                       array(),
-                       defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-               );
-
-               ob_start();
-               echo '<div class="bhg-winner-notifications">';
-               foreach ( $hunts as $hunt ) {
-                        $winners = function_exists( 'bhg_get_top_winners_for_hunt' )
-                                ? bhg_get_top_winners_for_hunt( $hunt->id, (int) $hunt->winners_count )
-                                : array();
-
-                       echo '<div class="bhg-winner">';
-			echo '<p><strong>' . esc_html( $hunt->title ) . '</strong></p>';
-			if ( $hunt->final_balance !== null ) {
-				echo '<p><em>' . esc_html__( 'Final', 'bonus-hunt-guesser' ) . ':</em> ' . esc_html( number_format_i18n( (float) $hunt->final_balance, 2 ) ) . '</p>';
-			}
-
-			if ( $winners ) {
-				echo '<ul class="bhg-winner-list">';
-				foreach ( $winners as $w ) {
-					$u  = get_userdata( (int) $w->user_id );
-					$nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
-                                        echo '<li>' . esc_html( $nm ) . ' ' . esc_html__( '—', 'bonus-hunt-guesser' ) . ' ' . esc_html( number_format_i18n( (float) $w->guess, 2 ) ) . ' (' . esc_html( number_format_i18n( (float) $w->diff, 2 ) ) . ')</li>';
-				}
-				echo '</ul>';
-			}
-
-			echo '</div>';
-		}
-		echo '</div>';
-		return ob_get_clean();
-	}
-
-	/** Minimal profile view: affiliate status badge */
-	public function user_profile_shortcode($atts) {
-		if (!is_user_logged_in()) return '<p>' . esc_html__('Please log in to view this content.', 'bonus-hunt-guesser') . '</p>';
-		wp_enqueue_style(
-			'bhg-shortcodes',
-			BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-			array(),
-			defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-		);
-		$user_id = get_current_user_id();
-		$is_affiliate = (int)get_user_meta($user_id, 'bhg_is_affiliate', true);
-		$badge = $is_affiliate ? '<span class="bhg-aff-green" aria-hidden="true"></span>' : '<span class="bhg-aff-red" aria-hidden="true"></span>';
-		return '<div class="bhg-user-profile">' . $badge . ' ' . esc_html(wp_get_current_user()->display_name) . '</div>';
-	}
-
-	/** [bhg_best_guessers] — simple wins leaderboard */
-	public function best_guessers_shortcode($atts) {
-		global $wpdb;
-
-		$wins_tbl = $wpdb->prefix . 'bhg_tournament_results';
-		$tours_tbl = $wpdb->prefix . 'bhg_tournaments';
-		$users_tbl = $wpdb->users;
-
-		$now_ts = current_time('timestamp');
-		$current_month = wp_date('Y-m', $now_ts);
-		$current_year  = wp_date('Y', $now_ts);
-
-		$periods = array(
-			'overall' => array(
-				'label' => esc_html__('Overall', 'bonus-hunt-guesser'),
-				'type'  => '',
-				'start' => '',
-				'end'   => '',
-			),
-			'monthly' => array(
-				'label' => esc_html__('Monthly', 'bonus-hunt-guesser'),
-				'type'  => 'monthly',
-				'start' => $current_month . '-01',
-				'end'   => wp_date('Y-m-t', strtotime($current_month . '-01', $now_ts)),
-			),
-			'yearly' => array(
-				'label' => esc_html__('Yearly', 'bonus-hunt-guesser'),
-				'type'  => 'yearly',
-				'start' => $current_year . '-01-01',
-				'end'   => $current_year . '-12-31',
-			),
-			'alltime' => array(
-				'label' => esc_html__('All-Time', 'bonus-hunt-guesser'),
-				'type'  => 'alltime',
-				'start' => '',
-				'end'   => '',
-			),
-		);
-
-		$results = array();
-		foreach ($periods as $key => $info) {
-			if ($info['type']) {
-				$where = 't.type = %s';
-				$params = array($info['type']);
-				if (!empty($info['start']) && !empty($info['end'])) {
-					$where .= ' AND t.start_date >= %s AND t.end_date <= %s';
-					$params[] = $info['start'];
-					$params[] = $info['end'];
-				}
-				$sql = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
+			$results = array();
+			foreach ( $periods as $key => $info ) {
+				if ( $info['type'] ) {
+					$where  = 't.type = %s';
+					$params = array( $info['type'] );
+					if ( ! empty( $info['start'] ) && ! empty( $info['end'] ) ) {
+						$where   .= ' AND t.start_date >= %s AND t.end_date <= %s';
+						$params[] = $info['start'];
+						$params[] = $info['end'];
+					}
+					$sql = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
 						FROM {$wins_tbl} r
 						INNER JOIN {$users_tbl} u ON u.ID = r.user_id
 						INNER JOIN {$tours_tbl} t ON t.id = r.tournament_id
@@ -854,100 +897,102 @@ echo '<td><a href="' . $detail_url . '">' . esc_html__('Show details','bonus-hun
 						GROUP BY u.ID, u.user_login
 						ORDER BY total_wins DESC, u.user_login ASC
 						LIMIT 50";
-				array_unshift($params, $sql);
-				$prepared = call_user_func_array(array($wpdb, 'prepare'), $params);
-				$results[$key] = $wpdb->get_results($prepared);
-			} else {
-				$sql = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
+					array_unshift( $params, $sql );
+					$prepared        = call_user_func_array( array( $wpdb, 'prepare' ), $params );
+					$results[ $key ] = $wpdb->get_results( $prepared );
+				} else {
+					$sql             = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
 						FROM {$wins_tbl} r
 						INNER JOIN {$users_tbl} u ON u.ID = r.user_id
 						GROUP BY u.ID, u.user_login
 						ORDER BY total_wins DESC, u.user_login ASC
 						LIMIT 50";
-				$results[$key] = $wpdb->get_results( $sql );
-			}
-		}
-
-		$hunts_tbl = $wpdb->prefix . 'bhg_bonus_hunts';
-		$hunts = $wpdb->get_results( "SELECT id, title FROM {$hunts_tbl} WHERE status='closed' ORDER BY created_at DESC LIMIT 50" );
-
-		wp_enqueue_style(
-			'bhg-shortcodes',
-			BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-			array(),
-			defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-		);
-		wp_enqueue_script(
-			'bhg-shortcodes-js',
-			BHG_PLUGIN_URL . 'assets/js/bhg-shortcodes.js',
-			array(),
-			defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
-			true
-		);
-
-		ob_start();
-		echo '<ul class="bhg-tabs">';
-		$first = true;
-		foreach ($periods as $key => $info) {
-			$active = $first ? ' class="active"' : '';
-			echo '<li' . $active . '><a href="#bhg-tab-' . esc_attr($key) . '">' . esc_html($info['label']) . '</a></li>';
-			$first = false;
-		}
-		if ($hunts) {
-			echo '<li><a href="#bhg-tab-hunts">' . esc_html__('Bonus Hunts', 'bonus-hunt-guesser') . '</a></li>';
-		}
-		echo '</ul>';
-
-		$first = true;
-		foreach ($periods as $key => $info) {
-			$active = $first ? ' active' : '';
-			echo '<div id="bhg-tab-' . esc_attr($key) . '" class="bhg-tab-pane' . $active . '">';
-			$rows = isset($results[$key]) ? $results[$key] : array();
-			if (!$rows) {
-				echo '<p>' . esc_html__('No data yet.', 'bonus-hunt-guesser') . '</p>';
-			} else {
-				echo '<table class="bhg-leaderboard"><thead><tr><th>#</th><th>' . esc_html__('User', 'bonus-hunt-guesser') . '</th><th>' . esc_html__('Wins', 'bonus-hunt-guesser') . '</th></tr></thead><tbody>';
-				$pos = 1;
-				foreach ($rows as $r) {
-                                       /* translators: %d: user ID. */
-                                       $user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
-					echo '<tr><td>' . (int) $pos++ . '</td><td>' . esc_html($user_label) . '</td><td>' . (int) $r->total_wins . '</td></tr>';
+					$results[ $key ] = $wpdb->get_results( $sql );
 				}
-				echo '</tbody></table>';
 			}
-			echo '</div>';
-			$first = false;
-		}
 
-		if ( $hunts ) {
-                       $base = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
-                       $base = esc_url_raw( remove_query_arg( 'hunt_id', $base ) );
-			echo '<div id="bhg-tab-hunts" class="bhg-tab-pane">';
-			echo '<ul class="bhg-hunt-history">';
-			foreach ( $hunts as $hunt ) {
-				$url = esc_url( add_query_arg( 'hunt_id', (int) $hunt->id, $base ) );
-				echo '<li><a href="' . $url . '">' . esc_html( $hunt->title ) . '</a></li>';
+			$hunts_tbl = $wpdb->prefix . 'bhg_bonus_hunts';
+			$hunts     = $wpdb->get_results( "SELECT id, title FROM {$hunts_tbl} WHERE status='closed' ORDER BY created_at DESC LIMIT 50" );
+
+			wp_enqueue_style(
+				'bhg-shortcodes',
+				BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+				array(),
+				defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+			);
+			wp_enqueue_script(
+				'bhg-shortcodes-js',
+				BHG_PLUGIN_URL . 'assets/js/bhg-shortcodes.js',
+				array(),
+				defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
+				true
+			);
+
+			ob_start();
+			echo '<ul class="bhg-tabs">';
+			$first = true;
+			foreach ( $periods as $key => $info ) {
+				$active = $first ? ' class="active"' : '';
+				echo '<li' . $active . '><a href="#bhg-tab-' . esc_attr( $key ) . '">' . esc_html( $info['label'] ) . '</a></li>';
+				$first = false;
+			}
+			if ( $hunts ) {
+				echo '<li><a href="#bhg-tab-hunts">' . esc_html__( 'Bonus Hunts', 'bonus-hunt-guesser' ) . '</a></li>';
 			}
 			echo '</ul>';
-			echo '</div>';
-		}
 
-		return ob_get_clean();
+			$first = true;
+			foreach ( $periods as $key => $info ) {
+				$active = $first ? ' active' : '';
+				echo '<div id="bhg-tab-' . esc_attr( $key ) . '" class="bhg-tab-pane' . $active . '">';
+				$rows = isset( $results[ $key ] ) ? $results[ $key ] : array();
+				if ( ! $rows ) {
+					echo '<p>' . esc_html__( 'No data yet.', 'bonus-hunt-guesser' ) . '</p>';
+				} else {
+					echo '<table class="bhg-leaderboard"><thead><tr><th>#</th><th>' . esc_html__( 'User', 'bonus-hunt-guesser' ) . '</th><th>' . esc_html__( 'Wins', 'bonus-hunt-guesser' ) . '</th></tr></thead><tbody>';
+					$pos = 1;
+					foreach ( $rows as $r ) {
+										/* translators: %d: user ID. */
+										$user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
+						echo '<tr><td>' . (int) $pos++ . '</td><td>' . esc_html( $user_label ) . '</td><td>' . (int) $r->total_wins . '</td></tr>';
+					}
+					echo '</tbody></table>';
+				}
+				echo '</div>';
+				$first = false;
+			}
+
+			if ( $hunts ) {
+						$base = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
+						$base = esc_url_raw( remove_query_arg( 'hunt_id', $base ) );
+				echo '<div id="bhg-tab-hunts" class="bhg-tab-pane">';
+				echo '<ul class="bhg-hunt-history">';
+				foreach ( $hunts as $hunt ) {
+					$url = esc_url( add_query_arg( 'hunt_id', (int) $hunt->id, $base ) );
+					echo '<li><a href="' . $url . '">' . esc_html( $hunt->title ) . '</a></li>';
+				}
+				echo '</ul>';
+				echo '</div>';
+			}
+
+			return ob_get_clean();
+		}
 	}
-}
 
 } // end if class not exists
 
 // Register once on init even if no other bootstrap instantiates the class
-if (!function_exists('bhg_register_shortcodes_once')) {
+if ( ! function_exists( 'bhg_register_shortcodes_once' ) ) {
 	function bhg_register_shortcodes_once() {
 		static $done = false;
-		if ($done) return;
+		if ( $done ) {
+			return;
+		}
 		$done = true;
-		if (class_exists('BHG_Shortcodes')) {
+		if ( class_exists( 'BHG_Shortcodes' ) ) {
 			// Instantiate to attach the hooks
 			new BHG_Shortcodes();
 		}
 	}
-	add_action('init', 'bhg_register_shortcodes_once', 20);
+	add_action( 'init', 'bhg_register_shortcodes_once', 20 );
 }

--- a/includes/class-bhg-utils.php
+++ b/includes/class-bhg-utils.php
@@ -1,9 +1,9 @@
 <?php
 /**
-* Utility functions and helpers for Bonus Hunt Guesser plugin.
-*
-* @package Bonus_Hunt_Guesser
-*/
+ * Utility functions and helpers for Bonus Hunt Guesser plugin.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
 
 // phpcs:disable WordPress.Files.FileOrganization
 
@@ -12,8 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
-* General utility methods used throughout the plugin.
-*/
+ * General utility methods used throughout the plugin.
+ */
 class BHG_Utils {
 	/**
 	 * Register hooks used by utility functions.

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,5 +1,6 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
 /**
  * Log debug messages when WP_DEBUG is enabled.
@@ -51,18 +52,23 @@ function bhg_admin_cap() {
 }
 
 // Smart login redirect back to referring page.
-add_filter( 'login_redirect', function( $redirect_to, $requested_redirect_to, $user ) {
-	$r = isset( $_REQUEST['bhg_redirect'] ) ? wp_unslash( $_REQUEST['bhg_redirect'] ) : '';
-	if ( ! empty( $r ) ) {
-		$safe     = esc_url_raw( $r );
-		$home_host = wp_parse_url( home_url(), PHP_URL_HOST );
-		$r_host   = wp_parse_url( $safe, PHP_URL_HOST );
-		if ( ! $r_host || $r_host === $home_host ) {
-			return $safe;
+add_filter(
+	'login_redirect',
+	function ( $redirect_to, $requested_redirect_to, $user ) {
+		$r = isset( $_REQUEST['bhg_redirect'] ) ? wp_unslash( $_REQUEST['bhg_redirect'] ) : '';
+		if ( ! empty( $r ) ) {
+			$safe      = esc_url_raw( $r );
+			$home_host = wp_parse_url( home_url(), PHP_URL_HOST );
+			$r_host    = wp_parse_url( $safe, PHP_URL_HOST );
+			if ( ! $r_host || $r_host === $home_host ) {
+				return $safe;
+			}
 		}
-	}
-	return $redirect_to;
-}, 10, 3 );
+		return $redirect_to;
+	},
+	10,
+	3
+);
 
 /**
  * Determine if code runs on the frontend.
@@ -83,7 +89,7 @@ if ( ! function_exists( 'bhg_t' ) ) {
 	 */
 	function bhg_t( $key, $default = '' ) {
 		global $wpdb;
-		static $cache = [];
+		static $cache = array();
 
 		if ( isset( $cache[ $key ] ) ) {
 			return $cache[ $key ];
@@ -111,63 +117,63 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 	 */
 	function bhg_get_default_translations() {
 		return array(
-			'welcome_message'        => 'Welcome!',
-			'goodbye_message'        => 'Goodbye!',
-			'menu_dashboard'         => 'Dashboard',
-			'menu_bonus_hunts'       => 'Bonus Hunts',
-			'menu_results'           => 'Results',
-			'menu_tournaments'       => 'Tournaments',
-			'menu_users'             => 'Users',
-			'menu_affiliates'        => 'Affiliates',
-			'menu_advertising'       => 'Advertising',
-			'menu_translations'      => 'Translations',
-			'menu_tools'             => 'Tools',
-			'menu_ads'               => 'Ads',
-			'label_start_balance'    => 'Starting Balance',
-			'label_number_bonuses'   => 'Number of Bonuses',
-			'label_prizes'           => 'Prizes',
-			'label_submit_guess'     => 'Submit Guess',
-			'label_guess'            => 'Guess',
-			'label_username'         => 'Username',
-			'label_position'         => 'Position',
-			'label_final_balance'    => 'Final Balance',
-			'label_leaderboard'      => 'Leaderboard',
-			'label_affiliate'        => 'Affiliate',
-			'label_non_affiliate'    => 'Non-affiliate',
-			'label_affiliate_status' => 'Affiliate Status',
-			'label_actions'          => 'Actions',
-			'label_placements'       => 'Placements',
-			'label_visible_to'       => 'Visible To',
-			'label_start_date'       => 'Start Date',
-			'label_end_date'         => 'End Date',
-			'label_email'            => 'Email',
-			'label_real_name'        => 'Real Name',
-			'label_search'           => 'Search',
-			'notice_login_required'  => 'You must be logged in to guess.',
-			'notice_guess_saved'     => 'Your guess has been saved.',
-			'notice_guess_updated'   => 'Your guess has been updated.',
-			'notice_hunt_closed'     => 'This bonus hunt is closed.',
-			'notice_invalid_guess'   => 'Please enter a valid guess.',
-			'notice_not_authorized'  => 'You are not authorized to perform this action.',
-			'notice_translations_saved' => 'Translations saved.',
-			'notice_translations_reset' => 'Translations reset.',
-			'notice_no_active_hunt'  => 'No active bonus hunt found.',
-			'notice_no_results'      => 'No results available.',
-			'notice_user_removed'    => 'User removed.',
-			'notice_ad_saved'        => 'Advertisement saved.',
-			'notice_ad_deleted'      => 'Advertisement deleted.',
-			'notice_settings_saved'  => 'Settings saved.',
-			'notice_profile_updated' => 'Profile updated.',
-			'button_save'            => 'Save',
-			'button_cancel'          => 'Cancel',
-			'button_delete'          => 'Delete',
-			'button_edit'            => 'Edit',
-			'button_view'            => 'View',
-			'button_back'            => 'Back',
-			'msg_no_guesses'         => 'No guesses yet.',
-			'msg_thank_you'          => 'Thank you!',
-			'msg_error'              => 'An error occurred.',
-			'placeholder_enter_guess'=> 'Enter your guess',
+			'welcome_message'             => 'Welcome!',
+			'goodbye_message'             => 'Goodbye!',
+			'menu_dashboard'              => 'Dashboard',
+			'menu_bonus_hunts'            => 'Bonus Hunts',
+			'menu_results'                => 'Results',
+			'menu_tournaments'            => 'Tournaments',
+			'menu_users'                  => 'Users',
+			'menu_affiliates'             => 'Affiliates',
+			'menu_advertising'            => 'Advertising',
+			'menu_translations'           => 'Translations',
+			'menu_tools'                  => 'Tools',
+			'menu_ads'                    => 'Ads',
+			'label_start_balance'         => 'Starting Balance',
+			'label_number_bonuses'        => 'Number of Bonuses',
+			'label_prizes'                => 'Prizes',
+			'label_submit_guess'          => 'Submit Guess',
+			'label_guess'                 => 'Guess',
+			'label_username'              => 'Username',
+			'label_position'              => 'Position',
+			'label_final_balance'         => 'Final Balance',
+			'label_leaderboard'           => 'Leaderboard',
+			'label_affiliate'             => 'Affiliate',
+			'label_non_affiliate'         => 'Non-affiliate',
+			'label_affiliate_status'      => 'Affiliate Status',
+			'label_actions'               => 'Actions',
+			'label_placements'            => 'Placements',
+			'label_visible_to'            => 'Visible To',
+			'label_start_date'            => 'Start Date',
+			'label_end_date'              => 'End Date',
+			'label_email'                 => 'Email',
+			'label_real_name'             => 'Real Name',
+			'label_search'                => 'Search',
+			'notice_login_required'       => 'You must be logged in to guess.',
+			'notice_guess_saved'          => 'Your guess has been saved.',
+			'notice_guess_updated'        => 'Your guess has been updated.',
+			'notice_hunt_closed'          => 'This bonus hunt is closed.',
+			'notice_invalid_guess'        => 'Please enter a valid guess.',
+			'notice_not_authorized'       => 'You are not authorized to perform this action.',
+			'notice_translations_saved'   => 'Translations saved.',
+			'notice_translations_reset'   => 'Translations reset.',
+			'notice_no_active_hunt'       => 'No active bonus hunt found.',
+			'notice_no_results'           => 'No results available.',
+			'notice_user_removed'         => 'User removed.',
+			'notice_ad_saved'             => 'Advertisement saved.',
+			'notice_ad_deleted'           => 'Advertisement deleted.',
+			'notice_settings_saved'       => 'Settings saved.',
+			'notice_profile_updated'      => 'Profile updated.',
+			'button_save'                 => 'Save',
+			'button_cancel'               => 'Cancel',
+			'button_delete'               => 'Delete',
+			'button_edit'                 => 'Edit',
+			'button_view'                 => 'View',
+			'button_back'                 => 'Back',
+			'msg_no_guesses'              => 'No guesses yet.',
+			'msg_thank_you'               => 'Thank you!',
+			'msg_error'                   => 'An error occurred.',
+			'placeholder_enter_guess'     => 'Enter your guess',
 			'notice_login_to_continue'    => 'Please log in to continue.',
 			'button_log_in'               => 'Log in',
 			'notice_no_active_hunts'      => 'No active bonus hunts at the moment.',
@@ -207,29 +213,29 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'label_user_number'           => 'User #%d',
 			'label_diff'                  => 'diff',
 			'notice_login_view_content'   => 'Please log in to view this content.',
-                        'label_latest_hunts'          => 'Latest Hunts',
-                        'label_bonushunt'             => 'Bonushunt',
-                        'label_all_winners'           => 'All Winners',
-                        'label_closed_at'             => 'Closed At',
-                        'label_hunt'                  => 'Hunt',
-                        'label_title'                 => 'Title',
-                        'notice_no_user_specified'    => 'No user specified.',
-                        'notice_no_guesses_found'     => 'No guesses found.',
-                        'msg_no_ads_yet'              => 'No ads yet.',
-                        'notice_no_winners_yet'       => 'No winners yet.',
-				// Shortcode labels for public views.
-				'sc_hunt'                     => 'Hunt',
-				'sc_guess'                    => 'Guess',
-				'sc_final'                    => 'Final',
-				'sc_title'                    => 'Title',
-				'sc_start_balance'            => 'Start Balance',
-				'sc_final_balance'            => 'Final Balance',
-				'sc_status'                   => 'Status',
-				'sc_affiliate'                => 'Affiliate',
-				'sc_position'                 => 'Position',
-				'sc_user'                     => 'User',
-                );
-        }
+			'label_latest_hunts'          => 'Latest Hunts',
+			'label_bonushunt'             => 'Bonushunt',
+			'label_all_winners'           => 'All Winners',
+			'label_closed_at'             => 'Closed At',
+			'label_hunt'                  => 'Hunt',
+			'label_title'                 => 'Title',
+			'notice_no_user_specified'    => 'No user specified.',
+			'notice_no_guesses_found'     => 'No guesses found.',
+			'msg_no_ads_yet'              => 'No ads yet.',
+			'notice_no_winners_yet'       => 'No winners yet.',
+			// Shortcode labels for public views.
+			'sc_hunt'                     => 'Hunt',
+			'sc_guess'                    => 'Guess',
+			'sc_final'                    => 'Final',
+			'sc_title'                    => 'Title',
+			'sc_start_balance'            => 'Start Balance',
+			'sc_final_balance'            => 'Final Balance',
+			'sc_status'                   => 'Status',
+			'sc_affiliate'                => 'Affiliate',
+			'sc_position'                 => 'Position',
+			'sc_user'                     => 'User',
+		);
+	}
 }
 
 if ( ! function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
@@ -283,7 +289,7 @@ function bhg_format_currency( $amount ) {
  * @return bool
  */
 function bhg_validate_guess( $guess ) {
-	$settings  = get_option( 'bhg_plugin_settings', [] );
+	$settings  = get_option( 'bhg_plugin_settings', array() );
 	$min_guess = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
 	$max_guess = isset( $settings['max_guess_amount'] ) ? (float) $settings['max_guess_amount'] : 100000;
 
@@ -416,37 +422,46 @@ if ( ! function_exists( 'bhg_render_affiliate_dot' ) ) {
  */
 function bhg_render_ads( $placement = 'footer', $hunt_id = 0 ) {
 	global $wpdb;
-	$tbl = $wpdb->prefix . 'bhg_ads';
-	$placement = sanitize_text_field($placement);
-	$rows = $wpdb->get_results($wpdb->prepare("SELECT content, link_url, visible_to FROM {$tbl} WHERE active=1 AND placement=%s ORDER BY id DESC", $placement));
+	$tbl          = $wpdb->prefix . 'bhg_ads';
+	$placement    = sanitize_text_field( $placement );
+	$rows         = $wpdb->get_results( $wpdb->prepare( "SELECT content, link_url, visible_to FROM {$tbl} WHERE active=1 AND placement=%s ORDER BY id DESC", $placement ) );
 	$hunt_site_id = 0;
-	if ($hunt_id) {
+	if ( $hunt_id ) {
 		$hunt_site_id = (int) $wpdb->get_var(
-			$wpdb->prepare("SELECT affiliate_site_id FROM {$wpdb->prefix}bhg_bonus_hunts WHERE id=%d", $hunt_id)
+			$wpdb->prepare( "SELECT affiliate_site_id FROM {$wpdb->prefix}bhg_bonus_hunts WHERE id=%d", $hunt_id )
 		);
 	}
-	if (!$rows) return '';
+	if ( ! $rows ) {
+		return '';
+	}
 
-	$out = '<div class="bhg-ads bhg-ads-' . esc_attr($placement) . '">';
-	foreach ($rows as $r) {
-		$vis = $r->visible_to ?: 'all';
+	$out = '<div class="bhg-ads bhg-ads-' . esc_attr( $placement ) . '">';
+	foreach ( $rows as $r ) {
+		$vis  = $r->visible_to ?: 'all';
 		$show = false;
-		if ($vis === 'all') $show = true;
-		elseif ($vis === 'guests' && !is_user_logged_in()) $show = true;
-		elseif ($vis === 'logged_in' && is_user_logged_in()) $show = true;
-		elseif ($vis === 'affiliates' && is_user_logged_in()) {
-			$uid = get_current_user_id();
+		if ( $vis === 'all' ) {
+			$show = true;
+		} elseif ( $vis === 'guests' && ! is_user_logged_in() ) {
+			$show = true;
+		} elseif ( $vis === 'logged_in' && is_user_logged_in() ) {
+			$show = true;
+		} elseif ( $vis === 'affiliates' && is_user_logged_in() ) {
+			$uid  = get_current_user_id();
 			$show = $hunt_site_id > 0
-				? bhg_is_user_affiliate_for_site($uid, $hunt_site_id)
-				: (bool) get_user_meta($uid, 'bhg_is_affiliate', true);
+				? bhg_is_user_affiliate_for_site( $uid, $hunt_site_id )
+				: (bool) get_user_meta( $uid, 'bhg_is_affiliate', true );
 		}
-		if (!$show) continue;
-		$msg  = wp_kses_post($r->content);
-		$link = $r->link_url ? esc_url($r->link_url) : '';
+		if ( ! $show ) {
+			continue;
+		}
+		$msg  = wp_kses_post( $r->content );
+		$link = $r->link_url ? esc_url( $r->link_url ) : '';
 		$out .= '<div class="bhg-ad" style="margin:10px 0;padding:10px;border:1px solid #e2e8f0;border-radius:6px;">';
-		if ($link) { $out .= '<a href="' . $link . '">'; }
+		if ( $link ) {
+			$out .= '<a href="' . $link . '">'; }
 		$out .= $msg;
-		if ($link) { $out .= '</a>'; }
+		if ( $link ) {
+			$out .= '</a>'; }
 		$out .= '</div>';
 	}
 	$out .= '</div>';
@@ -478,11 +493,13 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 		);
 
 		// Soft delete (DELETE) to preserve schema even if user lacks TRIGGER/TRUNCATE
-		foreach ($tables as $tbl) {
+		foreach ( $tables as $tbl ) {
 			// Skip translations/affiliates if table missing
-			$exists = $wpdb->get_var( $wpdb->prepare("SHOW TABLES LIKE %s", $tbl) );
-			if ($exists !== $tbl) continue;
-			if (strpos($tbl, 'bhg_translations') !== false || strpos($tbl, 'bhg_affiliate_websites') !== false) {
+			$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $tbl ) );
+			if ( $exists !== $tbl ) {
+				continue;
+			}
+			if ( strpos( $tbl, 'bhg_translations' ) !== false || strpos( $tbl, 'bhg_affiliate_websites' ) !== false ) {
 				// keep existing; we'll upsert below
 				continue;
 			}
@@ -491,67 +508,88 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 
 		// Seed affiliate websites (idempotent upsert by slug)
 		$aff_tbl = "{$p}bhg_affiliate_websites";
-		if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $aff_tbl)) === $aff_tbl) {
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $aff_tbl ) ) === $aff_tbl ) {
 			$affs = array(
-				array('name'=>'Main Site','slug'=>'main-site','url'=>home_url('/')),
-				array('name'=>'Casino Hub','slug'=>'casino-hub','url'=>home_url('/casino')),
+				array(
+					'name' => 'Main Site',
+					'slug' => 'main-site',
+					'url'  => home_url( '/' ),
+				),
+				array(
+					'name' => 'Casino Hub',
+					'slug' => 'casino-hub',
+					'url'  => home_url( '/casino' ),
+				),
 			);
-			foreach ($affs as $a) {
-				$id = $wpdb->get_var($wpdb->prepare("SELECT id FROM `{$aff_tbl}` WHERE slug=%s", $a['slug']));
-				if ($id) {
-					$wpdb->update($aff_tbl, $a, array('id'=>(int)$id), array('%s','%s','%s'), array('%d'));
+			foreach ( $affs as $a ) {
+				$id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM `{$aff_tbl}` WHERE slug=%s", $a['slug'] ) );
+				if ( $id ) {
+					$wpdb->update( $aff_tbl, $a, array( 'id' => (int) $id ), array( '%s', '%s', '%s' ), array( '%d' ) );
 				} else {
-					$wpdb->insert($aff_tbl, $a, array('%s','%s','%s'));
+					$wpdb->insert( $aff_tbl, $a, array( '%s', '%s', '%s' ) );
 				}
 			}
 		}
 
 		// Seed hunts
 		$hunts_tbl = "{$p}bhg_bonus_hunts";
-		if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $hunts_tbl)) === $hunts_tbl) {
-			$now = current_time('mysql', 1);
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $hunts_tbl ) ) === $hunts_tbl ) {
+			$now = current_time( 'mysql', 1 );
 			// Open hunt
-			$wpdb->insert($hunts_tbl, array(
-				'title' => __('Bonus Hunt – Demo Open', 'bonus-hunt-guesser'),
-				'starting_balance' => 2000.00,
-				'num_bonuses' => 10,
-				'prizes' => __('Gift card + swag', 'bonus-hunt-guesser'),
-				'status' => 'open',
-				'affiliate_site_id' => (int) $wpdb->get_var( "SELECT id FROM {$p}bhg_affiliate_websites ORDER BY id ASC LIMIT 1" ),
-				'created_at' => $now,
-				'updated_at' => $now,
-			), array('%s','%f','%d','%s','%s','%d','%s','%s'));
+			$wpdb->insert(
+				$hunts_tbl,
+				array(
+					'title'             => __( 'Bonus Hunt – Demo Open', 'bonus-hunt-guesser' ),
+					'starting_balance'  => 2000.00,
+					'num_bonuses'       => 10,
+					'prizes'            => __( 'Gift card + swag', 'bonus-hunt-guesser' ),
+					'status'            => 'open',
+					'affiliate_site_id' => (int) $wpdb->get_var( "SELECT id FROM {$p}bhg_affiliate_websites ORDER BY id ASC LIMIT 1" ),
+					'created_at'        => $now,
+					'updated_at'        => $now,
+				),
+				array( '%s', '%f', '%d', '%s', '%s', '%d', '%s', '%s' )
+			);
 			$open_id = (int) $wpdb->insert_id;
 
 			// Closed hunt with winner
-			$wpdb->insert($hunts_tbl, array(
-				'title' => __('Bonus Hunt – Demo Closed', 'bonus-hunt-guesser'),
-				'starting_balance' => 1500.00,
-				'num_bonuses' => 8,
-				'prizes' => __('T-shirt', 'bonus-hunt-guesser'),
-				'status' => 'closed',
-				'final_balance' => 1875.50,
-				'winner_user_id' => 1,
-				'winner_diff' => 12.50,
-				'closed_at' => gmdate('Y-m-d H:i:s', time() - 86400),
-				'created_at' => $now,
-				'updated_at' => $now,
-			), array('%s','%f','%d','%s','%s','%f','%d','%f','%s','%s','%s'));
+			$wpdb->insert(
+				$hunts_tbl,
+				array(
+					'title'            => __( 'Bonus Hunt – Demo Closed', 'bonus-hunt-guesser' ),
+					'starting_balance' => 1500.00,
+					'num_bonuses'      => 8,
+					'prizes'           => __( 'T-shirt', 'bonus-hunt-guesser' ),
+					'status'           => 'closed',
+					'final_balance'    => 1875.50,
+					'winner_user_id'   => 1,
+					'winner_diff'      => 12.50,
+					'closed_at'        => gmdate( 'Y-m-d H:i:s', time() - 86400 ),
+					'created_at'       => $now,
+					'updated_at'       => $now,
+				),
+				array( '%s', '%f', '%d', '%s', '%s', '%f', '%d', '%f', '%s', '%s', '%s' )
+			);
 			$closed_id = (int) $wpdb->insert_id;
 
 			// Seed guesses for open hunt
 			$g_tbl = "{$p}bhg_guesses";
 			$users = $wpdb->get_col( "SELECT ID FROM {$wpdb->users} ORDER BY ID ASC LIMIT 5" );
-			if (empty($users)) { $users = array(1); }
+			if ( empty( $users ) ) {
+				$users = array( 1 ); }
 			$val = 2100.00;
-			foreach ($users as $uid) {
-				$wpdb->insert($g_tbl, array(
-					'hunt_id' => $open_id,
-					'user_id' => (int)$uid,
-					'guess' => $val,
-					'created_at' => $now,
-					'updated_at' => $now,
-				), array('%d','%d','%f','%s','%s'));
+			foreach ( $users as $uid ) {
+				$wpdb->insert(
+					$g_tbl,
+					array(
+						'hunt_id'    => $open_id,
+						'user_id'    => (int) $uid,
+						'guess'      => $val,
+						'created_at' => $now,
+						'updated_at' => $now,
+					),
+					array( '%d', '%d', '%f', '%s', '%s' )
+				);
 				$val += 23.45;
 			}
 		}
@@ -559,59 +597,75 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 		// Tournaments + results based on closed hunts
 		$t_tbl = "{$p}bhg_tournaments";
 		$r_tbl = "{$p}bhg_tournament_results";
-		if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $t_tbl)) === $t_tbl) {
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $t_tbl ) ) === $t_tbl ) {
 			// Wipe results only
-			if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $r_tbl)) === $r_tbl) {
+			if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $r_tbl ) ) === $r_tbl ) {
 				$wpdb->query( "DELETE FROM `{$r_tbl}`" );
 			}
 			$closed = $wpdb->get_results( "SELECT winner_user_id, closed_at FROM {$hunts_tbl} WHERE status='closed' AND winner_user_id IS NOT NULL" );
-			foreach ($closed as $row) {
-				$ts = $row->closed_at ? strtotime($row->closed_at) : time();
-				$isoYear = date('o', $ts);
-				$week = str_pad(date('W', $ts), 2, '0', STR_PAD_LEFT);
-				$weekKey = $isoYear . '-W' . $week;
-				$monthKey = date('Y-m', $ts);
-				$yearKey = date('Y', $ts);
+			foreach ( $closed as $row ) {
+				$ts       = $row->closed_at ? strtotime( $row->closed_at ) : time();
+				$isoYear  = date( 'o', $ts );
+				$week     = str_pad( date( 'W', $ts ), 2, '0', STR_PAD_LEFT );
+				$weekKey  = $isoYear . '-W' . $week;
+				$monthKey = date( 'Y-m', $ts );
+				$yearKey  = date( 'Y', $ts );
 
-				$ensure = function($type, $period) use ($wpdb, $t_tbl) {
-					$now = current_time('mysql', 1);
-					$start = $now; $end = $now;
-					if ($type === 'weekly') {
-						$start = date('Y-m-d', strtotime($period . '-1'));
-						$end   = date('Y-m-d', strtotime($period . '-7'));
-					} elseif ($type === 'monthly') {
+				$ensure = function ( $type, $period ) use ( $wpdb, $t_tbl ) {
+					$now   = current_time( 'mysql', 1 );
+					$start = $now;
+					$end   = $now;
+					if ( $type === 'weekly' ) {
+						$start = date( 'Y-m-d', strtotime( $period . '-1' ) );
+						$end   = date( 'Y-m-d', strtotime( $period . '-7' ) );
+					} elseif ( $type === 'monthly' ) {
 						$start = $period . '-01';
-						$end   = date('Y-m-t', strtotime($start));
-					} elseif ($type === 'yearly') {
+						$end   = date( 'Y-m-t', strtotime( $start ) );
+					} elseif ( $type === 'yearly' ) {
 						$start = $period . '-01-01';
 						$end   = $period . '-12-31';
 					}
-					$id = $wpdb->get_var($wpdb->prepare(
-						"SELECT id FROM {$t_tbl} WHERE type=%s AND start_date=%s AND end_date=%s",
-						$type,
-						$start,
-						$end
-					));
-					if ($id) return (int) $id;
-					$wpdb->insert($t_tbl, array(
-						'type'=>$type,'start_date'=>$start,'end_date'=>$end,'status'=>'active',
-						'created_at'=>$now,'updated_at'=>$now
-					), array('%s','%s','%s','%s','%s','%s'));
-					return (int)$wpdb->insert_id;
+					$id = $wpdb->get_var(
+						$wpdb->prepare(
+							"SELECT id FROM {$t_tbl} WHERE type=%s AND start_date=%s AND end_date=%s",
+							$type,
+							$start,
+							$end
+						)
+					);
+					if ( $id ) {
+						return (int) $id;
+					}
+					$wpdb->insert(
+						$t_tbl,
+						array(
+							'type'       => $type,
+							'start_date' => $start,
+							'end_date'   => $end,
+							'status'     => 'active',
+							'created_at' => $now,
+							'updated_at' => $now,
+						),
+						array( '%s', '%s', '%s', '%s', '%s', '%s' )
+					);
+					return (int) $wpdb->insert_id;
 				};
 
-				$uids = (int)$row->winner_user_id;
-				foreach (array(
-					$ensure('weekly', $weekKey),
-					$ensure('monthly', $monthKey),
-					$ensure('yearly', $yearKey)
-				) as $tid) {
-					if ($tid && $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $r_tbl)) === $r_tbl) {
-						$wpdb->query($wpdb->prepare(
-							"INSERT INTO {$r_tbl} (tournament_id, user_id, wins) VALUES (%d, %d, 1)
+				$uids = (int) $row->winner_user_id;
+				foreach ( array(
+					$ensure( 'weekly', $weekKey ),
+					$ensure( 'monthly', $monthKey ),
+					$ensure( 'yearly', $yearKey ),
+				) as $tid ) {
+					if ( $tid && $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $r_tbl ) ) === $r_tbl ) {
+						$wpdb->query(
+							$wpdb->prepare(
+								"INSERT INTO {$r_tbl} (tournament_id, user_id, wins) VALUES (%d, %d, 1)
 							 ON DUPLICATE KEY UPDATE wins = wins + 1",
-							$tid, $uids
-						));
+								$tid,
+								$uids
+							)
+						);
 					}
 				}
 			}
@@ -619,40 +673,51 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 
 		// Seed translations (upsert)
 		$tr_tbl = "{$p}bhg_translations";
-		if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $tr_tbl)) === $tr_tbl) {
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $tr_tbl ) ) === $tr_tbl ) {
 			$pairs = array(
-				'email_results_title' => 'The Bonus Hunt has been closed!',
-				'email_final_balance' => 'Final Balance',
-				'email_winner' => 'Winner',
+				'email_results_title'    => 'The Bonus Hunt has been closed!',
+				'email_final_balance'    => 'Final Balance',
+				'email_winner'           => 'Winner',
 				'email_congrats_subject' => 'Congratulations! You won the Bonus Hunt',
-				'email_congrats_body' => 'You had the closest guess. Great job!',
-				'email_hunt' => 'Hunt',
+				'email_congrats_body'    => 'You had the closest guess. Great job!',
+				'email_hunt'             => 'Hunt',
 			);
-			foreach ($pairs as $k=>$v) {
-				$exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM {$tr_tbl} WHERE tkey=%s", $k));
-				if ($exists) {
-					$wpdb->update($tr_tbl, array('tvalue'=>$v), array('id'=>$exists), array('%s'), array('%d'));
+			foreach ( $pairs as $k => $v ) {
+				$exists = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$tr_tbl} WHERE tkey=%s", $k ) );
+				if ( $exists ) {
+					$wpdb->update( $tr_tbl, array( 'tvalue' => $v ), array( 'id' => $exists ), array( '%s' ), array( '%d' ) );
 				} else {
-					$wpdb->insert($tr_tbl, array('tkey'=>$k, 'tvalue'=>$v), array('%s','%s'));
+					$wpdb->insert(
+						$tr_tbl,
+						array(
+							'tkey'   => $k,
+							'tvalue' => $v,
+						),
+						array( '%s', '%s' )
+					);
 				}
 			}
 		}
 
 		// Seed ads
 		$ads_tbl = "{$p}bhg_ads";
-		if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $ads_tbl)) === $ads_tbl) {
-			$now = current_time('mysql', 1);
-			$wpdb->insert($ads_tbl, array(
-				'title'        => '',
-				'content'      => '<strong>Play responsibly.</strong> <a href="'.esc_url(home_url('/promo')).'">See promo</a>',
-				'link_url'     => '',
-				'placement'    => 'footer',
-				'visible_to'   => 'all',
-				'target_pages' => '',
-				'active'       => 1,
-				'created_at'   => $now,
-				'updated_at'   => $now,
-			), array('%s','%s','%s','%s','%s','%s','%d','%s','%s'));
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $ads_tbl ) ) === $ads_tbl ) {
+			$now = current_time( 'mysql', 1 );
+			$wpdb->insert(
+				$ads_tbl,
+				array(
+					'title'        => '',
+					'content'      => '<strong>Play responsibly.</strong> <a href="' . esc_url( home_url( '/promo' ) ) . '">See promo</a>',
+					'link_url'     => '',
+					'placement'    => 'footer',
+					'visible_to'   => 'all',
+					'target_pages' => '',
+					'active'       => 1,
+					'created_at'   => $now,
+					'updated_at'   => $now,
+				),
+				array( '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s' )
+			);
 		}
 
 		return true;

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -1,5 +1,7 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * BHG Shortcodes
@@ -7,204 +9,240 @@ if (!defined('ABSPATH')) exit;
  */
 
 // [bhg_user_profile] — profile only (no forms inside)
-add_shortcode('bhg_user_profile', function($atts) {
-    if (!is_user_logged_in()) {
-        return '<div class="bhg-box">' . esc_html__('Please log in to view your profile.', 'bonus-hunt-guesser') . '</div>';
-    }
-    
-    $u = wp_get_current_user();
-    $uid = get_current_user_id();
+add_shortcode(
+	'bhg_user_profile',
+	function ( $atts ) {
+		if ( ! is_user_logged_in() ) {
+			return '<div class="bhg-box">' . esc_html__( 'Please log in to view your profile.', 'bonus-hunt-guesser' ) . '</div>';
+		}
 
-    // Basic profile
-    ob_start(); ?>
-    <div class="bhg-box">
-        <h3><?php echo esc_html($u->display_name ?: $u->user_login); ?></h3>
-        <p><?php echo esc_html($u->user_email); ?></p>
-        <?php if (function_exists('bhg_get_affiliate_sites')): 
-            $sites = bhg_get_affiliate_sites($uid);
-            if (!empty($sites)): ?>
-                <h4><?php esc_html_e('Affiliate Sites', 'bonus-hunt-guesser'); ?></h4>
-                <ul class="bhg-list">
-                <?php foreach ($sites as $s): ?>
-                    <li><?php echo esc_html(is_array($s) ? ($s['name'] ?? $s['url'] ?? '') : (string)$s); ?></li>
-                <?php endforeach; ?>
-                </ul>
-            <?php endif; 
-        endif; ?>
+		$u   = wp_get_current_user();
+		$uid = get_current_user_id();
 
-        <?php
-        // Hunts participated
-        global $wpdb;
-        $rows = $wpdb->get_results($wpdb->prepare(
-            "SELECT DISTINCT h.id, h.title, h.status 
+		// Basic profile
+		ob_start(); ?>
+	<div class="bhg-box">
+		<h3><?php echo esc_html( $u->display_name ?: $u->user_login ); ?></h3>
+		<p><?php echo esc_html( $u->user_email ); ?></p>
+		<?php
+		if ( function_exists( 'bhg_get_affiliate_sites' ) ) :
+			$sites = bhg_get_affiliate_sites( $uid );
+			if ( ! empty( $sites ) ) :
+				?>
+				<h4><?php esc_html_e( 'Affiliate Sites', 'bonus-hunt-guesser' ); ?></h4>
+				<ul class="bhg-list">
+				<?php foreach ( $sites as $s ) : ?>
+					<li><?php echo esc_html( is_array( $s ) ? ( $s['name'] ?? $s['url'] ?? '' ) : (string) $s ); ?></li>
+				<?php endforeach; ?>
+				</ul>
+				<?php
+			endif;
+		endif;
+		?>
+
+		<?php
+		// Hunts participated
+		global $wpdb;
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT DISTINCT h.id, h.title, h.status 
             FROM {$wpdb->prefix}bhg_bonus_hunts h 
             INNER JOIN {$wpdb->prefix}bhg_guesses g ON g.hunt_id = h.id 
             WHERE g.user_id = %d 
-            ORDER BY h.id DESC", 
-            $uid
-        ));
-        
-        if ($rows): ?>
-            <h4><?php esc_html_e('Your Hunts', 'bonus-hunt-guesser'); ?></h4>
-            <ul class="bhg-list">
-            <?php foreach ($rows as $r): ?>
-                <li><?php echo esc_html($r->title ?: ('#' . $r->id)); ?> — <?php echo esc_html(ucfirst($r->status)); ?></li>
-            <?php endforeach; ?>
-            </ul>
-        <?php endif; ?>
-    </div>
-    <?php
-    return ob_get_clean();
-});
+            ORDER BY h.id DESC",
+				$uid
+			)
+		);
+
+		if ( $rows ) :
+			?>
+			<h4><?php esc_html_e( 'Your Hunts', 'bonus-hunt-guesser' ); ?></h4>
+			<ul class="bhg-list">
+			<?php foreach ( $rows as $r ) : ?>
+				<li><?php echo esc_html( $r->title ?: ( '#' . $r->id ) ); ?> — <?php echo esc_html( ucfirst( $r->status ) ); ?></li>
+			<?php endforeach; ?>
+			</ul>
+		<?php endif; ?>
+	</div>
+		<?php
+		return ob_get_clean();
+	}
+);
 
 // [bhg_active_hunt] — show all open hunts with description, prizes and user guesses
-add_shortcode('bhg_active_hunt', function($atts) {
-    global $wpdb;
-    $hunts = $wpdb->get_results("SELECT * FROM `" . $status . "`");
+add_shortcode(
+	'bhg_active_hunt',
+	function ( $atts ) {
+		global $wpdb;
+		$hunts = $wpdb->get_results( 'SELECT * FROM `' . $status . '`' );
 
-    ob_start(); ?>
-    
-    <div class="bhg-box">
-        <form method="get" class="bhg-field">
-            <?php foreach ($_GET as $k => $v): 
-                if ($k === 'status') continue; ?>
-                <input type="hidden" name="<?php echo esc_attr($k); ?>" value="<?php echo esc_attr($v); ?>">
-            <?php endforeach; ?>
-            
-            <label><?php esc_html_e('Filter', 'bonus-hunt-guesser'); ?></label>
-            <select name="status" onchange="this.form.submit()">
-                <option value="active" <?php selected($status, 'active'); ?>><?php esc_html_e('Active', 'bonus-hunt-guesser'); ?></option>
-                <option value="closed" <?php selected($status, 'closed'); ?>><?php esc_html_e('Closed', 'bonus-hunt-guesser'); ?></option>
-            </select>
-        </form>
+		ob_start();
+		?>
+	
+	<div class="bhg-box">
+		<form method="get" class="bhg-field">
+			<?php
+			foreach ( $_GET as $k => $v ) :
+				if ( $k === 'status' ) {
+					continue;
+				}
+				?>
+				<input type="hidden" name="<?php echo esc_attr( $k ); ?>" value="<?php echo esc_attr( $v ); ?>">
+			<?php endforeach; ?>
+			
+			<label><?php esc_html_e( 'Filter', 'bonus-hunt-guesser' ); ?></label>
+			<select name="status" onchange="this.form.submit()">
+				<option value="active" <?php selected( $status, 'active' ); ?>><?php esc_html_e( 'Active', 'bonus-hunt-guesser' ); ?></option>
+				<option value="closed" <?php selected( $status, 'closed' ); ?>><?php esc_html_e( 'Closed', 'bonus-hunt-guesser' ); ?></option>
+			</select>
+		</form>
 
-        <?php if ($rows): ?>
-            <ul class="bhg-list">
-                <?php foreach ($rows as $r): ?>
-                    <li><?php echo esc_html($r->title ?: ('#' . $r->id)); ?></li>
-                <?php endforeach; ?>
-            </ul>
-        <?php else: ?>
-            <p><?php esc_html_e('No tournaments found.', 'bonus-hunt-guesser'); ?></p>
-        <?php endif; ?>
-    </div>
-    
-    <?php
-    return ob_get_clean();
-});
+		<?php if ( $rows ) : ?>
+			<ul class="bhg-list">
+				<?php foreach ( $rows as $r ) : ?>
+					<li><?php echo esc_html( $r->title ?: ( '#' . $r->id ) ); ?></li>
+				<?php endforeach; ?>
+			</ul>
+		<?php else : ?>
+			<p><?php esc_html_e( 'No tournaments found.', 'bonus-hunt-guesser' ); ?></p>
+		<?php endif; ?>
+	</div>
+	
+		<?php
+		return ob_get_clean();
+	}
+);
 
 // [bhg_user_guesses] — list guesses by current user
-add_shortcode('bhg_user_guesses', function($atts) {
-    if (!is_user_logged_in()) {
-        return '<div class="bhg-box">' . esc_html__('Please log in.', 'bonus-hunt-guesser') . '</div>';
-    }
-    
-    global $wpdb;
-    $uid = get_current_user_id();
-    $rows = $wpdb->get_results($wpdb->prepare(
-        "SELECT g.*, h.title as hunt_title, h.status as hunt_status 
+add_shortcode(
+	'bhg_user_guesses',
+	function ( $atts ) {
+		if ( ! is_user_logged_in() ) {
+			return '<div class="bhg-box">' . esc_html__( 'Please log in.', 'bonus-hunt-guesser' ) . '</div>';
+		}
+
+		global $wpdb;
+		$uid  = get_current_user_id();
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT g.*, h.title as hunt_title, h.status as hunt_status 
         FROM {$wpdb->prefix}bhg_guesses g 
         LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id 
         WHERE g.user_id = %d 
-        ORDER BY g.id DESC", 
-        $uid
-    ));
-    
-    ob_start(); ?>
-    
-    <div class="bhg-box">
-        <h3><?php esc_html_e('Your Guesses', 'bonus-hunt-guesser'); ?></h3>
-        
-        <?php if ($rows): ?>
-            <table class="bhg-leaderboard">
-                <thead>
-                    <tr>
-                        <th><?php esc_html_e('Hunt', 'bonus-hunt-guesser'); ?></th>
-                        <th><?php esc_html_e('Guess', 'bonus-hunt-guesser'); ?></th>
-                        <th><?php esc_html_e('Status', 'bonus-hunt-guesser'); ?></th>
-                        <th><?php esc_html_e('Date', 'bonus-hunt-guesser'); ?></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($rows as $r): ?>
-                        <tr>
-                            <td><?php echo esc_html($r->hunt_title ?: ('#' . $r->hunt_id)); ?></td>
-                            <td><?php echo esc_html(number_format_i18n($r->guess, 2)); ?></td>
-                            <td><?php echo esc_html(ucfirst($r->hunt_status ?: 'open')); ?></td>
-                            <td><?php echo esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($r->created_at))); ?></td>
-                        </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-        <?php else: ?>
-            <p><?php esc_html_e('No guesses yet.', 'bonus-hunt-guesser'); ?></p>
-        <?php endif; ?>
-    </div>
-    
-    <?php
-    return ob_get_clean();
-});
+        ORDER BY g.id DESC",
+				$uid
+			)
+		);
+
+		ob_start();
+		?>
+	
+	<div class="bhg-box">
+		<h3><?php esc_html_e( 'Your Guesses', 'bonus-hunt-guesser' ); ?></h3>
+		
+		<?php if ( $rows ) : ?>
+			<table class="bhg-leaderboard">
+				<thead>
+					<tr>
+						<th><?php esc_html_e( 'Hunt', 'bonus-hunt-guesser' ); ?></th>
+						<th><?php esc_html_e( 'Guess', 'bonus-hunt-guesser' ); ?></th>
+						<th><?php esc_html_e( 'Status', 'bonus-hunt-guesser' ); ?></th>
+						<th><?php esc_html_e( 'Date', 'bonus-hunt-guesser' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php foreach ( $rows as $r ) : ?>
+						<tr>
+							<td><?php echo esc_html( $r->hunt_title ?: ( '#' . $r->hunt_id ) ); ?></td>
+							<td><?php echo esc_html( number_format_i18n( $r->guess, 2 ) ); ?></td>
+							<td><?php echo esc_html( ucfirst( $r->hunt_status ?: 'open' ) ); ?></td>
+							<td><?php echo esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ); ?></td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		<?php else : ?>
+			<p><?php esc_html_e( 'No guesses yet.', 'bonus-hunt-guesser' ); ?></p>
+		<?php endif; ?>
+	</div>
+	
+		<?php
+		return ob_get_clean();
+	}
+);
 
 // [bhg_winner_notifications] — winners of closed hunts
-add_shortcode('bhg_winner_notifications', function($atts) {
-    global $wpdb;
-    
-    // If winners table exists, use it; otherwise show closed hunts only
-    $winners_table = $wpdb->prefix . 'bhg_hunt_winners';
-    $table_exists = $wpdb->get_var($wpdb->prepare(
-        "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES 
-        WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s", 
-        DB_NAME, 
-        $winners_table
-    ));
-    
-    if ($table_exists) {
-        $rows = $wpdb->get_results($wpdb->prepare(
-            "SELECT h.id as hunt_id, h.title, w.user_id, w.position 
+add_shortcode(
+	'bhg_winner_notifications',
+	function ( $atts ) {
+		global $wpdb;
+
+		// If winners table exists, use it; otherwise show closed hunts only
+		$winners_table = $wpdb->prefix . 'bhg_hunt_winners';
+		$table_exists  = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES 
+        WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
+				DB_NAME,
+				$winners_table
+			)
+		);
+
+		if ( $table_exists ) {
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT h.id as hunt_id, h.title, w.user_id, w.position 
             FROM {$wpdb->prefix}bhg_bonus_hunts h 
             INNER JOIN {$wpdb->prefix}bhg_hunt_winners w ON w.hunt_id = h.id 
             WHERE h.status = %s 
-            ORDER BY h.id DESC", 
-            'closed'
-        ));
-    } else {
-        $rows = $wpdb->get_results($wpdb->prepare(
-            "SELECT id as hunt_id, title 
+            ORDER BY h.id DESC",
+					'closed'
+				)
+			);
+		} else {
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT id as hunt_id, title 
             FROM {$wpdb->prefix}bhg_bonus_hunts 
             WHERE status = %s 
-            ORDER BY id DESC", 
-            'closed'
-        ));
-    }
+            ORDER BY id DESC",
+					'closed'
+				)
+			);
+		}
 
-    ob_start(); ?>
-    
-    <div class="bhg-box">
-        <h3><?php esc_html_e('Winner Notifications', 'bonus-hunt-guesser'); ?></h3>
-        
-        <?php if ($rows): ?>
-            <ul class="bhg-list">
-            <?php foreach ($rows as $r): 
-                $u = isset($r->user_id) && $r->user_id ? get_userdata($r->user_id) : null; ?>
-                <li>
-                    <strong><?php echo esc_html($r->title ?: ('#' . $r->hunt_id)); ?></strong>
-                    
-                    <?php if ($u): ?>
-                        — <?php echo esc_html($u->display_name ?: $u->user_login); ?>
-                        <?php if (!empty($r->position)): ?>
-                            (<?php echo intval($r->position); ?>)
-                        <?php endif; ?>
-                    <?php else: ?>
-                        — <?php esc_html_e('Results pending', 'bonus-hunt-guesser'); ?>
-                    <?php endif; ?>
-                </li>
-            <?php endforeach; ?>
-            </ul>
-        <?php else: ?>
-            <p><?php esc_html_e('No winner notifications yet.', 'bonus-hunt-guesser'); ?></p>
-        <?php endif; ?>
-    </div>
-    
-    <?php
-    return ob_get_clean();
-});
+		ob_start();
+		?>
+	
+	<div class="bhg-box">
+		<h3><?php esc_html_e( 'Winner Notifications', 'bonus-hunt-guesser' ); ?></h3>
+		
+		<?php if ( $rows ) : ?>
+			<ul class="bhg-list">
+			<?php
+			foreach ( $rows as $r ) :
+				$u = isset( $r->user_id ) && $r->user_id ? get_userdata( $r->user_id ) : null;
+				?>
+				<li>
+					<strong><?php echo esc_html( $r->title ?: ( '#' . $r->hunt_id ) ); ?></strong>
+					
+					<?php if ( $u ) : ?>
+						— <?php echo esc_html( $u->display_name ?: $u->user_login ); ?>
+						<?php if ( ! empty( $r->position ) ) : ?>
+							(<?php echo intval( $r->position ); ?>)
+						<?php endif; ?>
+					<?php else : ?>
+						— <?php esc_html_e( 'Results pending', 'bonus-hunt-guesser' ); ?>
+					<?php endif; ?>
+				</li>
+			<?php endforeach; ?>
+			</ul>
+		<?php else : ?>
+			<p><?php esc_html_e( 'No winner notifications yet.', 'bonus-hunt-guesser' ); ?></p>
+		<?php endif; ?>
+	</div>
+	
+		<?php
+		return ob_get_clean();
+	}
+);

--- a/includes/upgrade/add-winners-limit.php
+++ b/includes/upgrade/add-winners-limit.php
@@ -1,9 +1,10 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
-function bhg_upgrade_add_winners_limit_column(){
+function bhg_upgrade_add_winners_limit_column() {
 	global $wpdb;
-	$hunts = $wpdb->prefix . 'bhg_bonus_hunts';
+	$hunts           = $wpdb->prefix . 'bhg_bonus_hunts';
 	$charset_collate = $wpdb->get_charset_collate();
 
 	require_once ABSPATH . 'wp-admin/includes/upgrade.php';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,12 +8,6 @@
 <file>includes</file>
 <exclude-pattern>vendor/*</exclude-pattern>
 <exclude-pattern>wpcs/*</exclude-pattern>
-<exclude-pattern>includes/helpers.php</exclude-pattern>
-<exclude-pattern>includes/shortcodes.php</exclude-pattern>
+<exclude-pattern>admin/class-bhg-demo.php</exclude-pattern>
 <exclude-pattern>includes/demo.php</exclude-pattern>
-<exclude-pattern>includes/class-bhg-shortcodes.php</exclude-pattern>
-<exclude-pattern>includes/class-bhg-models.php</exclude-pattern>
-<exclude-pattern>includes/class-bhg-db.php</exclude-pattern>
-<exclude-pattern>includes/class-bhg-ads.php</exclude-pattern>
-<exclude-pattern>admin/views/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
## Summary
- remove broad PHPCS excludes so admin and includes directories are checked
- apply WordPress coding standards fixes across admin and includes directories
- document and sanitize database interactions in data-layer models

## Testing
- `phpcs --standard=phpcs.xml --report=summary`


------
https://chatgpt.com/codex/tasks/task_e_68bce4aea33c8333a057f6862b54982e