### PR TITLE
Add ranking and field filtering to leaderboards shortcode

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -32,20 +32,20 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			// Legacy/aliases
 			add_shortcode( 'bonus_hunt_leaderboard', array( $this, 'leaderboard_shortcode' ) );
 			add_shortcode( 'bonus_hunt_login', array( $this, 'login_hint_shortcode' ) );
-                        add_shortcode( 'bhg_active', array( $this, 'active_hunt_shortcode' ) );
+			 add_shortcode( 'bhg_active', array( $this, 'active_hunt_shortcode' ) );
                 }
 
                 private function sanitize_table( $table ) {
-                        global $wpdb;
-                        $allowed = array(
-                                $wpdb->prefix . 'bhg_bonus_hunts',
-                                $wpdb->prefix . 'bhg_guesses',
-                                $wpdb->prefix . 'bhg_tournaments',
-                                $wpdb->prefix . 'bhg_tournament_results',
-                                $wpdb->prefix . 'bhg_affiliates',
-                                $wpdb->users,
-                        );
-                        return in_array( $table, $allowed, true ) ? esc_sql( $table ) : '';
+			 global $wpdb;
+			 $allowed = array(
+			         $wpdb->prefix . 'bhg_bonus_hunts',
+			         $wpdb->prefix . 'bhg_guesses',
+			         $wpdb->prefix . 'bhg_tournaments',
+			         $wpdb->prefix . 'bhg_tournament_results',
+			         $wpdb->prefix . 'bhg_affiliates',
+			         $wpdb->users,
+			 );
+			 return in_array( $table, $allowed, true ) ? esc_sql( $table ) : '';
                 }
 
                 /** Minimal login hint used by some themes */
@@ -63,15 +63,15 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 
 		/** [bhg_active_hunt] — list all open hunts */
 		public function active_hunt_shortcode( $atts ) {
-                        global $wpdb;
-                        $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-                        $hunts       = $wpdb->get_results(
-                                $wpdb->prepare(
-                                        "SELECT * FROM {$hunts_table} WHERE status = %s ORDER BY created_at DESC" // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-                                        ,
-                                        'open'
-                                )
-                        );
+			 global $wpdb;
+			$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			 $hunts       = $wpdb->get_results(
+			         $wpdb->prepare(
+			                 "SELECT * FROM {$hunts_table} WHERE status = %s ORDER BY created_at DESC" // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			                 ,
+			                 'open'
+			         )
+			 );
 
 			if ( ! $hunts ) {
 				return '<div class="bhg-active-hunt"><p>' . esc_html__( 'No active bonus hunts at the moment.', 'bonus-hunt-guesser' ) . '</p></div>';
@@ -116,9 +116,9 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					. '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
 			}
 
-                        global $wpdb;
-                        $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-                        $open_hunts  = $wpdb->get_results( "SELECT id, title FROM {$hunts_table} WHERE status='open' ORDER BY created_at DESC" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			 global $wpdb;
+			 $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			 $open_hunts  = $wpdb->get_results( "SELECT id, title FROM {$hunts_table} WHERE status='open' ORDER BY created_at DESC" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 			if ( $hunt_id <= 0 ) {
 				if ( ! $open_hunts ) {
@@ -129,10 +129,10 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				}
 			}
 
-                        $user_id        = get_current_user_id();
-                        $table          = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
-                        $existing_id    = $hunt_id > 0 ? (int) $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$table} WHERE user_id=%d AND hunt_id=%d", $user_id, $hunt_id ) ) : 0; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-                        $existing_guess = $existing_id ? (float) $wpdb->get_var( $wpdb->prepare( "SELECT guess FROM {$table} WHERE id=%d", $existing_id ) ) : ''; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			 $user_id        = get_current_user_id();
+			 $table          = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
+			 $existing_id    = $hunt_id > 0 ? (int) $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$table} WHERE user_id=%d AND hunt_id=%d", $user_id, $hunt_id ) ) : 0; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			 $existing_guess = $existing_id ? (float) $wpdb->get_var( $wpdb->prepare( "SELECT guess FROM {$table} WHERE id=%d", $existing_id ) ) : ''; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 			$settings = get_option( 'bhg_plugin_settings' );
 			$min      = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
@@ -174,32 +174,37 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			return ob_get_clean();
 		}
 
-		/** [bhg_leaderboard] */
-		public function leaderboard_shortcode( $atts ) {
+/**
+ * [bhg_leaderboard]
+ * Supports ranking (1-10) and fields (comma-separated list).
+ */
+public function leaderboard_shortcode( $atts ) {
 			$a = shortcode_atts(
-				array(
-					'hunt_id'  => 0,
-					'orderby'  => 'guess', // guess|user|position
-					'order'    => 'ASC',
-					'page'     => 1,
-					'per_page' => 20,
-				),
-				$atts,
-				'bhg_leaderboard'
+			        array(
+			                'hunt_id'  => 0,
+			                'orderby'  => 'guess', // guess|user|position
+			                'order'    => 'ASC',
+			                'page'     => 1,
+			                'per_page' => 20,
+			                'ranking'  => 0, // top N results
+			                'fields'   => 'position,user,guess',
+			        ),
+			        $atts,
+			        'bhg_leaderboard'
 			);
 
-                        global $wpdb;
-                        $hunt_id = (int) $a['hunt_id'];
-                        if ( $hunt_id <= 0 ) {
-                                $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-                                $hunt_id     = (int) $wpdb->get_var( "SELECT id FROM {$hunts_table} ORDER BY created_at DESC LIMIT 1" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-                                if ( $hunt_id <= 0 ) {
-                                        return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
-                                }
-                        }
+			 global $wpdb;
+			 $hunt_id = (int) $a['hunt_id'];
+			 if ( $hunt_id <= 0 ) {
+			         $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			         $hunt_id     = (int) $wpdb->get_var( "SELECT id FROM {$hunts_table} ORDER BY created_at DESC LIMIT 1" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			         if ( $hunt_id <= 0 ) {
+			                 return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
+			         }
+			 }
 
-                        $g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
-                        $u = $this->sanitize_table( $wpdb->users );
+			 $g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
+			 $u = $this->sanitize_table( $wpdb->users );
 
 			$order       = ( strtoupper( $a['order'] ) === 'DESC' ) ? 'DESC' : 'ASC';
 			$map         = array(
@@ -213,25 +218,42 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			$per         = max( 1, (int) $a['per_page'] );
 			$offset      = ( $page - 1 ) * $per;
 
-                        $total = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$g} WHERE hunt_id=%d", $hunt_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			if ( $total < 1 ) {
-				return '<p>' . esc_html__( 'No guesses yet.', 'bonus-hunt-guesser' ) . '</p>';
+			$ranking = max( 0, min( 10, (int) $a['ranking'] ) );
+			if ( $ranking > 0 ) {
+			        $per    = $ranking;
+			        $page   = 1;
+			        $offset = 0;
 			}
 
-                        $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-                        $rows        = $wpdb->get_results(
-                                $wpdb->prepare(
-                                        "SELECT g.*, u.user_login, h.affiliate_site_id
-                                         FROM {$g} g
-                                         LEFT JOIN {$u} u ON u.ID = g.user_id
-                                         LEFT JOIN {$hunts_table} h ON h.id = g.hunt_id
-                                         WHERE g.hunt_id=%d
-                                         ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d",
-                                        $hunt_id,
-                                        $per,
-                                        $offset
-                                )
-                        ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$fields_raw    = explode( ',', (string) $a['fields'] );
+			$allowed_field = array( 'position', 'user', 'guess' );
+			$fields        = array_values( array_intersect( $allowed_field, array_map( 'sanitize_key', array_map( 'trim', $fields_raw ) ) ) );
+			if ( empty( $fields ) ) {
+			        $fields = $allowed_field;
+			}
+
+			$total = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$g} WHERE hunt_id=%d", $hunt_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			if ( $total < 1 ) {
+			        return '<p>' . esc_html__( 'No guesses yet.', 'bonus-hunt-guesser' ) . '</p>';
+			}
+			if ( $ranking > 0 && $total > $ranking ) {
+			        $total = $ranking;
+			}
+
+			 $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			 $rows        = $wpdb->get_results(
+			         $wpdb->prepare(
+			                 "SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id
+			                  FROM {$g} g
+			                  LEFT JOIN {$u} u ON u.ID = g.user_id
+			                  LEFT JOIN {$hunts_table} h ON h.id = g.hunt_id
+			                  WHERE g.hunt_id=%d
+			                  ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d",
+			                 $hunt_id,
+			                 $per,
+			                 $offset
+			         )
+			 ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 			wp_enqueue_style(
 				'bhg-shortcodes',
@@ -243,32 +265,47 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			ob_start();
 			echo '<table class="bhg-leaderboard">';
 			echo '<thead><tr>';
-			echo '<th class="sortable" data-column="position">' . esc_html__( 'Position', 'bonus-hunt-guesser' ) . '</th>';
-			echo '<th class="sortable" data-column="user">' . esc_html__( 'User', 'bonus-hunt-guesser' ) . '</th>';
-			echo '<th class="sortable" data-column="guess">' . esc_html__( 'Guess', 'bonus-hunt-guesser' ) . '</th>';
+			foreach ( $fields as $field ) {
+			        if ( 'position' === $field ) {
+			                echo '<th class="sortable" data-column="position">' . esc_html__( 'Position', 'bonus-hunt-guesser' ) . '</th>';
+			        } elseif ( 'user' === $field ) {
+			                echo '<th class="sortable" data-column="user">' . esc_html__( 'User', 'bonus-hunt-guesser' ) . '</th>';
+			        } elseif ( 'guess' === $field ) {
+			                echo '<th class="sortable" data-column="guess">' . esc_html__( 'Guess', 'bonus-hunt-guesser' ) . '</th>';
+			        }
+			}
 			echo '</tr></thead><tbody>';
 
-			$pos = $offset + 1;
+			$pos       = $offset + 1;
+			$need_user = in_array( 'user', $fields, true );
 			foreach ( $rows as $r ) {
-				$site_id = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
-				$is_aff  = $site_id > 0
-					? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
-					: (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
+			        if ( $need_user ) {
+			                $site_id    = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
+			                $is_aff     = $site_id > 0
+			                        ? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
+			                        : (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
+			                $aff        = $is_aff ? 'green' : 'red';
+			                /* translators: %d: user ID. */
+			                $user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
+			        }
 
-				$aff     = $is_aff ? 'green' : 'red';
-				/* translators: %d: user ID. */
-				$user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
-
-				echo '<tr>';
-				echo '<td data-column="position">' . (int) $pos++ . '</td>';
-				echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $this->render_affiliate_dot( $aff ) . '</td>';
-				echo '<td data-column="guess">' . esc_html( number_format_i18n( (float) $r->guess, 2 ) ) . '</td>';
-				echo '</tr>';
+			        echo '<tr>';
+			        foreach ( $fields as $field ) {
+			                if ( 'position' === $field ) {
+			                        echo '<td data-column="position">' . (int) $pos . '</td>';
+			                } elseif ( 'user' === $field ) {
+			                        echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $this->render_affiliate_dot( $aff ) . '</td>';
+			                } elseif ( 'guess' === $field ) {
+			                        echo '<td data-column="guess">' . esc_html( number_format_i18n( (float) $r->guess, 2 ) ) . '</td>';
+			                }
+			        }
+			        echo '</tr>';
+			        $pos++;
 			}
 			echo '</tbody></table>';
 
 			$pages = (int) ceil( $total / $per );
-			if ( $pages > 1 ) {
+			if ( $pages > 1 && 0 === $ranking ) {
 				$raw  = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : home_url( '/' );
 				$base = esc_url_raw( remove_query_arg( 'page', wp_validate_redirect( $raw, home_url( '/' ) ) ) );
 				echo '<div class="bhg-pagination">';
@@ -313,8 +350,8 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				return '<p>' . esc_html__( 'No user specified.', 'bonus-hunt-guesser' ) . '</p>';
 			}
 
-                        $g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
-                        $h = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			 $g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
+			 $h = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
 
 			$where  = array( 'g.user_id = %d' );
 			$params = array( $user_id );
@@ -362,7 +399,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					WHERE " . implode( ' AND ', $where ) . "
 					ORDER BY {$orderby} {$order}{$limit_sql}";
 
-                        $rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			 $rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			if ( ! $rows ) {
 				return '<p>' . esc_html__( 'No guesses found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
@@ -415,9 +452,9 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				'bhg_hunts'
 			);
 
-                        global $wpdb;
-                        $h         = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-                        $aff_table = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliates' );
+			 global $wpdb;
+			 $h         = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			 $aff_table = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliates' );
 
 			$where  = array();
 			$params = array();
@@ -465,7 +502,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				$sql .= ' LIMIT 10';
 			}
 
-                        $rows = $params ? $wpdb->get_results( $wpdb->prepare( $sql, $params ) ) : $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			 $rows = $params ? $wpdb->get_results( $wpdb->prepare( $sql, $params ) ) : $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			if ( ! $rows ) {
 				return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
@@ -498,26 +535,31 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			return ob_get_clean();
 		}
 
-		/**
-		 * [bhg_leaderboards] — show multiple hunts’ leaderboards.
-		 * id (hunt), status, website, timeline (''|'recent'|day|week|month|year)
-		 * aff yes/no (render affiliate dots)
-		 */
+               /**
+                * [bhg_leaderboards] — show multiple hunts’ leaderboards.
+                * id (hunt), status, website, timeline (''|'recent'|day|week|month|year)
+                * aff yes/no (render affiliate dots)
+                * ranking 1-10, fields (comma-separated list)
+                */
 		public function leaderboards_shortcode( $atts ) {
 			$a = shortcode_atts(
-				array(
-					'id'       => 0,
-					'aff'      => 'yes',
-					'website'  => 0,
-					'status'   => '',
-					'timeline' => '',
-				),
-				$atts,
-				'bhg_leaderboards'
+			        array(
+			                'id'       => 0,
+			                'aff'      => 'yes',
+			                'website'  => 0,
+			                'status'   => '',
+			                'timeline' => '',
+			                'ranking'  => 0,
+			                'fields'   => 'position,user,guess',
+			        ),
+			        $atts,
+			        'bhg_leaderboards'
 			);
 
-                        global $wpdb;
-                        $h = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			global $wpdb;
+			$h       = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			$ranking = max( 0, min( 10, (int) $a['ranking'] ) );
+			$fields  = (string) $a['fields'];
 
 			$where  = array();
 			$params = array();
@@ -563,7 +605,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				$sql .= ' LIMIT 5';
 			}
 
-                        $hunts = $params ? $wpdb->get_results( $wpdb->prepare( $sql, $params ) ) : $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$hunts = $params ? $wpdb->get_results( $wpdb->prepare( $sql, $params ) ) : $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			if ( ! $hunts ) {
 				return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
@@ -574,7 +616,13 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			foreach ( $hunts as $hunt ) {
 				echo '<div class="bhg-leaderboard-wrap">';
 				echo '<h3>' . esc_html( $hunt->title ) . '</h3>';
-				$html = $this->leaderboard_shortcode( array( 'hunt_id' => (int) $hunt->id ) );
+				$html = $this->leaderboard_shortcode(
+					array(
+						'hunt_id' => (int) $hunt->id,
+						'ranking' => $ranking,
+						'fields'  => $fields,
+					)
+				);
 				if ( ! $show_aff ) {
 					// Strip affiliate dot spans if requested
 					$html = preg_replace( '/<span class="bhg-aff-dot[^>]*><\/span>/', '', $html );
@@ -607,16 +655,16 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			// Details screen
 			$details_id = isset( $_GET['bhg_tournament_id'] ) ? absint( wp_unslash( $_GET['bhg_tournament_id'] ) ) : 0;
 			if ( $details_id > 0 ) {
-                                $t = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
-                                $r = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
-                                $u = $this->sanitize_table( $wpdb->users );
+			         $t = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
+			         $r = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
+			         $u = $this->sanitize_table( $wpdb->users );
 
-                                $tournament = $wpdb->get_row(
-                                        $wpdb->prepare(
-                                                "SELECT id, type, start_date, end_date, status FROM {$t} WHERE id=%d",
-                                                $details_id
-                                        )
-                                ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			         $tournament = $wpdb->get_row(
+			                 $wpdb->prepare(
+			                         "SELECT id, type, start_date, end_date, status FROM {$t} WHERE id=%d",
+			                         $details_id
+			                 )
+			         ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				if ( ! $tournament ) {
 					return '<p>' . esc_html__( 'Tournament not found.', 'bonus-hunt-guesser' ) . '</p>';
 				}
@@ -637,16 +685,16 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				}
 				$order_by_sql = $allowed[ $orderby ] . ' ' . strtoupper( $order );
 
-                                $rows = $wpdb->get_results(
-                                        $wpdb->prepare(
-                                                "SELECT r.user_id, r.wins, r.last_win_date, u.user_login
-                                                 FROM {$r} r
-                                                 INNER JOIN {$u} u ON u.ID = r.user_id
-                                                 WHERE r.tournament_id=%d
-                                                 ORDER BY {$order_by_sql}, r.user_id ASC",
-                                                $tournament->id
-                                        )
-                                ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			         $rows = $wpdb->get_results(
+			                 $wpdb->prepare(
+			                         "SELECT r.user_id, r.wins, r.last_win_date, u.user_login
+			                          FROM {$r} r
+			                          INNER JOIN {$u} u ON u.ID = r.user_id
+			                          WHERE r.tournament_id=%d
+			                          ORDER BY {$order_by_sql}, r.user_id ASC",
+			                         $tournament->id
+			                 )
+			         ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 				$base   = remove_query_arg( array( 'orderby', 'order' ) );
 				$toggle = function ( $key ) use ( $orderby, $order, $base ) {
@@ -717,7 +765,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				'bhg_tournaments'
 			);
 
-                        $t          = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
+			 $t          = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
 			$where      = array();
 			$args       = array();
 
@@ -762,7 +810,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			}
 			$sql .= ' ORDER BY start_date DESC, id DESC';
 
-                        $rows = $args ? $wpdb->get_results( $wpdb->prepare( $sql, $args ) ) : $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			 $rows = $args ? $wpdb->get_results( $wpdb->prepare( $sql, $args ) ) : $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			if ( ! $rows ) {
 				return '<p>' . esc_html__( 'No tournaments found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
@@ -978,8 +1026,8 @@ $wpdb->prepare(
 							ORDER BY total_wins DESC, u.user_login ASC
 							LIMIT 50";
 					array_unshift( $params, $sql );
-                                        $prepared        = call_user_func_array( array( $wpdb, 'prepare' ), $params );
-                                        $results[ $key ] = $wpdb->get_results( $prepared ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			                 $prepared        = call_user_func_array( array( $wpdb, 'prepare' ), $params );
+			                 $results[ $key ] = $wpdb->get_results( $prepared ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 				} else {
 					$sql             = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
 							FROM {$wins_tbl} r
@@ -987,7 +1035,7 @@ $wpdb->prepare(
 							GROUP BY u.ID, u.user_login
 							ORDER BY total_wins DESC, u.user_login ASC
 							LIMIT 50";
-                                        $results[ $key ] = $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			                 $results[ $key ] = $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 				}
 			}
 


### PR DESCRIPTION
## Summary
- extend leaderboard shortcode to support `ranking` and `fields` arguments
- forward ranking and column selection through leaderboards wrapper

## Testing
- `composer phpcs` *(fails: Missing doc comment for function bhg_remove_guess; Missing file doc comment in class-bhg-logger.php; Missing doc comment for class BHG_Logger; Missing doc comment for function info(); Missing doc comment for function error())*

------
https://chatgpt.com/codex/tasks/task_e_68bcf85da518833398d9560a40e1d9cd