### PR TITLE
Remove duplicated settings save handler in admin class

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -31,7 +31,6 @@ class BHG_Admin {
 		add_action( 'admin_post_bhg_tournament_save', array( $this, 'handle_save_tournament' ) );
 		add_action( 'admin_post_bhg_save_affiliate', array( $this, 'handle_save_affiliate' ) );
 		add_action( 'admin_post_bhg_delete_affiliate', array( $this, 'handle_delete_affiliate' ) );
-		add_action( 'admin_post_bhg_save_settings', array( $this, 'handle_save_settings' ) );
 		add_action( 'admin_post_bhg_save_user_meta', array( $this, 'handle_save_user_meta' ) );
 	}
 
@@ -491,25 +490,6 @@ class BHG_Admin {
 			$wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
 		}
 		wp_safe_redirect( admin_url( 'admin.php?page=bhg-affiliates' ) );
-		exit;
-	}
-
-	/**
-	 * Save plugin settings.
-	 */
-	public function handle_save_settings() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
-		}
-		check_admin_referer( 'bhg_save_settings' );
-		$opts = array(
-			'allow_guess_edit_until_close' => isset( $_POST['allow_guess_edit_until_close'] ) ? 'yes' : 'no',
-			'guesses_max'                  => isset( $_POST['guesses_max'] ) ? max( 1, absint( wp_unslash( $_POST['guesses_max'] ) ) ) : 1,
-		);
-		foreach ( $opts as $k => $v ) {
-			update_option( 'bhg_' . $k, $v, false );
-		}
-		wp_safe_redirect( admin_url( 'admin.php?page=bhg-settings&updated=1' ) );
 		exit;
 	}
 


### PR DESCRIPTION
## Summary
- delegate settings save handling to global function `bhg_handle_settings_save`
- drop duplicate `admin_post_bhg_save_settings` hook and method from admin class

## Testing
- `vendor/bin/phpcs -n --standard=phpcs.xml admin/class-bhg-admin.php`

------
https://chatgpt.com/codex/tasks/task_e_68bcec3d399c83339bd2127366f5c2c1