### PR TITLE
Sanitize leaderboard fields selection

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -581,9 +581,16 @@ public function leaderboard_shortcode( $atts ) {
 			);
 
 			global $wpdb;
-			$h       = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-			$ranking = max( 0, min( 10, (int) $a['ranking'] ) );
-			$fields  = (string) $a['fields'];
+                        $h       = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+                        $ranking = max( 0, min( 10, (int) $a['ranking'] ) );
+
+                        $fields_raw    = explode( ',', (string) $a['fields'] );
+                        $allowed_field = array( 'position', 'user', 'guess' );
+                        $fields_arr    = array_values( array_intersect( $allowed_field, array_map( 'sanitize_key', array_map( 'trim', $fields_raw ) ) ) );
+                        if ( empty( $fields_arr ) ) {
+                                $fields_arr = $allowed_field;
+                        }
+                        $fields = implode( ',', $fields_arr );
 
 			$where  = array();
 			$params = array();


### PR DESCRIPTION
## Summary
- Sanitize `ranking` and `fields` attributes for `[bhg_leaderboards]` shortcode
- Restrict column output to allowed list and pass selection to leaderboard renderer

## Testing
- `composer install`
- `composer phpcs includes/class-bhg-shortcodes.php` *(fails: FOUND 350 ERRORS AND 192 WARNINGS AFFECTING 286 LINES)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0859a52c8333bbda317dc323eb37