### PR TITLE
Add timeline filters for shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Bonus Hunt Guesser
+
+## Shortcodes
+
+### `[bhg_user_guesses]`
+Display guesses submitted by a user.
+
+- `timeline`: limit results to past `day`, `week`, `month`, or `year`.
+
+### `[bhg_hunts]`
+List bonus hunts.
+
+- `timeline`: filter hunts created within the past `day`, `week`, `month`, or `year`.
+
+### `[bhg_leaderboards]`
+Show leaderboards for multiple hunts.
+
+- `timeline`: restrict hunts to those created within the past `day`, `week`, `month`, or `year`.
+
+### `[bhg_tournaments]`
+List tournaments or show details.
+
+- `timeline`: limit tournaments created within the past `day`, `week`, `month`, or `year`.
+


### PR DESCRIPTION
## Summary
- allow timeline filter (day/week/month/year) in user guesses, hunts, leaderboards, and tournaments shortcodes
- document timeline options in shortcode comments and README

## Testing
- `composer install`
- `vendor/bin/phpcs --standard=phpcs.xml includes/class-bhg-shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68bce4afe2a083338cc9dfe4d4bb0686