### PR TITLE
refactor: tighten phpcs ruleset

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --no-progress
       - name: Run PHPCS
-        run: composer phpcs
+        run: vendor/bin/phpcs --standard=phpcs.xml

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,11 +4,8 @@
 <rule ref="WordPress"/>
 <arg name="tab-width" value="4"/>
 <arg name="extensions" value="php"/>
-<file>admin</file>
-<file>includes</file>
 <file>bonus-hunt-guesser.php</file>
-<exclude-pattern>vendor/*</exclude-pattern>
-<exclude-pattern>wpcs/*</exclude-pattern>
-<exclude-pattern>admin/class-bhg-demo.php</exclude-pattern>
-<exclude-pattern>includes/demo.php</exclude-pattern>
+<file>admin/</file>
+<file>includes/</file>
+<file>uninstall.php</file>
 </ruleset>


### PR DESCRIPTION
## Summary
- explicitly list plugin files in `phpcs.xml`
- update workflow to run `phpcs` against the custom ruleset

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml --report=summary | tail -n 9`

------
https://chatgpt.com/codex/tasks/task_e_68bd01f198b88333a22db93fa4f0685b