### PR TITLE
Convert dashboard to card layout and refine admin styling

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -27,106 +27,98 @@ if ( ! function_exists( 'bhg_get_latest_closed_hunts' ) ) {
 $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect array of objects with: id, title, starting_balance, final_balance, winners_count, closed_at.
 ?>
 <div class="wrap bhg-dashboard">
-	<h1><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h1>
+<h1><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h1>
 
-	<table class="widefat striped">
-		<thead>
-			<tr>
-				<th><?php esc_html_e( 'Bonushunt', 'bonus-hunt-guesser' ); ?></th>
-				<th><?php esc_html_e( 'All Winners', 'bonus-hunt-guesser' ); ?></th>
-				<th><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
-				<th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
-				<th><?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?></th>
-			</tr>
-		</thead>
-		<tbody>
-		<?php if ( ! empty( $hunts ) && is_array( $hunts ) ) : ?>
-			<?php foreach ( $hunts as $h ) : ?>
+<div class="dashboard-widgets">
+<?php if ( ! empty( $hunts ) && is_array( $hunts ) ) : ?>
+	<?php foreach ( $hunts as $h ) : ?>
+		<?php
+		$hunt_id       = isset( $h->id ) ? (int) $h->id : 0;
+		$winners_count = isset( $h->winners_count ) ? (int) $h->winners_count : 0;
+		$winners       = array();
+
+		if ( $hunt_id && function_exists( 'bhg_get_top_winners_for_hunt' ) ) {
+			$winners = bhg_get_top_winners_for_hunt( $hunt_id, $winners_count );
+			if ( ! is_array( $winners ) ) {
+				$winners = array();
+			}
+		}
+		?>
+<div class="card bhg-dashboard-card">
+<h2 class="hndle"><?php echo isset( $h->title ) ? esc_html( (string) $h->title ) : esc_html__( '(untitled)', 'bonus-hunt-guesser' ); ?></h2>
+<div class="inside">
+		<?php if ( ! empty( $winners ) ) : ?>
+<p class="bhg-dashboard-subtitle"><?php esc_html_e( 'All Winners', 'bonus-hunt-guesser' ); ?></p>
+<ul class="bhg-dashboard-winners">
+			<?php foreach ( $winners as $w ) : ?>
 				<?php
-				$hunt_id        = isset( $h->id ) ? (int) $h->id : 0;
-				$winners_count  = isset( $h->winners_count ) ? (int) $h->winners_count : 0;
-				$winners        = array();
+				$user_id = isset( $w->user_id ) ? (int) $w->user_id : 0;
+				$guess   = isset( $w->guess ) ? (float) $w->guess : 0.0;
+				$diff    = isset( $w->diff ) ? (float) $w->diff : 0.0;
 
-				if ( $hunt_id && function_exists( 'bhg_get_top_winners_for_hunt' ) ) {
-					$winners = bhg_get_top_winners_for_hunt( $hunt_id, $winners_count );
-					if ( ! is_array( $winners ) ) {
-						$winners = array();
-					}
-				}
+				$u  = $user_id ? get_userdata( $user_id ) : false;
+				$nm = $u ? $u->user_login : sprintf(
+				/* translators: %d: user ID. */
+					esc_html__( 'User #%d', 'bonus-hunt-guesser' ),
+					$user_id
+				);
+
+				$label = sprintf(
+					'%1$s %2$s %3$s (%4$s %5$s)',
+					esc_html( $nm ),
+					esc_html_x( '—', 'name/guess separator', 'bonus-hunt-guesser' ),
+					esc_html( number_format_i18n( $guess, 2 ) ),
+					esc_html__( 'diff', 'bonus-hunt-guesser' ),
+					esc_html( number_format_i18n( $diff, 2 ) )
+				);
 				?>
-				<tr>
-					<td><?php echo isset( $h->title ) ? esc_html( (string) $h->title ) : esc_html__( '(untitled)', 'bonus-hunt-guesser' ); ?></td>
-					<td>
-						<?php
-						if ( ! empty( $winners ) ) {
-							$out = array();
-							foreach ( $winners as $w ) {
-								$user_id = isset( $w->user_id ) ? (int) $w->user_id : 0;
-								$guess   = isset( $w->guess ) ? (float) $w->guess : 0.0;
-								$diff    = isset( $w->diff ) ? (float) $w->diff : 0.0;
-
-								$u  = $user_id ? get_userdata( $user_id ) : false;
-								$nm = $u ? $u->user_login : sprintf(
-									/* translators: %d: user ID. */
-									esc_html__( 'User #%d', 'bonus-hunt-guesser' ),
-									$user_id
-								);
-
-								// Build a plain-text, safely escaped chunk: "name — 1,234.00 (diff 12.34)".
-								$out[] = sprintf(
-									'%1$s %2$s %3$s (%4$s %5$s)',
-									esc_html( $nm ),
-									esc_html_x( '—', 'name/guess separator', 'bonus-hunt-guesser' ),
-									esc_html( number_format_i18n( $guess, 2 ) ),
-									esc_html__( 'diff', 'bonus-hunt-guesser' ),
-									esc_html( number_format_i18n( $diff, 2 ) )
-								);
-							}
-							echo esc_html( implode( ' • ', $out ) );
-						} else {
-							esc_html_e( 'No winners yet', 'bonus-hunt-guesser' );
-						}
-						?>
-					</td>
-					<td>
-						<?php
-						$start = isset( $h->starting_balance ) ? (float) $h->starting_balance : 0.0;
-						echo esc_html( number_format_i18n( $start, 2 ) );
-						?>
-					</td>
-					<td>
-						<?php
-						if ( isset( $h->final_balance ) && null !== $h->final_balance ) {
-							echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
-						} else {
-							esc_html_e( '—', 'bonus-hunt-guesser' );
-						}
-						?>
-					</td>
-					<td>
-						<?php
-						if ( ! empty( $h->closed_at ) ) {
-							$ts = strtotime( (string) $h->closed_at );
-							echo esc_html(
-								false !== $ts
-									? date_i18n(
-										get_option( 'date_format' ) . ' ' . get_option( 'time_format' ),
-										$ts
-									)
-									: (string) $h->closed_at
-							);
-						} else {
-							esc_html_e( '—', 'bonus-hunt-guesser' );
-						}
-						?>
-					</td>
-				</tr>
-			<?php endforeach; ?>
-		<?php else : ?>
-			<tr>
-				<td colspan="5"><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></td>
-			</tr>
-		<?php endif; ?>
-		</tbody>
-	</table>
+<li><?php echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></li>
+<?php endforeach; ?>
+</ul>
+<?php else : ?>
+<p><?php esc_html_e( 'No winners yet', 'bonus-hunt-guesser' ); ?></p>
+<?php endif; ?>
+<ul class="bhg-dashboard-meta">
+<li><strong><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?>:</strong>
+		<?php
+		$start = isset( $h->starting_balance ) ? (float) $h->starting_balance : 0.0;
+		echo esc_html( number_format_i18n( $start, 2 ) );
+		?>
+</li>
+<li><strong><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?>:</strong>
+		<?php
+		if ( isset( $h->final_balance ) && null !== $h->final_balance ) {
+			echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
+		} else {
+			esc_html_e( '—', 'bonus-hunt-guesser' );
+		}
+		?>
+</li>
+<li><strong><?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?>:</strong>
+		<?php
+		if ( ! empty( $h->closed_at ) ) {
+			$ts = strtotime( (string) $h->closed_at );
+			echo esc_html(
+				false !== $ts
+				? date_i18n(
+					get_option( 'date_format' ) . ' ' . get_option( 'time_format' ),
+					$ts
+				)
+				: (string) $h->closed_at
+			);
+		} else {
+			esc_html_e( '—', 'bonus-hunt-guesser' );
+		}
+		?>
+</li>
+</ul>
+</div>
+</div>
+	<?php endforeach; ?>
+<?php else : ?>
+<div class="card bhg-dashboard-card">
+<h2 class="hndle"><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></h2>
+</div>
+<?php endif; ?>
+</div>
 </div>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -97,3 +97,27 @@
 .bhg-dashboard-winners li {
     margin-bottom: 4px;
 }
+
+/* Enhanced dashboard layout */
+.bhg-dashboard .dashboard-widgets {
+    display: grid;
+    grid-template-columns: repeat(auto-fill,minmax(260px,1fr));
+    gap: var(--bhg-spacing);
+}
+
+.bhg-dashboard-card {
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    line-height: 1.5;
+    font-size: 14px;
+}
+
+.bhg-dashboard-meta li + li {
+    margin-top: 4px;
+}
+
+.bhg-dashboard-meta strong {
+    color: var(--bhg-accent-color);
+}
+


### PR DESCRIPTION
## Summary
- Render latest hunts using WordPress card widgets with winner lists and meta details
- Improve admin styles with better typography, spacing and color accents

## Testing
- `vendor/bin/phpcs -v --standard=phpcs.xml admin/views/dashboard.php`
- `vendor/bin/phpcs -v --standard=phpcs.xml assets/css/admin.css` *(no files in queue)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf1f93f808333aee8d60844fb84b7