### PR TITLE
Add missing guess range translation and improve seeding

### DIFF
--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -9,8 +9,8 @@ if ( ! current_user_can( 'manage_options' ) ) {
 global $wpdb;
 $table = $wpdb->prefix . 'bhg_translations';
 
-if ( function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
-	bhg_seed_default_translations_if_empty();
+if ( function_exists( 'bhg_seed_default_translations' ) ) {
+       bhg_seed_default_translations();
 }
 
 $default_translations = function_exists( 'bhg_get_default_translations' ) ? bhg_get_default_translations() : array();

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -188,7 +188,7 @@ function bhg_activate_plugin() {
 
 	bhg_create_tables();
 
-        bhg_seed_default_translations_if_empty();
+       bhg_seed_default_translations();
 
 		// Set default options.
 	add_option( 'bhg_version', BHG_VERSION );

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -429,11 +429,12 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'period'                                       => 'Period:',
 			'placement'                                    => 'Placement',
 			'please_enter_a_guess'                         => 'Please enter a guess.',
-			'guess_required'                               => 'Please enter a guess.',
-			'please_enter_a_valid_number'                  => 'Please enter a valid number.',
-			'guess_numeric'                                => 'Please enter a valid number.',
-			'guess_submitted'                              => 'Your guess has been submitted!',
-			'ajax_error'                                   => 'An error occurred. Please try again.',
+                        'guess_required'                               => 'Please enter a guess.',
+                        'please_enter_a_valid_number'                  => 'Please enter a valid number.',
+                        'guess_numeric'                                => 'Please enter a valid number.',
+                        'guess_range'                                  => 'Guess must be between %1$s and %2$s.',
+                        'guess_submitted'                              => 'Your guess has been submitted!',
+                        'ajax_error'                                   => 'An error occurred. Please try again.',
 			'profile'                                      => 'Profile',
 			'reminder_assign_your_bhg_menus_adminmoderator_loggedin_guest_under_appearance_menus_manage_locations_use_shortcode_bhgnav_to_display' => 'Reminder: Assign your BHG menus (Admin/Moderator, Logged-in, Guest) under Appearance → Menus → Manage Locations. Use shortcode [bhg_nav] to display.',
 			'remove'                                       => 'Remove',
@@ -493,13 +494,13 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 	}
 }
 
-if ( ! function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
-	/**
-		* Seed default translations, avoiding duplicate entries.
-		*
-		* @return void
-		*/
-	function bhg_seed_default_translations_if_empty() {
+if ( ! function_exists( 'bhg_seed_default_translations' ) ) {
+       /**
+                * Seed default translations, inserting any missing keys.
+                *
+                * @return void
+                */
+       function bhg_seed_default_translations() {
 		global $wpdb;
 
 		$table = $wpdb->prefix . 'bhg_translations';
@@ -527,8 +528,8 @@ if ( ! function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
 					),
 					array( '%s', '%s', '%s' )
 				);
-			}
-		}
+       }
+}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `guess_range` default translation used by frontend validation
- rename seeding helper to `bhg_seed_default_translations` and call it on activation and translations admin page

## Testing
- `composer phpcs` *(fails: many existing coding standard issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0fb0142883338bc79a39b447d4ef