### PR TITLE
Use dashboard cards for recent hunts

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -20,58 +20,47 @@ if ( ! function_exists( 'bhg_get_latest_closed_hunts' ) ) {
 
 $hunts = bhg_get_latest_closed_hunts( 3 );
 ?>
-<div class="wrap">
+<div class="wrap bhg-dashboard">
   <h1><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h1>
-  <table class="widefat striped">
-	<thead>
-	  <tr>
-		<th><?php esc_html_e( 'Bonushunt', 'bonus-hunt-guesser' ); ?></th>
-		<th><?php esc_html_e( 'All Winners', 'bonus-hunt-guesser' ); ?></th>
-		<th><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
-		<th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
-		<th><?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?></th>
-	  </tr>
-	</thead>
-	<tbody>
-	  <?php if ( $hunts ) : ?>
-		<?php foreach ( $hunts as $h ) : ?>
-		  <?php
-		  $winners = function_exists( 'bhg_get_top_winners_for_hunt' )
-			  ? bhg_get_top_winners_for_hunt( $h->id, (int) $h->winners_count )
-			  : array();
-		  ?>
-		  <tr>
-			<td><?php echo esc_html( $h->title ); ?></td>
-			<td>
-			  <?php
-			  if ( $winners ) {
-				  $out = array();
-				  foreach ( $winners as $w ) {
-					  $u  = get_userdata( (int) $w->user_id );
-					  $nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
-                                          $out[] = sprintf(
-                                                  '%s %s %s (%s %s)',
-                                                  esc_html( $nm ),
-                                                  esc_html__( '—', 'bonus-hunt-guesser' ),
-                                                  esc_html( number_format_i18n( (float) $w->guess, 2 ) ),
-                                                  esc_html__( 'diff', 'bonus-hunt-guesser' ),
-                                                  esc_html( number_format_i18n( (float) $w->diff, 2 ) )
-                                          );
-				  }
-				  echo esc_html( implode( ' • ', $out ) );
-			  } else {
-				  esc_html_e( 'No winners yet', 'bonus-hunt-guesser' );
-			  }
-			  ?>
-			</td>
-			<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-                        <td><?php echo ( $h->final_balance !== null ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-                        <td><?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-		  </tr>
-		<?php endforeach; ?>
-	  <?php else : ?>
-		<tr><td colspan="5"><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></td></tr>
-	  <?php endif; ?>
-	</tbody>
-  </table>
+  <?php if ( $hunts ) : ?>
+        <div id="dashboard-widgets-wrap">
+          <div id="dashboard-widgets" class="metabox-holder">
+                <div id="postbox-container-1" class="postbox-container">
+                  <?php foreach ( $hunts as $h ) : ?>
+                        <?php
+                        $winners = function_exists( 'bhg_get_top_winners_for_hunt' )
+                                ? bhg_get_top_winners_for_hunt( $h->id, (int) $h->winners_count )
+                                : array();
+                        ?>
+                        <div class="postbox bhg-dashboard-card">
+                          <h2 class="hndle"><span><?php echo esc_html( $h->title ); ?></span></h2>
+                          <div class="inside">
+                                <ul class="bhg-dashboard-meta">
+                                  <li><strong><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?>:</strong> <?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></li>
+                                  <li><strong><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?>:</strong> <?php echo ( $h->final_balance !== null ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></li>
+                                  <li><strong><?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?>:</strong> <?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></li>
+                                </ul>
+                                <h3 class="bhg-dashboard-subtitle"><?php esc_html_e( 'Winners', 'bonus-hunt-guesser' ); ?></h3>
+                                <?php if ( $winners ) : ?>
+                                  <ul class="bhg-dashboard-winners">
+                                        <?php foreach ( $winners as $w ) : ?>
+                                          <?php
+                                          $u  = get_userdata( (int) $w->user_id );
+                                          $nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
+                                          ?>
+                                          <li><?php echo esc_html( $nm ); ?> — <?php echo esc_html( number_format_i18n( (float) $w->guess, 2 ) ); ?> (<?php esc_html_e( 'diff', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( number_format_i18n( (float) $w->diff, 2 ) ); ?>)</li>
+                                        <?php endforeach; ?>
+                                  </ul>
+                                <?php else : ?>
+                                  <p><?php esc_html_e( 'No winners yet', 'bonus-hunt-guesser' ); ?></p>
+                                <?php endif; ?>
+                          </div>
+                        </div>
+                  <?php endforeach; ?>
+                </div>
+          </div>
+        </div>
+  <?php else : ?>
+        <p><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></p>
+  <?php endif; ?>
 </div>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -48,3 +48,52 @@
 .bhg-text-center {
     text-align: center;
 }
+
+/* Dashboard styles */
+:root {
+    --bhg-accent-color: #2271b1;
+    --bhg-spacing: 16px;
+    --bhg-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+.bhg-dashboard h1 {
+    color: var(--bhg-accent-color);
+    font-family: var(--bhg-font-family);
+    margin-bottom: var(--bhg-spacing);
+}
+
+.bhg-dashboard-card {
+    font-family: var(--bhg-font-family);
+}
+
+.bhg-dashboard-card .hndle {
+    background: var(--bhg-accent-color);
+    color: #fff;
+    padding: 12px 16px;
+    margin: 0;
+}
+
+.bhg-dashboard-card .inside {
+    padding: var(--bhg-spacing);
+}
+
+.bhg-dashboard-meta {
+    list-style: none;
+    margin: 0 0 12px;
+    padding: 0;
+}
+
+.bhg-dashboard-subtitle {
+    margin: 0 0 8px;
+    color: var(--bhg-accent-color);
+    font-size: 14px;
+}
+
+.bhg-dashboard-winners {
+    margin: 0;
+    padding-left: 20px;
+}
+
+.bhg-dashboard-winners li {
+    margin-bottom: 4px;
+}


### PR DESCRIPTION
## Summary
- Present latest bonus hunts as WordPress dashboard cards with winners and balances
- Add admin dashboard typography, spacing, and accent color variables

## Testing
- `composer install`
- `composer phpcs` *(fails: Use placeholders and $wpdb->prepare(); found interpolated variable $guesses_table)*

------
https://chatgpt.com/codex/tasks/task_e_68bce4b401288333b9bd73711e12108e