### PR TITLE
chore: apply WordPress coding style

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -1,22 +1,22 @@
 <?php
 /**
-	* Admin functionality for Bonus Hunt Guesser.
-	*
-	* @package Bonus_Hunt_Guesser
-	*/
+ * Admin functionality for Bonus Hunt Guesser.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 		exit;
 }
 
 /**
-	* Handles admin screens and actions for the plugin.
-	*/
+ * Handles admin screens and actions for the plugin.
+ */
 class BHG_Admin {
 
 	/**
-		* Initialize admin hooks and actions.
-		*/
+	 * Initialize admin hooks and actions.
+	 */
 	public function __construct() {
 		// Menus.
 		add_action( 'admin_menu', array( $this, 'menu' ) );
@@ -76,10 +76,10 @@ class BHG_Admin {
 	}
 
 		/**
-			* Enqueue admin assets on BHG screens.
-			*
-			* @param string $hook Current admin page hook.
-			*/
+		 * Enqueue admin assets on BHG screens.
+		 *
+		 * @param string $hook Current admin page hook.
+		 */
 	public function assets( $hook ) {
 		if ( false !== strpos( $hook, 'bhg' ) ) {
 			wp_enqueue_style(
@@ -103,43 +103,43 @@ class BHG_Admin {
 
 	// -------------------- Views --------------------
 	/**
-		* Render the dashboard page.
-		*/
+	 * Render the dashboard page.
+	 */
 	public function dashboard() {
 		require BHG_PLUGIN_DIR . 'admin/views/dashboard.php';
 	}
 
 	/**
-		* Render the bonus hunts page.
-		*/
+	 * Render the bonus hunts page.
+	 */
 	public function bonus_hunts() {
 		require BHG_PLUGIN_DIR . 'admin/views/bonus-hunts.php';
 	}
 
 	/**
-		* Render the bonus hunts results page.
-		*/
+	 * Render the bonus hunts results page.
+	 */
 	public function bonus_hunts_results() {
 		require BHG_PLUGIN_DIR . 'admin/views/bonus-hunts-results.php';
 	}
 
 	/**
-		* Render the tournaments page.
-		*/
+	 * Render the tournaments page.
+	 */
 	public function tournaments() {
 		require BHG_PLUGIN_DIR . 'admin/views/tournaments.php';
 	}
 
 	/**
-		* Render the users page.
-		*/
+	 * Render the users page.
+	 */
 	public function users() {
 		require BHG_PLUGIN_DIR . 'admin/views/users.php';
 	}
 
 	/**
-		* Render the affiliates management page.
-		*/
+	 * Render the affiliates management page.
+	 */
 	public function affiliates() {
 		$view = BHG_PLUGIN_DIR . 'admin/views/affiliate-websites.php';
 		if ( file_exists( $view ) ) {
@@ -147,15 +147,15 @@ class BHG_Admin {
 			echo '<div class="wrap"><h1>' . esc_html__( 'Affiliates', 'bonus-hunt-guesser' ) . '</h1><p>' . esc_html__( 'Affiliate management UI not provided yet.', 'bonus-hunt-guesser' ) . '</p></div>'; }
 	}
 	/**
-		* Render the advertising page.
-		*/
+	 * Render the advertising page.
+	 */
 	public function advertising() {
 		require BHG_PLUGIN_DIR . 'admin/views/advertising.php';
 	}
 
 	/**
-		* Render the translations page.
-		*/
+	 * Render the translations page.
+	 */
 	public function translations() {
 		$view = BHG_PLUGIN_DIR . 'admin/views/translations.php';
 		if ( file_exists( $view ) ) {
@@ -163,8 +163,8 @@ class BHG_Admin {
 			echo '<div class="wrap"><h1>' . esc_html__( 'Translations', 'bonus-hunt-guesser' ) . '</h1><p>' . esc_html__( 'No translations UI found.', 'bonus-hunt-guesser' ) . '</p></div>'; }
 	}
 	/**
-		* Render the database maintenance page.
-		*/
+	 * Render the database maintenance page.
+	 */
 	public function database() {
 		$view = BHG_PLUGIN_DIR . 'admin/views/database.php';
 		if ( file_exists( $view ) ) {
@@ -172,8 +172,8 @@ class BHG_Admin {
 			echo '<div class="wrap"><h1>' . esc_html__( 'Database', 'bonus-hunt-guesser' ) . '</h1><p>' . esc_html__( 'No database UI found.', 'bonus-hunt-guesser' ) . '</p></div>'; }
 	}
 	/**
-		* Render the settings page.
-		*/
+	 * Render the settings page.
+	 */
 	public function settings() {
 		$view = BHG_PLUGIN_DIR . 'admin/views/settings.php';
 		if ( file_exists( $view ) ) {
@@ -181,8 +181,8 @@ class BHG_Admin {
 			echo '<div class="wrap"><h1>' . esc_html__( 'Settings', 'bonus-hunt-guesser' ) . '</h1><p>' . esc_html__( 'No settings UI found.', 'bonus-hunt-guesser' ) . '</p></div>'; }
 	}
 		/**
-			* Render the tools page.
-			*/
+		 * Render the tools page.
+		 */
 	public function bhg_tools_page() {
 			$view = BHG_PLUGIN_DIR . 'admin/views/tools.php';
 		if ( file_exists( $view ) ) {
@@ -195,8 +195,8 @@ class BHG_Admin {
 	// -------------------- Handlers --------------------
 
 	/**
-		* Handle deletion of a guess from the admin screen.
-		*/
+	 * Handle deletion of a guess from the admin screen.
+	 */
 	public function handle_delete_guess() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
@@ -214,8 +214,8 @@ class BHG_Admin {
 	}
 
 	/**
-		* Handle creation and updating of a bonus hunt.
-		*/
+	 * Handle creation and updating of a bonus hunt.
+	 */
 	public function handle_save_hunt() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
@@ -261,32 +261,32 @@ class BHG_Admin {
 
 			$emails_enabled = (int) get_option( 'bhg_email_enabled', 1 );
 			if ( $emails_enabled ) {
-                               $guesses_table = $wpdb->prefix . 'bhg_guesses';
+								$guesses_table = $wpdb->prefix . 'bhg_guesses';
 
-                               $rows = $wpdb->get_results(
-                                       $wpdb->prepare(
-                                               sprintf(
-                                                       'SELECT DISTINCT user_id FROM %s WHERE hunt_id = %%d',
-                                                       esc_sql( $guesses_table )
-                                               ),
-                                               $id
-                                       )
-                               );
+								$rows = $wpdb->get_results(
+									$wpdb->prepare(
+										sprintf(
+											'SELECT DISTINCT user_id FROM %s WHERE hunt_id = %%d',
+											esc_sql( $guesses_table )
+										),
+										$id
+									)
+								);
 
 				$template = get_option(
 					'bhg_email_template',
 					'Hi {{username}},\nThe Bonus Hunt "{{hunt}}" is closed. Final balance: €{{final}}. Winners: {{winners}}. Thanks for playing!'
 				);
 
-                               $hunt_title = (string) $wpdb->get_var(
-                                       $wpdb->prepare(
-                                               sprintf(
-                                                       'SELECT title FROM %s WHERE id = %%d',
-                                                       esc_sql( $hunts_table )
-                                               ),
-                                               $id
-                                       )
-                               );
+								$hunt_title = (string) $wpdb->get_var(
+									$wpdb->prepare(
+										sprintf(
+											'SELECT title FROM %s WHERE id = %%d',
+											esc_sql( $hunts_table )
+										),
+										$id
+									)
+								);
 
 				$winner_names = array();
 				foreach ( (array) $winners as $winner_id ) {
@@ -335,8 +335,8 @@ class BHG_Admin {
 	}
 
 	/**
-		* Close an active bonus hunt.
-		*/
+	 * Close an active bonus hunt.
+	 */
 	public function handle_close_hunt() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
@@ -362,8 +362,8 @@ class BHG_Admin {
 	}
 
 	/**
-		* Save or update an advertising entry.
-		*/
+	 * Save or update an advertising entry.
+	 */
 	public function handle_save_ad() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
@@ -406,8 +406,8 @@ class BHG_Admin {
 	}
 
 	/**
-		* Save a tournament record.
-		*/
+	 * Save a tournament record.
+	 */
 	public function handle_save_tournament() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
@@ -450,8 +450,8 @@ class BHG_Admin {
 	}
 
 	/**
-		* Save or update an affiliate record.
-		*/
+	 * Save or update an affiliate record.
+	 */
 	public function handle_save_affiliate() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
@@ -483,8 +483,8 @@ class BHG_Admin {
 	}
 
 	/**
-		* Delete an affiliate.
-		*/
+	 * Delete an affiliate.
+	 */
 	public function handle_delete_affiliate() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
@@ -501,8 +501,8 @@ class BHG_Admin {
 	}
 
 	/**
-		* Save custom user metadata from the admin screen.
-		*/
+	 * Save custom user metadata from the admin screen.
+	 */
 	public function handle_save_user_meta() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
@@ -520,8 +520,8 @@ class BHG_Admin {
 	}
 
 	/**
-		* Display admin notices for tournament actions.
-		*/
+	 * Display admin notices for tournament actions.
+	 */
 	public function admin_notices() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;

--- a/admin/class-bhg-bonus-hunts-controller.php
+++ b/admin/class-bhg-bonus-hunts-controller.php
@@ -1,9 +1,9 @@
 <?php
 /**
-	* Admin controller for bonus hunt forms.
-	*
-	* @package BonusHuntGuesser
-	*/
+ * Admin controller for bonus hunt forms.
+ *
+ * @package BonusHuntGuesser
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -11,21 +11,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 	/**
-		* Handles create, update and delete actions for bonus hunts.
-		*/
+	 * Handles create, update and delete actions for bonus hunts.
+	 */
 	class BHG_Bonus_Hunts_Controller {
 		/**
-			* Singleton instance.
-			*
-			* @var BHG_Bonus_Hunts_Controller|null
-			*/
+		 * Singleton instance.
+		 *
+		 * @var BHG_Bonus_Hunts_Controller|null
+		 */
 		private static $instance = null;
 
 		/**
-			* Get singleton instance.
-			*
-			* @return BHG_Bonus_Hunts_Controller
-			*/
+		 * Get singleton instance.
+		 *
+		 * @return BHG_Bonus_Hunts_Controller
+		 */
 		public static function get_instance() {
 			if ( null === self::$instance ) {
 				self::$instance = new self();
@@ -34,25 +34,25 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 		}
 
 		/**
-			* Constructor.
-			*/
+		 * Constructor.
+		 */
 		private function __construct() {}
 
 		/**
-			* Initialize hooks.
-			*
-			* @return void
-			*/
+		 * Initialize hooks.
+		 *
+		 * @return void
+		 */
 		public function init() {
 						add_action( 'admin_init', array( $this, 'handle_form_submissions' ) );
 												add_action( 'admin_post_bhg_delete_guess', [ $this, 'delete_guess' ] ); // phpcs:ignore Generic.WhiteSpace.DisallowSpaceIndent,Universal.Arrays.DisallowShortArraySyntax
 		}
 
 		/**
-			* Retrieve data for bonus hunt admin views.
-			*
-			* @return array
-			*/
+		 * Retrieve data for bonus hunt admin views.
+		 *
+		 * @return array
+		 */
 		public function get_admin_view_vars() {
 			$db = new BHG_DB();
 
@@ -64,10 +64,10 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 
 
 		/**
-			* Handle bonus hunt form submissions.
-			*
-			* @return void
-			*/
+		 * Handle bonus hunt form submissions.
+		 *
+		 * @return void
+		 */
 		public function handle_form_submissions() {
 			if ( empty( $_POST['bhg_action'] ) ) {
 				return;
@@ -161,10 +161,10 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 		}
 
 				/**
-					* Delete a guess submitted for a hunt.
-					*
-					* @return void
-					*/
+				 * Delete a guess submitted for a hunt.
+				 *
+				 * @return void
+				 */
 		public function delete_guess() {
 			if ( ! current_user_can( 'manage_options' ) ) {
 						wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );

--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -1,53 +1,60 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
 class BHG_Demo {
 	public function __construct() {
-		add_action('admin_menu', [$this,'demo_menu']);
-		add_action('admin_post_bhg_demo_reseed', [$this,'reseed']);
+		add_action( 'admin_menu', array( $this, 'demo_menu' ) );
+		add_action( 'admin_post_bhg_demo_reseed', array( $this, 'reseed' ) );
 	}
 
 	public function demo_menu() {
 		add_submenu_page(
 			'bhg_dashboard',
-			__('Demo Tools','bonus-hunt-guesser'),
-			__('Demo Tools','bonus-hunt-guesser'),
+			__( 'Demo Tools', 'bonus-hunt-guesser' ),
+			__( 'Demo Tools', 'bonus-hunt-guesser' ),
 			'manage_options',
 			'bhg_demo',
-			[$this,'render_demo']
+			array( $this, 'render_demo' )
 		);
 	}
 
 	public function render_demo() {
 		echo '<div class="wrap"><h1>Demo Tools</h1>';
-				echo '<form method="post" action="'.admin_url('admin-post.php').'">';
+				echo '<form method="post" action="' . admin_url( 'admin-post.php' ) . '">';
 				echo '<input type="hidden" name="action" value="bhg_demo_reseed" />';
 				wp_nonce_field( 'bhg_demo_reseed' );
-				submit_button(__('Reset & Reseed Demo','bonus-hunt-guesser'));
+				submit_button( __( 'Reset & Reseed Demo', 'bonus-hunt-guesser' ) );
 				echo '</form></div>';
-		}
+	}
 
-		public function reseed() {
-				check_admin_referer( 'bhg_demo_reseed' );
-				global $wpdb;
+	public function reseed() {
+			check_admin_referer( 'bhg_demo_reseed' );
+			global $wpdb;
 
-				// Wipe demo data
-				$wpdb->query( "DELETE FROM {$wpdb->prefix}bhg_bonus_hunts WHERE title LIKE '%(Demo)%'" );
-				$wpdb->query( "DELETE FROM {$wpdb->prefix}bhg_tournaments WHERE title LIKE '%(Demo)%'" );
+			// Wipe demo data
+			$wpdb->query( "DELETE FROM {$wpdb->prefix}bhg_bonus_hunts WHERE title LIKE '%(Demo)%'" );
+			$wpdb->query( "DELETE FROM {$wpdb->prefix}bhg_tournaments WHERE title LIKE '%(Demo)%'" );
 
 		// Insert demo hunt
-		$wpdb->insert("{$wpdb->prefix}bhg_bonus_hunts",[
-			'title'=>'Sample Hunt (Demo)',
-			'starting_balance'=>1000,
-			'num_bonuses'=>5,
-			'status'=>'open'
-		]);
+		$wpdb->insert(
+			"{$wpdb->prefix}bhg_bonus_hunts",
+			array(
+				'title'            => 'Sample Hunt (Demo)',
+				'starting_balance' => 1000,
+				'num_bonuses'      => 5,
+				'status'           => 'open',
+			)
+		);
 
 		// Insert demo tournament
-		$wpdb->insert("{$wpdb->prefix}bhg_tournaments",[
-			'title'=>'August Tournament (Demo)',
-			'status'=>'active'
-		]);
+		$wpdb->insert(
+			"{$wpdb->prefix}bhg_tournaments",
+			array(
+				'title'  => 'August Tournament (Demo)',
+				'status' => 'active',
+			)
+		);
 
 		wp_safe_redirect( admin_url( 'admin.php?page=bhg_demo&demo_reset=1' ) );
 		exit;

--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -30,7 +30,7 @@ if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
 // Fetch ads
 // db call ok; no-cache ok.
 $ads = $wpdb->get_results(
-		$wpdb->prepare( 'SELECT * FROM %i ORDER BY id DESC', $table )
+	$wpdb->prepare( 'SELECT * FROM %i ORDER BY id DESC', $table )
 );
 ?>
 <div class="wrap">
@@ -90,12 +90,12 @@ endif;
 	<h2 style="margin-top:2em"><?php echo $edit_id ? esc_html__( 'Edit Ad', 'bonus-hunt-guesser' ) : esc_html__( 'Add Ad', 'bonus-hunt-guesser' ); ?></h2>
 	<?php
 		$ad = null;
-		if ( $edit_id ) {
-										// db call ok; no-cache ok.
-										$ad = $wpdb->get_row(
-												$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $edit_id )
-										);
-		}
+	if ( $edit_id ) {
+									// db call ok; no-cache ok.
+									$ad = $wpdb->get_row(
+										$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $edit_id )
+									);
+	}
 	?>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="max-width:800px">
 	<?php wp_nonce_field( 'bhg_save_ad' ); ?>

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -15,13 +15,13 @@ $table = esc_sql( $table );
 // Load for edit
 $edit_id = isset( $_GET['edit'] ) ? (int) $_GET['edit'] : 0;
 $row     = $edit_id ? $wpdb->get_row(
-		$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $edit_id )
+	$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $edit_id )
 ) : null;
 
 // List
 // db call ok; no-cache ok.
 $rows = $wpdb->get_results(
-		$wpdb->prepare( 'SELECT * FROM %i ORDER BY id DESC', $table )
+	$wpdb->prepare( 'SELECT * FROM %i ORDER BY id DESC', $table )
 );
 ?>
 <div class="wrap">

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -35,17 +35,17 @@ if ( 'list' === $view ) :
 
 				// db call ok; no-cache ok.
 				$hunts = $wpdb->get_results(
-						$wpdb->prepare(
-								'SELECT * FROM %i ORDER BY id DESC LIMIT %d OFFSET %d',
-								$hunts_table,
-								$per_page,
-								$offset
-						)
+					$wpdb->prepare(
+						'SELECT * FROM %i ORDER BY id DESC LIMIT %d OFFSET %d',
+						$hunts_table,
+						$per_page,
+						$offset
+					)
 				);
 
 				// db call ok; no-cache ok.
-				$total    = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $hunts_table ) );
-		$base_url = remove_query_arg( array( 'paged' ) );
+				$total = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $hunts_table ) );
+		$base_url      = remove_query_arg( array( 'paged' ) );
 	?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Bonus Hunts', 'bonus-hunt-guesser' ); ?></h1>
@@ -155,8 +155,8 @@ endif;
 if ( 'close' === $view ) :
 		$id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
 		// db call ok; no-cache ok.
-		$hunt   = $wpdb->get_row(
-				$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $hunts_table, $id )
+		$hunt = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $hunts_table, $id )
 		);
 	if ( ! $hunt || 'open' !== $hunt->status ) :
 		echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt.', 'bonus-hunt-guesser' ) . '</p></div>';
@@ -222,10 +222,10 @@ if ( $view === 'add' ) :
 			}
 			$aff_table = esc_sql( $aff_table );
 						// db call ok; no-cache ok.
-						$affs      = $wpdb->get_results(
-								$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
+						$affs = $wpdb->get_results(
+							$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
 						);
-			$sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
+			$sel              = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
 			?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
 				<option value="0"><?php echo esc_html__( 'None', 'bonus-hunt-guesser' ); ?></option>
@@ -269,8 +269,8 @@ if ( $view === 'add' ) :
 if ( $view === 'edit' ) :
 		$id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
 		// db call ok; no-cache ok.
-		$hunt   = $wpdb->get_row(
-				$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $hunts_table, $id )
+		$hunt = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $hunts_table, $id )
 		);
 	if ( ! $hunt ) {
 		echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt', 'bonus-hunt-guesser' ) . '</p></div>';
@@ -282,13 +282,13 @@ if ( $view === 'edit' ) :
 	}
 	$users_table = esc_sql( $users_table );
 		// db call ok; no-cache ok.
-		$guesses     = $wpdb->get_results(
-				$wpdb->prepare(
-						'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
-						$guesses_table,
-						$users_table,
-						$id
-				)
+		$guesses = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
+				$guesses_table,
+				$users_table,
+				$id
+			)
 		);
 	?>
 <div class="wrap">
@@ -327,10 +327,10 @@ if ( $view === 'edit' ) :
 			}
 			$aff_table = esc_sql( $aff_table );
 						// db call ok; no-cache ok.
-						$affs      = $wpdb->get_results(
-								$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
+						$affs = $wpdb->get_results(
+							$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
 						);
-			$sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
+			$sel              = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
 			?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
 				<option value="0"><?php echo esc_html__( 'None', 'bonus-hunt-guesser' ); ?></option>

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -1,9 +1,9 @@
 <?php
 /**
-	* Dashboard: Latest Hunts overview.
-	*
-	* @package Bonus_Hunt_Guesser
-	*/
+ * Dashboard: Latest Hunts overview.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/admin/views/tools.php
+++ b/admin/views/tools.php
@@ -1,9 +1,9 @@
 <?php
 /**
-	* Tools page for Bonus Hunt Guesser.
-	*
-	* @package Bonus_Hunt_Guesser
-	*/
+ * Tools page for Bonus Hunt Guesser.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -10,7 +10,7 @@ global $wpdb;
 $table = $wpdb->prefix . 'bhg_translations';
 
 if ( function_exists( 'bhg_seed_default_translations' ) ) {
-       bhg_seed_default_translations();
+		bhg_seed_default_translations();
 }
 
 $default_translations = function_exists( 'bhg_get_default_translations' ) ? bhg_get_default_translations() : array();

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -188,7 +188,7 @@ function bhg_activate_plugin() {
 
 	bhg_create_tables();
 
-       bhg_seed_default_translations();
+		bhg_seed_default_translations();
 
 		// Set default options.
 	add_option( 'bhg_version', BHG_VERSION );
@@ -598,17 +598,17 @@ function bhg_build_ads_query( $table, $placement = 'footer' ) {
 			return array();
 	}
 
-       $table = esc_sql( $table );
+		$table = esc_sql( $table );
 
-       // db call ok; no-cache ok.
-       $rows = $wpdb->get_results(
-               $wpdb->prepare(
-                       'SELECT * FROM %i WHERE placement = %s AND active = %d',
-                       $table,
-                       $placement,
-                       1
-               )
-       );
+		// db call ok; no-cache ok.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE placement = %s AND active = %d',
+				$table,
+				$placement,
+				1
+			)
+		);
 	if ( did_action( 'wp' ) && function_exists( 'get_queried_object_id' ) ) {
 			$pid = (int) get_queried_object_id();
 		if ( $pid && is_array( $rows ) ) {
@@ -701,10 +701,10 @@ function bhg_generate_leaderboard_html( $timeframe, $paged ) {
 		$args[] = $start_date;
 	}
 
-       // db call ok; no-cache ok.
-       $total = (int) $wpdb->get_var(
-               $wpdb->prepare(
-                       "SELECT COUNT(*) FROM (
+		// db call ok; no-cache ok.
+		$total = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM (
         SELECT g.user_id
         FROM %i g
         INNER JOIN %i h ON h.id = g.hunt_id
@@ -715,18 +715,18 @@ function bhg_generate_leaderboard_html( $timeframe, $paged ) {
         )
         GROUP BY g.user_id
 ) t",
-                       $g,
-                       $h,
-                       $g,
-                       ...$args
-               )
-       );
+				$g,
+				$h,
+				$g,
+				...$args
+			)
+		);
 
-       $args_query = array_merge( $args, array( $per_page, $offset ) );
-       // db call ok; no-cache ok.
-       $rows = $wpdb->get_results(
-               $wpdb->prepare(
-                       "SELECT g.user_id, u.user_login, COUNT(*) AS wins
+		$args_query = array_merge( $args, array( $per_page, $offset ) );
+		// db call ok; no-cache ok.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT g.user_id, u.user_login, COUNT(*) AS wins
 FROM %i g
 INNER JOIN %i h ON h.id = g.hunt_id
 INNER JOIN %i u ON u.ID = g.user_id
@@ -738,13 +738,13 @@ WHERE {$where} AND NOT EXISTS (
 GROUP BY g.user_id, u.user_login
 ORDER BY wins DESC, u.user_login ASC
 LIMIT %d OFFSET %d",
-                       $g,
-                       $h,
-                       $u,
-                       $g,
-                       ...$args_query
-               )
-       );
+				$g,
+				$h,
+				$u,
+				$g,
+				...$args_query
+			)
+		);
 
 	if ( ! $rows ) {
 		return '<p>' . esc_html__( 'No data available.', 'bonus-hunt-guesser' ) . '</p>';

--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -134,18 +134,18 @@ class BHG_Ads {
 	}
 
 	/**
-		* Shortcode handler for rendering a single ad row regardless of placement.
-		*
-		* Usage examples:
-		* [bhg_ad id="123"]
-		* [bhg_advertising ad="123" status="inactive"]
-		*
-		* @param array  $atts    Shortcode attributes.
-		* @param string $content Content enclosed by shortcode (unused).
-		* @param string $tag     Shortcode tag.
-		*
-		* @return string
-		*/
+	 * Shortcode handler for rendering a single ad row regardless of placement.
+	 *
+	 * Usage examples:
+	 * [bhg_ad id="123"]
+	 * [bhg_advertising ad="123" status="inactive"]
+	 *
+	 * @param array  $atts    Shortcode attributes.
+	 * @param string $content Content enclosed by shortcode (unused).
+	 * @param string $tag     Shortcode tag.
+	 *
+	 * @return string
+	 */
 	public static function shortcode( $atts = array(), $content = '', $tag = '' ) {
 		$a = shortcode_atts(
 			array(

--- a/includes/class-bhg-bonus-hunts.php
+++ b/includes/class-bhg-bonus-hunts.php
@@ -3,16 +3,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; }
 
 /**
-	* Bonus hunt data helpers.
-	*/
+ * Bonus hunt data helpers.
+ */
 class BHG_Bonus_Hunts {
 
 	/**
-		* Retrieve latest hunts with winners.
-		*
-		* @param int $limit Number of hunts to fetch. Default 3.
-		* @return array List of hunts and winners.
-		*/
+	 * Retrieve latest hunts with winners.
+	 *
+	 * @param int $limit Number of hunts to fetch. Default 3.
+	 * @return array List of hunts and winners.
+	 */
 	public static function get_latest_hunts_with_winners( $limit = 3 ) {
 		global $wpdb;
 		$hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
@@ -60,11 +60,11 @@ class BHG_Bonus_Hunts {
 	}
 
 	/**
-		* Retrieve a hunt by ID.
-		*
-		* @param int $hunt_id Hunt ID.
-		* @return object|null Hunt data or null if not found.
-		*/
+	 * Retrieve a hunt by ID.
+	 *
+	 * @param int $hunt_id Hunt ID.
+	 * @return object|null Hunt data or null if not found.
+	 */
 	public static function get_hunt( $hunt_id ) {
 		global $wpdb;
 		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
@@ -73,11 +73,11 @@ class BHG_Bonus_Hunts {
 	}
 
 	/**
-		* Get ranked guesses for a hunt.
-		*
-		* @param int $hunt_id Hunt ID.
-		* @return array List of guesses.
-		*/
+	 * Get ranked guesses for a hunt.
+	 *
+	 * @param int $hunt_id Hunt ID.
+	 * @return array List of guesses.
+	 */
 	public static function get_hunt_guesses_ranked( $hunt_id ) {
 		global $wpdb;
 		$hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -251,12 +251,12 @@ class BHG_DB {
 	}
 
 	/**
-		* Check if a column exists, falling back when information_schema is not accessible.
-		*
-		* @param string $table  Table name.
-		* @param string $column Column to check.
-		* @return bool
-		*/
+	 * Check if a column exists, falling back when information_schema is not accessible.
+	 *
+	 * @param string $table  Table name.
+	 * @param string $column Column to check.
+	 * @return bool
+	 */
 	private function column_exists( $table, $column ) {
 		global $wpdb;
 
@@ -281,12 +281,12 @@ class BHG_DB {
 	}
 
 	/**
-		* Check if an index exists, falling back when information_schema is not accessible.
-		*
-		* @param string $table Table name.
-		* @param string $index Index to check.
-		* @return bool
-		*/
+	 * Check if an index exists, falling back when information_schema is not accessible.
+	 *
+	 * @param string $table Table name.
+	 * @param string $index Index to check.
+	 * @return bool
+	 */
 	private function index_exists( $table, $index ) {
 		global $wpdb;
 

--- a/includes/class-bhg-front-menus.php
+++ b/includes/class-bhg-front-menus.php
@@ -1,22 +1,22 @@
 <?php
 /**
-	* Front-end menu handling.
-	*
-	* @package BonusHuntGuesser
-	*/
+ * Front-end menu handling.
+ *
+ * @package BonusHuntGuesser
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
-	* Front-end menus.
-	*/
+ * Front-end menus.
+ */
 class BHG_Front_Menus {
 
 	/**
-		* Set up hooks.
-		*/
+	 * Set up hooks.
+	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_locations' ) );
 		add_shortcode( 'bhg_nav', array( $this, 'nav_shortcode' ) );
@@ -24,10 +24,10 @@ class BHG_Front_Menus {
 	}
 
 	/**
-		* Register menu locations.
-		*
-		* @return void
-		*/
+	 * Register menu locations.
+	 *
+	 * @return void
+	 */
 	public function register_locations() {
 		register_nav_menus(
 			array(
@@ -39,11 +39,11 @@ class BHG_Front_Menus {
 	}
 
 	/**
-		* Render navigation based on provided attributes.
-		*
-		* @param array $atts Shortcode attributes.
-		* @return string Menu markup.
-		*/
+	 * Render navigation based on provided attributes.
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string Menu markup.
+	 */
 	public function nav_shortcode( $atts ) {
 		$a   = shortcode_atts( array( 'area' => 'guest' ), $atts, 'bhg_nav' );
 		$loc = 'bhg_menu_guest';
@@ -73,11 +73,11 @@ class BHG_Front_Menus {
 	}
 
 	/**
-		* Render the correct menu location based on role/login.
-		*
-		* @param array $args Menu arguments.
-		* @return string Menu markup.
-		*/
+	 * Render the correct menu location based on role/login.
+	 *
+	 * @param array $args Menu arguments.
+	 * @return string Menu markup.
+	 */
 	public static function render_role_menu( $args = array() ) {
 		if ( current_user_can( 'manage_options' ) || current_user_can( 'moderate_comments' ) ) {
 			$loc = 'bhg_menu_admin';
@@ -104,11 +104,11 @@ class BHG_Front_Menus {
 	}
 
 	/**
-		* Shortcode: [bhg_menu].
-		*
-		* @param array $atts Shortcode attributes.
-		* @return string Menu markup.
-		*/
+	 * Shortcode: [bhg_menu].
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string Menu markup.
+	 */
 	public static function menu_shortcode( $atts ) {
 		unset( $atts );
 		return self::render_role_menu();

--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -1,33 +1,33 @@
 <?php
 /**
-	* Data layer utilities for Bonus Hunt Guesser.
-	*
-	* This class previously handled guess submissions directly. Guess handling is
-	* now centralized through {@see bhg_handle_submit_guess()} in
-	* `bonus-hunt-guesser.php`. The methods related to form handling and request
-	* routing were removed to avoid duplication and ensure a single canonical
-	* implementation.
-	*
-	* @package BonusHuntGuesser
-	*/
+ * Data layer utilities for Bonus Hunt Guesser.
+ *
+ * This class previously handled guess submissions directly. Guess handling is
+ * now centralized through {@see bhg_handle_submit_guess()} in
+ * `bonus-hunt-guesser.php`. The methods related to form handling and request
+ * routing were removed to avoid duplication and ensure a single canonical
+ * implementation.
+ *
+ * @package BonusHuntGuesser
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 		exit;
 }
 
 /**
-	* Class providing data layer utilities for Bonus Hunt Guesser.
-	*/
+ * Class providing data layer utilities for Bonus Hunt Guesser.
+ */
 class BHG_Models {
 
 	/**
-		* Close a bonus hunt and determine winners.
-		*
-		* @param int   $hunt_id       Hunt identifier.
-		* @param float $final_balance Final balance for the hunt.
-		*
-		* @return int[] Array of winning user IDs.
-		*/
+	 * Close a bonus hunt and determine winners.
+	 *
+	 * @param int   $hunt_id       Hunt identifier.
+	 * @param float $final_balance Final balance for the hunt.
+	 *
+	 * @return int[] Array of winning user IDs.
+	 */
 	public static function close_hunt( $hunt_id, $final_balance ) {
 		global $wpdb;
 
@@ -41,16 +41,16 @@ class BHG_Models {
 		$hunts_tbl   = $wpdb->prefix . 'bhg_bonus_hunts';
 		$guesses_tbl = $wpdb->prefix . 'bhg_guesses';
 
-               // Determine number of winners for this hunt.
-               $winners_count = (int) $wpdb->get_var(
-                       $wpdb->prepare(
-                               sprintf(
-                                       'SELECT winners_count FROM %s WHERE id = %%d',
-                                       esc_sql( $hunts_tbl )
-                               ),
-                               $hunt_id
-                       )
-               );
+				// Determine number of winners for this hunt.
+				$winners_count = (int) $wpdb->get_var(
+					$wpdb->prepare(
+						sprintf(
+							'SELECT winners_count FROM %s WHERE id = %%d',
+							esc_sql( $hunts_tbl )
+						),
+						$hunt_id
+					)
+				);
 		if ( $winners_count <= 0 ) {
 			$winners_count = 1;
 		}
@@ -70,18 +70,18 @@ class BHG_Models {
 			array( '%d' )
 		);
 
-               // Fetch winners based on proximity to final balance.
-               $rows = $wpdb->get_results(
-                       $wpdb->prepare(
-                               sprintf(
-                                       'SELECT user_id FROM %s WHERE hunt_id = %%d ORDER BY ABS(guess - %%f) ASC, id ASC LIMIT %%d',
-                                       esc_sql( $guesses_tbl )
-                               ),
-                               $hunt_id,
-                               $final_balance,
-                               $winners_count
-                       )
-               );
+				// Fetch winners based on proximity to final balance.
+				$rows = $wpdb->get_results(
+					$wpdb->prepare(
+						sprintf(
+							'SELECT user_id FROM %s WHERE hunt_id = %%d ORDER BY ABS(guess - %%f) ASC, id ASC LIMIT %%d',
+							esc_sql( $guesses_tbl )
+						),
+						$hunt_id,
+						$final_balance,
+						$winners_count
+					)
+				);
 
 		if ( empty( $rows ) ) {
 			return array();

--- a/includes/class-bhg-settings.php
+++ b/includes/class-bhg-settings.php
@@ -1,24 +1,24 @@
 <?php
 /**
-	* Settings handling for Bonus Hunt Guesser.
-	*
-	* @package BonusHuntGuesser
-	*/
+ * Settings handling for Bonus Hunt Guesser.
+ *
+ * @package BonusHuntGuesser
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
-	* Settings page logic.
-	*/
+ * Settings page logic.
+ */
 class BHG_Settings {
 
 	/**
-		* Render settings page.
-		*
-		* @return void
-		*/
+	 * Render settings page.
+	 *
+	 * @return void
+	 */
 	public static function render() {
 		BHG_Utils::require_cap();
 

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -1,19 +1,19 @@
 <?php
 /**
-	* Shortcodes for Bonus Hunt Guesser
-	*
-	* PHP 7.4 safe, WP 6.3.5 compatible.
-	* Registers all shortcodes on init (once) and avoids parse errors.
-	*/
+ * Shortcodes for Bonus Hunt Guesser
+ *
+ * PHP 7.4 safe, WP 6.3.5 compatible.
+ * Registers all shortcodes on init (once) and avoids parse errors.
+ */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 
-		class BHG_Shortcodes {
+	class BHG_Shortcodes {
 
-				public function __construct() {
+		public function __construct() {
 			// Core shortcodes
 			add_shortcode( 'bhg_active_hunt', array( $this, 'active_hunt_shortcode' ) );
 			add_shortcode( 'bhg_guess_form', array( $this, 'guess_form_shortcode' ) );
@@ -31,47 +31,47 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			// Legacy/aliases
 			add_shortcode( 'bonus_hunt_leaderboard', array( $this, 'leaderboard_shortcode' ) );
 			add_shortcode( 'bonus_hunt_login', array( $this, 'login_hint_shortcode' ) );
-				add_shortcode( 'bhg_active', array( $this, 'active_hunt_shortcode' ) );
-				}
+			add_shortcode( 'bhg_active', array( $this, 'active_hunt_shortcode' ) );
+		}
 
-				private function sanitize_table( $table ) {
-				global $wpdb;
-				$allowed = array(
-						$wpdb->prefix . 'bhg_bonus_hunts',
-						$wpdb->prefix . 'bhg_guesses',
-						$wpdb->prefix . 'bhg_tournaments',
-						$wpdb->prefix . 'bhg_tournament_results',
-						$wpdb->prefix . 'bhg_affiliates',
-						$wpdb->users,
-				);
-				return in_array( $table, $allowed, true ) ? esc_sql( $table ) : '';
-				}
+		private function sanitize_table( $table ) {
+			global $wpdb;
+			$allowed = array(
+				$wpdb->prefix . 'bhg_bonus_hunts',
+				$wpdb->prefix . 'bhg_guesses',
+				$wpdb->prefix . 'bhg_tournaments',
+				$wpdb->prefix . 'bhg_tournament_results',
+				$wpdb->prefix . 'bhg_affiliates',
+				$wpdb->users,
+			);
+			return in_array( $table, $allowed, true ) ? esc_sql( $table ) : '';
+		}
 
-				/** Minimal login hint used by some themes */
-				public function login_hint_shortcode( $atts = array() ) {
+			/** Minimal login hint used by some themes */
+		public function login_hint_shortcode( $atts = array() ) {
 			if ( is_user_logged_in() ) {
 				return '';
 			}
-			$raw     = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : home_url( '/' );
-			$base    = wp_validate_redirect( $raw, home_url( '/' ) );
-			$redirect = esc_url_raw( add_query_arg( array(), $base ) );
+				$raw      = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : home_url( '/' );
+				$base     = wp_validate_redirect( $raw, home_url( '/' ) );
+				$redirect = esc_url_raw( add_query_arg( array(), $base ) );
 
-			return '<p>' . esc_html__( 'Please log in to continue.', 'bonus-hunt-guesser' ) . '</p>'
+				return '<p>' . esc_html__( 'Please log in to continue.', 'bonus-hunt-guesser' ) . '</p>'
 				. '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
 		}
 
-		/** [bhg_active_hunt] — list all open hunts */
+			/** [bhg_active_hunt] — list all open hunts */
 		public function active_hunt_shortcode( $atts ) {
-				global $wpdb;
+			global $wpdb;
 			$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-						// db call ok; no-cache ok.
-                                               $hunts       = $wpdb->get_results(
-                                                               $wpdb->prepare(
-                                                                               'SELECT * FROM %i WHERE status = %s ORDER BY created_at DESC',
-                                                                               $hunts_table,
-                                                                               'open'
-                                                               )
-                                               );
+					// db call ok; no-cache ok.
+											$hunts = $wpdb->get_results(
+												$wpdb->prepare(
+													'SELECT * FROM %i WHERE status = %s ORDER BY created_at DESC',
+													$hunts_table,
+													'open'
+												)
+											);
 
 			if ( ! $hunts ) {
 				return '<div class="bhg-active-hunt"><p>' . esc_html__( 'No active bonus hunts at the moment.', 'bonus-hunt-guesser' ) . '</p></div>';
@@ -102,7 +102,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			return ob_get_clean();
 		}
 
-		/** [bhg_guess_form hunt_id=""] */
+			/** [bhg_guess_form hunt_id=""] */
 		public function guess_form_shortcode( $atts ) {
 			$atts    = shortcode_atts( array( 'hunt_id' => 0 ), $atts, 'bhg_guess_form' );
 			$hunt_id = (int) $atts['hunt_id'];
@@ -113,19 +113,19 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				$redirect = esc_url_raw( add_query_arg( array(), $base ) );
 
 				return '<p>' . esc_html__( 'Please log in to submit your guess.', 'bonus-hunt-guesser' ) . '</p>'
-					. '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
+				. '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
 			}
 
-						global $wpdb;
-						$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-						// db call ok; no-cache ok.
-                                               $open_hunts  = $wpdb->get_results(
-                                                               $wpdb->prepare(
-                                                                               'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC',
-                                                                               $hunts_table,
-                                                                               'open'
-                                                               )
-                                               );
+					global $wpdb;
+					$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+					// db call ok; no-cache ok.
+											$open_hunts = $wpdb->get_results(
+												$wpdb->prepare(
+													'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC',
+													$hunts_table,
+													'open'
+												)
+											);
 
 			if ( $hunt_id <= 0 ) {
 				if ( ! $open_hunts ) {
@@ -136,12 +136,12 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				}
 			}
 
-						$user_id        = get_current_user_id();
-						$table          = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
-						// db call ok; no-cache ok.
-                                               $existing_id    = $hunt_id > 0 ? (int) $wpdb->get_var( $wpdb->prepare( 'SELECT id FROM %i WHERE user_id = %d AND hunt_id = %d', $table, $user_id, $hunt_id ) ) : 0;
-                                               // db call ok; no-cache ok.
-                                               $existing_guess = $existing_id ? (float) $wpdb->get_var( $wpdb->prepare( 'SELECT guess FROM %i WHERE id = %d', $table, $existing_id ) ) : '';
+					$user_id = get_current_user_id();
+					$table   = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
+					// db call ok; no-cache ok.
+											$existing_id = $hunt_id > 0 ? (int) $wpdb->get_var( $wpdb->prepare( 'SELECT id FROM %i WHERE user_id = %d AND hunt_id = %d', $table, $user_id, $hunt_id ) ) : 0;
+											// db call ok; no-cache ok.
+											$existing_guess = $existing_id ? (float) $wpdb->get_var( $wpdb->prepare( 'SELECT guess FROM %i WHERE id = %d', $table, $existing_id ) ) : '';
 
 			$settings = get_option( 'bhg_plugin_settings' );
 			$min      = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
@@ -157,9 +157,9 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			ob_start(); ?>
 			<form class="bhg-guess-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 				<input type="hidden" name="action" value="bhg_submit_guess">
-				<?php wp_nonce_field( 'bhg_submit_guess', 'bhg_nonce' ); ?>
+					<?php wp_nonce_field( 'bhg_submit_guess', 'bhg_nonce' ); ?>
 
-				<?php if ( $open_hunts && count( $open_hunts ) > 1 ) : ?>
+					<?php if ( $open_hunts && count( $open_hunts ) > 1 ) : ?>
 					<label for="bhg-hunt-select"><?php esc_html_e( 'Choose a hunt:', 'bonus-hunt-guesser' ); ?></label>
 					<select id="bhg-hunt-select" name="hunt_id" required>
 						<option value=""><?php esc_html_e( 'Select a hunt', 'bonus-hunt-guesser' ); ?></option>
@@ -179,17 +179,17 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				<div class="bhg-error-message"></div>
 				<button type="submit" class="bhg-submit-btn button button-primary"><?php echo esc_html__( 'Submit Guess', 'bonus-hunt-guesser' ); ?></button>
 			</form>
-			<?php
-			return ob_get_clean();
+				<?php
+				return ob_get_clean();
 		}
 
-/**
-	* [bhg_leaderboard]
-	* Supports ranking (1-10) and fields (comma-separated list).
-	*/
-public function leaderboard_shortcode( $atts ) {
-			$a = shortcode_atts(
-					array(
+			/**
+			 * [bhg_leaderboard]
+			 * Supports ranking (1-10) and fields (comma-separated list).
+			 */
+		public function leaderboard_shortcode( $atts ) {
+					$a = shortcode_atts(
+						array(
 							'hunt_id'  => 0,
 							'orderby'  => 'guess', // guess|user|position
 							'order'    => 'ASC',
@@ -197,129 +197,129 @@ public function leaderboard_shortcode( $atts ) {
 							'per_page' => 20,
 							'ranking'  => 0, // top N results
 							'fields'   => 'position,user,guess',
-					),
-					$atts,
-					'bhg_leaderboard'
-			);
+						),
+						$atts,
+						'bhg_leaderboard'
+					);
 
-				global $wpdb;
-				$hunt_id = (int) $a['hunt_id'];
-						if ( $hunt_id <= 0 ) {
-								$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-								// db call ok; no-cache ok.
-                                                               $hunt_id     = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT id FROM %i ORDER BY created_at DESC LIMIT 1', $hunts_table ) );
-								if ( $hunt_id <= 0 ) {
-										return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
-								}
-						}
-
-				$g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
-				$u = $this->sanitize_table( $wpdb->users );
-
-			$order       = ( strtoupper( $a['order'] ) === 'DESC' ) ? 'DESC' : 'ASC';
-			$map         = array(
-				'guess'    => 'g.guess',
-				'user'     => 'u.user_login',
-				'position' => 'g.id', // stable proxy
-			);
-			$orderby_key = array_key_exists( $a['orderby'], $map ) ? $a['orderby'] : 'guess';
-			$orderby     = $map[ $orderby_key ];
-			$page        = max( 1, (int) $a['page'] );
-			$per         = max( 1, (int) $a['per_page'] );
-			$offset      = ( $page - 1 ) * $per;
-
-			$ranking = max( 0, min( 10, (int) $a['ranking'] ) );
-			if ( $ranking > 0 ) {
-					$per    = $ranking;
-					$page   = 1;
-					$offset = 0;
+			global $wpdb;
+			$hunt_id = (int) $a['hunt_id'];
+			if ( $hunt_id <= 0 ) {
+					$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+					// db call ok; no-cache ok.
+													$hunt_id = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT id FROM %i ORDER BY created_at DESC LIMIT 1', $hunts_table ) );
+				if ( $hunt_id <= 0 ) {
+							return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
+				}
 			}
 
-			$fields_raw    = explode( ',', (string) $a['fields'] );
-			$allowed_field = array( 'position', 'user', 'guess' );
-			$fields        = array_values( array_intersect( $allowed_field, array_map( 'sanitize_key', array_map( 'trim', $fields_raw ) ) ) );
-			if ( empty( $fields ) ) {
-					$fields = $allowed_field;
-			}
+			$g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
+			$u = $this->sanitize_table( $wpdb->users );
 
-						// db call ok; no-cache ok.
-                                               $total = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE hunt_id = %d', $g, $hunt_id ) );
-			if ( $total < 1 ) {
-					return '<p>' . esc_html__( 'No guesses yet.', 'bonus-hunt-guesser' ) . '</p>';
-			}
-			if ( $ranking > 0 && $total > $ranking ) {
-					$total = $ranking;
-			}
+					$order       = ( strtoupper( $a['order'] ) === 'DESC' ) ? 'DESC' : 'ASC';
+					$map         = array(
+						'guess'    => 'g.guess',
+						'user'     => 'u.user_login',
+						'position' => 'g.id', // stable proxy
+					);
+					$orderby_key = array_key_exists( $a['orderby'], $map ) ? $a['orderby'] : 'guess';
+					$orderby     = $map[ $orderby_key ];
+					$page        = max( 1, (int) $a['page'] );
+					$per         = max( 1, (int) $a['per_page'] );
+					$offset      = ( $page - 1 ) * $per;
 
-						$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-						// db call ok; no-cache ok.
-                                               $rows        = $wpdb->get_results(
-                                                               $wpdb->prepare(
-                                                                               'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id
+					$ranking = max( 0, min( 10, (int) $a['ranking'] ) );
+					if ( $ranking > 0 ) {
+							$per    = $ranking;
+							$page   = 1;
+							$offset = 0;
+					}
+
+					$fields_raw    = explode( ',', (string) $a['fields'] );
+					$allowed_field = array( 'position', 'user', 'guess' );
+					$fields        = array_values( array_intersect( $allowed_field, array_map( 'sanitize_key', array_map( 'trim', $fields_raw ) ) ) );
+					if ( empty( $fields ) ) {
+							$fields = $allowed_field;
+					}
+
+					// db call ok; no-cache ok.
+											$total = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE hunt_id = %d', $g, $hunt_id ) );
+					if ( $total < 1 ) {
+							return '<p>' . esc_html__( 'No guesses yet.', 'bonus-hunt-guesser' ) . '</p>';
+					}
+					if ( $ranking > 0 && $total > $ranking ) {
+							$total = $ranking;
+					}
+
+					$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+					// db call ok; no-cache ok.
+											$rows = $wpdb->get_results(
+												$wpdb->prepare(
+													'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id
                                                                                         FROM %i g
                                                                                         LEFT JOIN %i u ON u.ID = g.user_id
                                                                                         LEFT JOIN %i h ON h.id = g.hunt_id
                                                                                         WHERE g.hunt_id = %d
                                                                                         ORDER BY ' . $orderby . ' ' . $order . ' LIMIT %d OFFSET %d',
-                                                                               $g,
-                                                                               $u,
-                                                                               $hunts_table,
-                                                                               $hunt_id,
-                                                                               $per,
-                                                                               $offset
-                                                               )
-                                               );
+													$g,
+													$u,
+													$hunts_table,
+													$hunt_id,
+													$per,
+													$offset
+												)
+											);
 
-			wp_enqueue_style(
-				'bhg-shortcodes',
-				( defined( 'BHG_PLUGIN_URL' ) ? BHG_PLUGIN_URL : plugins_url( '/', __FILE__ ) ) . 'assets/css/bhg-shortcodes.css',
-				array(),
-				defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-			);
+					wp_enqueue_style(
+						'bhg-shortcodes',
+						( defined( 'BHG_PLUGIN_URL' ) ? BHG_PLUGIN_URL : plugins_url( '/', __FILE__ ) ) . 'assets/css/bhg-shortcodes.css',
+						array(),
+						defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+					);
 
-			ob_start();
-			echo '<table class="bhg-leaderboard">';
-			echo '<thead><tr>';
+					ob_start();
+					echo '<table class="bhg-leaderboard">';
+					echo '<thead><tr>';
 			foreach ( $fields as $field ) {
-					if ( 'position' === $field ) {
+				if ( 'position' === $field ) {
 							echo '<th class="sortable" data-column="position">' . esc_html__( 'Position', 'bonus-hunt-guesser' ) . '</th>';
-					} elseif ( 'user' === $field ) {
-							echo '<th class="sortable" data-column="user">' . esc_html__( 'User', 'bonus-hunt-guesser' ) . '</th>';
-					} elseif ( 'guess' === $field ) {
-							echo '<th class="sortable" data-column="guess">' . esc_html__( 'Guess', 'bonus-hunt-guesser' ) . '</th>';
-					}
+				} elseif ( 'user' === $field ) {
+					echo '<th class="sortable" data-column="user">' . esc_html__( 'User', 'bonus-hunt-guesser' ) . '</th>';
+				} elseif ( 'guess' === $field ) {
+					echo '<th class="sortable" data-column="guess">' . esc_html__( 'Guess', 'bonus-hunt-guesser' ) . '</th>';
+				}
 			}
-			echo '</tr></thead><tbody>';
+				echo '</tr></thead><tbody>';
 
-			$pos       = $offset + 1;
-			$need_user = in_array( 'user', $fields, true );
+				$pos       = $offset + 1;
+				$need_user = in_array( 'user', $fields, true );
 			foreach ( $rows as $r ) {
-					if ( $need_user ) {
-							$site_id    = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
-							$is_aff     = $site_id > 0
-									? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
-									: (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
-							$aff        = $is_aff ? 'green' : 'red';
-							/* translators: %d: user ID. */
-							$user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
-					}
+				if ( $need_user ) {
+					$site_id = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
+					$is_aff  = $site_id > 0
+					? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
+					: (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
+					$aff     = $is_aff ? 'green' : 'red';
+					/* translators: %d: user ID. */
+					$user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
+				}
 
 					echo '<tr>';
-					foreach ( $fields as $field ) {
-							if ( 'position' === $field ) {
-									echo '<td data-column="position">' . (int) $pos . '</td>';
-							} elseif ( 'user' === $field ) {
-									echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $this->render_affiliate_dot( $aff ) . '</td>';
-							} elseif ( 'guess' === $field ) {
-									echo '<td data-column="guess">' . esc_html( number_format_i18n( (float) $r->guess, 2 ) ) . '</td>';
-							}
+				foreach ( $fields as $field ) {
+					if ( 'position' === $field ) {
+						echo '<td data-column="position">' . (int) $pos . '</td>';
+					} elseif ( 'user' === $field ) {
+							echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $this->render_affiliate_dot( $aff ) . '</td>';
+					} elseif ( 'guess' === $field ) {
+							echo '<td data-column="guess">' . esc_html( number_format_i18n( (float) $r->guess, 2 ) ) . '</td>';
 					}
-					echo '</tr>';
-					$pos++;
+				}
+						echo '</tr>';
+						++$pos;
 			}
-			echo '</tbody></table>';
+				echo '</tbody></table>';
 
-			$pages = (int) ceil( $total / $per );
+				$pages = (int) ceil( $total / $per );
 			if ( $pages > 1 && 0 === $ranking ) {
 				$raw  = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : home_url( '/' );
 				$base = esc_url_raw( remove_query_arg( 'page', wp_validate_redirect( $raw, home_url( '/' ) ) ) );
@@ -331,15 +331,15 @@ public function leaderboard_shortcode( $atts ) {
 				echo '</div>';
 			}
 
-			return ob_get_clean();
+				return ob_get_clean();
 		}
 
-		/**
-			* [bhg_user_guesses]
-			* id (user), aff (yes/no), website (affiliate id), status (open|closed),
-			* timeline: '' | 'recent' (limit 10) | relative period: day|week|month|year
-			* orderby: hunt|guess ; order: ASC|DESC
-			*/
+			/**
+			 * [bhg_user_guesses]
+			 * id (user), aff (yes/no), website (affiliate id), status (open|closed),
+			 * timeline: '' | 'recent' (limit 10) | relative period: day|week|month|year
+			 * orderby: hunt|guess ; order: ASC|DESC
+			 */
 		public function user_guesses_shortcode( $atts ) {
 			$a = shortcode_atts(
 				array(
@@ -365,8 +365,8 @@ public function leaderboard_shortcode( $atts ) {
 				return '<p>' . esc_html__( 'No user specified.', 'bonus-hunt-guesser' ) . '</p>';
 			}
 
-				$g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
-				$h = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			$g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
+			$h = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
 
 			$where  = array( 'g.user_id = %d' );
 			$params = array( $user_id );
@@ -383,7 +383,7 @@ public function leaderboard_shortcode( $atts ) {
 			}
 
 			// Timeline handling (relative time window)
-			$timeline = sanitize_key( $a['timeline'] );
+			$timeline  = sanitize_key( $a['timeline'] );
 			$intervals = array(
 				'day'   => '-1 day',
 				'week'  => '-1 week',
@@ -396,7 +396,7 @@ public function leaderboard_shortcode( $atts ) {
 				$params[] = $since;
 			}
 
-			$order = ( strtoupper( $a['order'] ) === 'ASC' ) ? 'ASC' : 'DESC';
+			$order       = ( strtoupper( $a['order'] ) === 'ASC' ) ? 'ASC' : 'DESC';
 			$orderby_map = array(
 				'guess' => 'g.guess',
 				'hunt'  => 'h.created_at',
@@ -409,15 +409,15 @@ public function leaderboard_shortcode( $atts ) {
 				$limit_sql = ' LIMIT 10';
 			}
 
-                                               $sql = 'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id
+											$sql = 'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id
                                                                                FROM %i g INNER JOIN %i h ON h.id = g.hunt_id
                                                                                WHERE ' . implode( ' AND ', $where ) . '
                                                                                ORDER BY ' . $orderby . ' ' . $order . $limit_sql;
 
-                                               $prep_params = array_merge( array( $sql, $g, $h ), $params );
-                                               $query       = call_user_func_array( array( $wpdb, 'prepare' ), $prep_params );
-						// db call ok; no-cache ok.
-						$rows        = $wpdb->get_results( $query );
+											$prep_params = array_merge( array( $sql, $g, $h ), $params );
+											$query       = call_user_func_array( array( $wpdb, 'prepare' ), $prep_params );
+					// db call ok; no-cache ok.
+					$rows = $wpdb->get_results( $query );
 			if ( ! $rows ) {
 				return '<p>' . esc_html__( 'No guesses found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
@@ -437,9 +437,9 @@ public function leaderboard_shortcode( $atts ) {
 				echo '<td>' . esc_html( $row->title ) . '</td>';
 				$guess_cell = esc_html( number_format_i18n( (float) $row->guess, 2 ) );
 				if ( $show_aff ) {
-					$dot = $this->render_affiliate_dot(
+					$dot        = $this->render_affiliate_dot(
 						( get_user_meta( (int) $current_user_id, 'bhg_affiliate_website_' . (int) $row->affiliate_site_id, true )
-							|| get_user_meta( (int) $current_user_id, 'bhg_is_affiliate', true ) ) ? 'green' : 'red'
+						|| get_user_meta( (int) $current_user_id, 'bhg_is_affiliate', true ) ) ? 'green' : 'red'
 					);
 					$guess_cell = $dot . $guess_cell;
 				}
@@ -451,12 +451,12 @@ public function leaderboard_shortcode( $atts ) {
 			return ob_get_clean();
 		}
 
-		/**
-			* [bhg_hunts]
-			* id (hunt), status (open|closed), website (affiliate id),
-			* timeline: '' | 'recent' (limit 10) | relative period: day|week|month|year
-			* aff: yes/no to show affiliate column
-			*/
+			/**
+			 * [bhg_hunts]
+			 * id (hunt), status (open|closed), website (affiliate id),
+			 * timeline: '' | 'recent' (limit 10) | relative period: day|week|month|year
+			 * aff: yes/no to show affiliate column
+			 */
 		public function hunts_shortcode( $atts ) {
 			$a = shortcode_atts(
 				array(
@@ -470,9 +470,9 @@ public function leaderboard_shortcode( $atts ) {
 				'bhg_hunts'
 			);
 
-				global $wpdb;
-				$h         = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-				$aff_table = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliates' );
+			global $wpdb;
+			$h         = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			$aff_table = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliates' );
 
 			$where  = array();
 			$params = array();
@@ -508,25 +508,25 @@ public function leaderboard_shortcode( $atts ) {
 				$params[] = $since;
 			}
 
-                       $sql = 'SELECT h.id, h.title, h.starting_balance, h.final_balance, h.status, h.created_at, h.closed_at, a.name AS aff_name
+					$sql = 'SELECT h.id, h.title, h.starting_balance, h.final_balance, h.status, h.created_at, h.closed_at, a.name AS aff_name
                                         FROM %i h
                                         LEFT JOIN %i a ON a.id = h.affiliate_site_id';
-                       if ( $where ) {
-                               $sql .= ' WHERE ' . implode( ' AND ', $where );
-                       }
-                       $sql .= ' ORDER BY h.created_at DESC';
+			if ( $where ) {
+					$sql .= ' WHERE ' . implode( ' AND ', $where );
+			}
+					$sql .= ' ORDER BY h.created_at DESC';
 
 			if ( 'recent' === strtolower( $a['timeline'] ) ) {
 				$sql .= ' LIMIT 10';
 			}
 
-                       // db call ok; no-cache ok.
-                       if ( $params ) {
-                               $prep_args = array_merge( array( $sql, $h, $aff_table ), $params );
-                               $rows      = $wpdb->get_results( call_user_func_array( array( $wpdb, 'prepare' ), $prep_args ) );
-                       } else {
-                               $rows = $wpdb->get_results( $wpdb->prepare( $sql, $h, $aff_table ) );
-                       }
+					// db call ok; no-cache ok.
+			if ( $params ) {
+					$prep_args = array_merge( array( $sql, $h, $aff_table ), $params );
+					$rows      = $wpdb->get_results( call_user_func_array( array( $wpdb, 'prepare' ), $prep_args ) );
+			} else {
+					$rows = $wpdb->get_results( $wpdb->prepare( $sql, $h, $aff_table ) );
+			}
 			if ( ! $rows ) {
 				return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
@@ -559,45 +559,45 @@ public function leaderboard_shortcode( $atts ) {
 			return ob_get_clean();
 		}
 
-				/**
-				* [bhg_leaderboards] — show multiple hunts’ leaderboards.
-				* id (hunt), status, website, timeline (''|'recent'|day|week|month|year)
-				* aff yes/no (render affiliate dots)
-				* ranking 1-10, fields (comma-separated list)
-				*/
+			/**
+			 * [bhg_leaderboards] — show multiple hunts’ leaderboards.
+			 * id (hunt), status, website, timeline (''|'recent'|day|week|month|year)
+			 * aff yes/no (render affiliate dots)
+			 * ranking 1-10, fields (comma-separated list)
+			 */
 		public function leaderboards_shortcode( $atts ) {
 			$a = shortcode_atts(
-					array(
-							'id'       => 0,
-							'aff'      => 'yes',
-							'website'  => 0,
-							'status'   => '',
-							'timeline' => '',
-							'ranking'  => 0,
-							'fields'   => 'position,user,guess',
-					),
-					$atts,
-					'bhg_leaderboards'
+				array(
+					'id'       => 0,
+					'aff'      => 'yes',
+					'website'  => 0,
+					'status'   => '',
+					'timeline' => '',
+					'ranking'  => 0,
+					'fields'   => 'position,user,guess',
+				),
+				$atts,
+				'bhg_leaderboards'
 			);
 
 			global $wpdb;
-                        $h       = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-                        $ranking = max( 0, min( 10, (int) $a['ranking'] ) );
+					$h       = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+					$ranking = max( 0, min( 10, (int) $a['ranking'] ) );
 
-                       $fields_raw    = explode( ',', (string) $a['fields'] );
-                       $allowed_field = array( 'position', 'user', 'guess' );
-                       $fields_arr    = array_values(
-                               array_unique(
-                                       array_intersect(
-                                               $allowed_field,
-                                               array_map( 'sanitize_key', array_map( 'trim', $fields_raw ) )
-                                       )
-                               )
-                       );
-                       if ( empty( $fields_arr ) ) {
-                               $fields_arr = $allowed_field;
-                       }
-                       $fields = implode( ',', $fields_arr );
+					$fields_raw    = explode( ',', (string) $a['fields'] );
+					$allowed_field = array( 'position', 'user', 'guess' );
+					$fields_arr    = array_values(
+						array_unique(
+							array_intersect(
+								$allowed_field,
+								array_map( 'sanitize_key', array_map( 'trim', $fields_raw ) )
+							)
+						)
+					);
+			if ( empty( $fields_arr ) ) {
+					$fields_arr = $allowed_field;
+			}
+					$fields = implode( ',', $fields_arr );
 
 			$where  = array();
 			$params = array();
@@ -633,23 +633,23 @@ public function leaderboard_shortcode( $atts ) {
 				$params[] = $since;
 			}
 
-                       $sql = 'SELECT id, title FROM %i';
-                       if ( $where ) {
-                               $sql .= ' WHERE ' . implode( ' AND ', $where );
-                       }
-                       $sql .= ' ORDER BY created_at DESC';
+					$sql = 'SELECT id, title FROM %i';
+			if ( $where ) {
+					$sql .= ' WHERE ' . implode( ' AND ', $where );
+			}
+					$sql .= ' ORDER BY created_at DESC';
 
-                       if ( 'recent' === strtolower( $a['timeline'] ) ) {
-                               $sql .= ' LIMIT 5';
-                       }
+			if ( 'recent' === strtolower( $a['timeline'] ) ) {
+					$sql .= ' LIMIT 5';
+			}
 
-                                               // db call ok; no-cache ok.
-                                               if ( $params ) {
-                                                       $prep_args = array_merge( array( $sql, $h ), $params );
-                                                       $hunts     = $wpdb->get_results( call_user_func_array( array( $wpdb, 'prepare' ), $prep_args ) );
-                                               } else {
-                                                       $hunts = $wpdb->get_results( $wpdb->prepare( $sql, $h ) );
-                                               }
+											// db call ok; no-cache ok.
+			if ( $params ) {
+					$prep_args = array_merge( array( $sql, $h ), $params );
+					$hunts     = $wpdb->get_results( call_user_func_array( array( $wpdb, 'prepare' ), $prep_args ) );
+			} else {
+					$hunts = $wpdb->get_results( $wpdb->prepare( $sql, $h ) );
+			}
 			if ( ! $hunts ) {
 				return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
@@ -677,15 +677,15 @@ public function leaderboard_shortcode( $atts ) {
 			return ob_get_clean();
 		}
 
-		/**
-			* [bhg_tournaments]
-			* Filters:
-			*   status (active|closed), tournament (id), website (affiliate id),
-			*   timeline:
-			*     - relative date window: day|week|month|year
-			*     - or tournament type: weekly|monthly|yearly|quarterly|alltime
-			* Details view via ?bhg_tournament_id=ID
-			*/
+			/**
+			 * [bhg_tournaments]
+			 * Filters:
+			 *   status (active|closed), tournament (id), website (affiliate id),
+			 *   timeline:
+			 *     - relative date window: day|week|month|year
+			 *     - or tournament type: weekly|monthly|yearly|quarterly|alltime
+			 * Details view via ?bhg_tournament_id=ID
+			 */
 		public function tournaments_shortcode( $atts ) {
 			global $wpdb;
 
@@ -699,18 +699,18 @@ public function leaderboard_shortcode( $atts ) {
 			// Details screen
 			$details_id = isset( $_GET['bhg_tournament_id'] ) ? absint( wp_unslash( $_GET['bhg_tournament_id'] ) ) : 0;
 			if ( $details_id > 0 ) {
-						$t = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
-						$r = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
-						$u = $this->sanitize_table( $wpdb->users );
+					$t = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
+					$r = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
+					$u = $this->sanitize_table( $wpdb->users );
 
-								// db call ok; no-cache ok.
-                                               $tournament = $wpdb->get_row(
-                                                                               $wpdb->prepare(
-                                                                                               'SELECT id, type, start_date, end_date, status FROM %i WHERE id = %d',
-                                                                                               $t,
-                                                                                               $details_id
-                                                                               )
-                                               );
+							// db call ok; no-cache ok.
+											$tournament = $wpdb->get_row(
+												$wpdb->prepare(
+													'SELECT id, type, start_date, end_date, status FROM %i WHERE id = %d',
+													$t,
+													$details_id
+												)
+											);
 				if ( ! $tournament ) {
 					return '<p>' . esc_html__( 'Tournament not found.', 'bonus-hunt-guesser' ) . '</p>';
 				}
@@ -731,19 +731,19 @@ public function leaderboard_shortcode( $atts ) {
 				}
 				$order_by_sql = $allowed[ $orderby ] . ' ' . strtoupper( $order );
 
-								// db call ok; no-cache ok.
-                                                               $rows = $wpdb->get_results(
-                                                                               $wpdb->prepare(
-                                                                                               'SELECT r.user_id, r.wins, r.last_win_date, u.user_login
+							// db call ok; no-cache ok.
+															$rows = $wpdb->get_results(
+																$wpdb->prepare(
+																	'SELECT r.user_id, r.wins, r.last_win_date, u.user_login
                                                                                                        FROM %i r
                                                                                                        INNER JOIN %i u ON u.ID = r.user_id
                                                                                                        WHERE r.tournament_id = %d
                                                                                                        ORDER BY ' . $order_by_sql . ', r.user_id ASC',
-                                                                                               $r,
-                                                                                               $u,
-                                                                                               $tournament->id
-                                                                               )
-                                                               );
+																	$r,
+																	$u,
+																	$tournament->id
+																)
+															);
 
 				$base   = remove_query_arg( array( 'orderby', 'order' ) );
 				$toggle = function ( $key ) use ( $orderby, $order, $base ) {
@@ -759,13 +759,13 @@ public function leaderboard_shortcode( $atts ) {
 					);
 				};
 
-				ob_start();
-				echo '<div class="bhg-tournament-details">';
-				echo '<p><a href="' . esc_url( remove_query_arg( 'bhg_tournament_id' ) ) . '">&larr; ' . esc_html__( 'Back to tournaments', 'bonus-hunt-guesser' ) . '</a></p>';
-				echo '<h3>' . esc_html( ucfirst( $tournament->type ) ) . '</h3>';
-				echo '<p><strong>' . esc_html__( 'Start', 'bonus-hunt-guesser' ) . ':</strong> ' . esc_html( mysql2date( get_option( 'date_format' ), $tournament->start_date ) ) . ' &nbsp; ';
-				echo '<strong>' . esc_html__( 'End', 'bonus-hunt-guesser' ) . ':</strong> ' . esc_html( mysql2date( get_option( 'date_format' ), $tournament->end_date ) ) . ' &nbsp; ';
-				echo '<strong>' . esc_html__( 'Status', 'bonus-hunt-guesser' ) . ':</strong> ' . esc_html( $tournament->status ) . '</p>';
+					ob_start();
+					echo '<div class="bhg-tournament-details">';
+					echo '<p><a href="' . esc_url( remove_query_arg( 'bhg_tournament_id' ) ) . '">&larr; ' . esc_html__( 'Back to tournaments', 'bonus-hunt-guesser' ) . '</a></p>';
+					echo '<h3>' . esc_html( ucfirst( $tournament->type ) ) . '</h3>';
+					echo '<p><strong>' . esc_html__( 'Start', 'bonus-hunt-guesser' ) . ':</strong> ' . esc_html( mysql2date( get_option( 'date_format' ), $tournament->start_date ) ) . ' &nbsp; ';
+					echo '<strong>' . esc_html__( 'End', 'bonus-hunt-guesser' ) . ':</strong> ' . esc_html( mysql2date( get_option( 'date_format' ), $tournament->end_date ) ) . ' &nbsp; ';
+					echo '<strong>' . esc_html__( 'Status', 'bonus-hunt-guesser' ) . ':</strong> ' . esc_html( $tournament->status ) . '</p>';
 
 				if ( ! $rows ) {
 					echo '<p>' . esc_html__( 'No results yet.', 'bonus-hunt-guesser' ) . '</p>';
@@ -773,21 +773,21 @@ public function leaderboard_shortcode( $atts ) {
 					return ob_get_clean();
 				}
 
-				echo '<table class="bhg-leaderboard">';
-				echo '<thead><tr>';
-				echo '<th>#</th>';
-				echo '<th><a href="' . $toggle( 'username' ) . '">' . esc_html__( 'Username', 'bonus-hunt-guesser' ) . '</a></th>';
-				echo '<th><a href="' . $toggle( 'wins' ) . '">' . esc_html__( 'Wins', 'bonus-hunt-guesser' ) . '</a></th>';
-				echo '<th><a href="' . $toggle( 'last_win_at' ) . '">' . esc_html__( 'Last win', 'bonus-hunt-guesser' ) . '</a></th>';
-				echo '</tr></thead><tbody>';
+					echo '<table class="bhg-leaderboard">';
+					echo '<thead><tr>';
+					echo '<th>#</th>';
+					echo '<th><a href="' . $toggle( 'username' ) . '">' . esc_html__( 'Username', 'bonus-hunt-guesser' ) . '</a></th>';
+					echo '<th><a href="' . $toggle( 'wins' ) . '">' . esc_html__( 'Wins', 'bonus-hunt-guesser' ) . '</a></th>';
+					echo '<th><a href="' . $toggle( 'last_win_at' ) . '">' . esc_html__( 'Last win', 'bonus-hunt-guesser' ) . '</a></th>';
+					echo '</tr></thead><tbody>';
 
-				$pos = 1;
+					$pos = 1;
 				foreach ( $rows as $row ) {
 					echo '<tr>';
 					echo '<td>' . (int) $pos++ . '</td>';
 					echo '<td>' . esc_html(
 						$row->user_login ?: sprintf(
-							/* translators: %d: user ID. */
+						/* translators: %d: user ID. */
 							__( 'user#%d', 'bonus-hunt-guesser' ),
 							(int) $row->user_id
 						)
@@ -796,10 +796,10 @@ public function leaderboard_shortcode( $atts ) {
 					echo '<td>' . ( $row->last_win_date ? esc_html( mysql2date( get_option( 'date_format' ), $row->last_win_date ) ) : esc_html__( '—', 'bonus-hunt-guesser' ) ) . '</td>';
 					echo '</tr>';
 				}
-				echo '</tbody></table>';
-				echo '</div>';
+					echo '</tbody></table>';
+					echo '</div>';
 
-				return ob_get_clean();
+					return ob_get_clean();
 			}
 
 			// List view with filters
@@ -814,12 +814,12 @@ public function leaderboard_shortcode( $atts ) {
 				'bhg_tournaments'
 			);
 
-				$t          = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
-			$where      = array();
-			$args       = array();
+			$t     = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
+			$where = array();
+			$args  = array();
 
-			$status   = isset( $_GET['bhg_status'] ) ? sanitize_key( wp_unslash( $_GET['bhg_status'] ) ) : sanitize_key( $a['status'] );
-			$timeline = isset( $_GET['bhg_timeline'] ) ? sanitize_key( wp_unslash( $_GET['bhg_timeline'] ) ) : sanitize_key( $a['timeline'] );
+			$status     = isset( $_GET['bhg_status'] ) ? sanitize_key( wp_unslash( $_GET['bhg_status'] ) ) : sanitize_key( $a['status'] );
+			$timeline   = isset( $_GET['bhg_timeline'] ) ? sanitize_key( wp_unslash( $_GET['bhg_timeline'] ) ) : sanitize_key( $a['timeline'] );
 			$tournament = absint( $a['tournament'] );
 			$website    = absint( $a['website'] );
 
@@ -834,13 +834,13 @@ public function leaderboard_shortcode( $atts ) {
 
 			// Accept either relative time window OR explicit type
 			if ( in_array( $timeline, array( 'day', 'week', 'month', 'year' ), true ) ) {
-				$map    = array(
+				$map     = array(
 					'day'   => '-1 day',
 					'week'  => '-1 week',
 					'month' => '-1 month',
 					'year'  => '-1 year',
 				);
-				$since  = wp_date( 'Y-m-d H:i:s', strtotime( $map[ $timeline ], current_time( 'timestamp' ) ) );
+				$since   = wp_date( 'Y-m-d H:i:s', strtotime( $map[ $timeline ], current_time( 'timestamp' ) ) );
 				$where[] = 'created_at >= %s';
 				$args[]  = $since;
 			} elseif ( in_array( $timeline, array( 'weekly', 'monthly', 'yearly', 'quarterly', 'alltime' ), true ) ) {
@@ -853,26 +853,26 @@ public function leaderboard_shortcode( $atts ) {
 				$args[]  = $website;
 			}
 
-                       $sql = 'SELECT * FROM %i';
-                       if ( $where ) {
-                               $sql .= ' WHERE ' . implode( ' AND ', $where );
-                       }
-                                               $sql .= ' ORDER BY start_date DESC, id DESC';
+					$sql = 'SELECT * FROM %i';
+			if ( $where ) {
+					$sql .= ' WHERE ' . implode( ' AND ', $where );
+			}
+											$sql .= ' ORDER BY start_date DESC, id DESC';
 
-                                               // db call ok; no-cache ok.
-                                               if ( $args ) {
-                                                       $prep_args = array_merge( array( $sql, $t ), $args );
-                                                       $rows      = $wpdb->get_results( call_user_func_array( array( $wpdb, 'prepare' ), $prep_args ) );
-                                               } else {
-                                                       $rows = $wpdb->get_results( $wpdb->prepare( $sql, $t ) );
-                                               }
+											// db call ok; no-cache ok.
+			if ( $args ) {
+					$prep_args = array_merge( array( $sql, $t ), $args );
+					$rows      = $wpdb->get_results( call_user_func_array( array( $wpdb, 'prepare' ), $prep_args ) );
+			} else {
+					$rows = $wpdb->get_results( $wpdb->prepare( $sql, $t ) );
+			}
 			if ( ! $rows ) {
 				return '<p>' . esc_html__( 'No tournaments found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
 
 			$current_url = isset( $_SERVER['REQUEST_URI'] )
-				? esc_url_raw( wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) ) )
-				: home_url( '/' );
+			? esc_url_raw( wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) ) )
+			: home_url( '/' );
 
 			ob_start();
 			echo '<form method="get" class="bhg-tournament-filters">';
@@ -887,7 +887,7 @@ public function leaderboard_shortcode( $atts ) {
 
 			echo '<label class="bhg-tournament-label">' . esc_html__( 'Timeline:', 'bonus-hunt-guesser' ) . ' ';
 			echo '<select name="bhg_timeline">';
-			$timelines = array(
+			$timelines    = array(
 				'all'       => __( 'All', 'bonus-hunt-guesser' ),
 				'weekly'    => __( 'Weekly', 'bonus-hunt-guesser' ),
 				'monthly'   => __( 'Monthly', 'bonus-hunt-guesser' ),
@@ -907,7 +907,7 @@ public function leaderboard_shortcode( $atts ) {
 
 			echo '<label>' . esc_html__( 'Status:', 'bonus-hunt-guesser' ) . ' ';
 			echo '<select name="bhg_status">';
-			$statuses = array(
+			$statuses   = array(
 				'active' => __( 'Active', 'bonus-hunt-guesser' ),
 				'closed' => __( 'Closed', 'bonus-hunt-guesser' ),
 				'all'    => __( 'All', 'bonus-hunt-guesser' ),
@@ -945,7 +945,7 @@ public function leaderboard_shortcode( $atts ) {
 			return ob_get_clean();
 		}
 
-		/** Minimal winners widget: latest closed hunts */
+			/** Minimal winners widget: latest closed hunts */
 		public function winner_notifications_shortcode( $atts ) {
 			global $wpdb;
 
@@ -955,18 +955,18 @@ public function leaderboard_shortcode( $atts ) {
 				'bhg_winner_notifications'
 			);
 
-$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-// db call ok; no-cache ok.
-$hunts       = $wpdb->get_results(
-$wpdb->prepare(
-'SELECT id, title, final_balance, winners_count, closed_at
+			$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			// db call ok; no-cache ok.
+			$hunts = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT id, title, final_balance, winners_count, closed_at
         FROM %i
         WHERE status = %s ORDER BY closed_at DESC LIMIT %d',
-$hunts_table,
-'closed',
-(int) $a['limit']
-)
-);
+					$hunts_table,
+					'closed',
+					(int) $a['limit']
+				)
+			);
 
 			if ( ! $hunts ) {
 				return '<p>' . esc_html__( 'No closed hunts yet.', 'bonus-hunt-guesser' ) . '</p>';
@@ -983,8 +983,8 @@ $hunts_table,
 			echo '<div class="bhg-winner-notifications">';
 			foreach ( $hunts as $hunt ) {
 				$winners = function_exists( 'bhg_get_top_winners_for_hunt' )
-					? bhg_get_top_winners_for_hunt( $hunt->id, (int) $hunt->winners_count )
-					: array();
+				? bhg_get_top_winners_for_hunt( $hunt->id, (int) $hunt->winners_count )
+				: array();
 
 				echo '<div class="bhg-winner">';
 				echo '<p><strong>' . esc_html( $hunt->title ) . '</strong></p>';
@@ -1008,7 +1008,7 @@ $hunts_table,
 			return ob_get_clean();
 		}
 
-		/** Minimal profile view: affiliate status badge */
+			/** Minimal profile view: affiliate status badge */
 		public function user_profile_shortcode( $atts ) {
 			if ( ! is_user_logged_in() ) {
 				return '<p>' . esc_html__( 'Please log in to view this content.', 'bonus-hunt-guesser' ) . '</p>';
@@ -1025,7 +1025,7 @@ $hunts_table,
 			return '<div class="bhg-user-profile">' . $badge . ' ' . esc_html( wp_get_current_user()->display_name ) . '</div>';
 		}
 
-		/** [bhg_best_guessers] — simple wins leaderboard with tabs */
+			/** [bhg_best_guessers] — simple wins leaderboard with tabs */
 		public function best_guessers_shortcode( $atts ) {
 			global $wpdb;
 
@@ -1067,14 +1067,14 @@ $hunts_table,
 			$results = array();
 			foreach ( $periods as $key => $info ) {
 				if ( $info['type'] ) {
-					$where   = 't.type = %s';
-					$params  = array( $info['type'] );
+					$where  = 't.type = %s';
+					$params = array( $info['type'] );
 					if ( ! empty( $info['start'] ) && ! empty( $info['end'] ) ) {
 						$where   .= ' AND t.start_date >= %s AND t.end_date <= %s';
 						$params[] = $info['start'];
 						$params[] = $info['end'];
 					}
-                                       $sql = 'SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
+									$sql         = 'SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
                                                         FROM %i r
                                                         INNER JOIN %i u ON u.ID = r.user_id
                                                         INNER JOIN %i t ON t.id = r.tournament_id
@@ -1082,31 +1082,31 @@ $hunts_table,
                                                         GROUP BY u.ID, u.user_login
                                                         ORDER BY total_wins DESC, u.user_login ASC
                                                         LIMIT 50';
-                                       $prep_params     = array_merge( array( $sql, $wins_tbl, $users_tbl, $tours_tbl ), $params );
-                                       $prepared        = call_user_func_array( array( $wpdb, 'prepare' ), $prep_params );
-                                       // db call ok; no-cache ok.
-                                       $results[ $key ] = $wpdb->get_results( $prepared );
+									$prep_params = array_merge( array( $sql, $wins_tbl, $users_tbl, $tours_tbl ), $params );
+									$prepared    = call_user_func_array( array( $wpdb, 'prepare' ), $prep_params );
+									// db call ok; no-cache ok.
+									$results[ $key ] = $wpdb->get_results( $prepared );
 				} else {
-                                       $sql             = 'SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
+									$sql = 'SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
                                                                                                                 FROM %i r
                                                                                                                 INNER JOIN %i u ON u.ID = r.user_id
                                                                                                                 GROUP BY u.ID, u.user_login
                                                                                                                 ORDER BY total_wins DESC, u.user_login ASC
                                                                                                                 LIMIT 50';
-                                                                               // db call ok; no-cache ok.
-                                                                               $results[ $key ] = $wpdb->get_results( $wpdb->prepare( $sql, $wins_tbl, $users_tbl ) );
+																			// db call ok; no-cache ok.
+																			$results[ $key ] = $wpdb->get_results( $wpdb->prepare( $sql, $wins_tbl, $users_tbl ) );
 				}
 			}
 
-$hunts_tbl = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-$hunts     = $wpdb->get_results(
-$wpdb->prepare(
-'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC LIMIT %d',
-$hunts_tbl,
-'closed',
-50
-)
-);
+			$hunts_tbl = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			$hunts     = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC LIMIT %d',
+					$hunts_tbl,
+					'closed',
+					50
+				)
+			);
 
 			wp_enqueue_style(
 				'bhg-shortcodes',
@@ -1172,7 +1172,7 @@ $hunts_tbl,
 			return ob_get_clean();
 		}
 
-		/** Private: render affiliate dot span */
+			/** Private: render affiliate dot span */
 		private function render_affiliate_dot( $color ) {
 			$c = ( 'green' === $color ) ? 'green' : 'red';
 			return '<span class="bhg-aff-dot bhg-aff-' . esc_attr( $c ) . '" aria-hidden="true"></span> ';

--- a/includes/class-bhg-utils.php
+++ b/includes/class-bhg-utils.php
@@ -1,9 +1,9 @@
 <?php
 /**
-	* Utility functions and helpers for Bonus Hunt Guesser plugin.
-	*
-	* @package Bonus_Hunt_Guesser
-	*/
+ * Utility functions and helpers for Bonus Hunt Guesser plugin.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
 
 // phpcs:disable WordPress.Files.FileOrganization
 
@@ -12,32 +12,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
-	* General utility methods used throughout the plugin.
-	*/
+ * General utility methods used throughout the plugin.
+ */
 class BHG_Utils {
 	/**
-		* Register hooks used by utility functions.
-		*
-		* @return void
-		*/
+	 * Register hooks used by utility functions.
+	 *
+	 * @return void
+	 */
 	public static function init_hooks() {
 		add_action( 'init', array( __CLASS__, 'register_shortcodes' ) );
 	}
 
 	/**
-		* Register shortcodes handled in the shortcode constructor.
-		*
-		* @return void
-		*/
+	 * Register shortcodes handled in the shortcode constructor.
+	 *
+	 * @return void
+	 */
 	public static function register_shortcodes() {
 		// Handled in BHG_Shortcodes constructor, kept for legacy.
 	}
 
 	/**
-		* Retrieve plugin settings merged with defaults.
-		*
-		* @return array Plugin settings.
-		*/
+	 * Retrieve plugin settings merged with defaults.
+	 *
+	 * @return array Plugin settings.
+	 */
 	public static function get_settings() {
 		$defaults = array(
 			'allow_guess_edit' => 1,
@@ -52,11 +52,11 @@ class BHG_Utils {
 	}
 
 	/**
-		* Update plugin settings.
-		*
-		* @param array $data New settings data.
-		* @return array Updated settings.
-		*/
+	 * Update plugin settings.
+	 *
+	 * @param array $data New settings data.
+	 * @return array Updated settings.
+	 */
 	public static function update_settings( $data ) {
 		$current = self::get_settings();
 		$new     = array_merge( $current, $data );
@@ -65,10 +65,10 @@ class BHG_Utils {
 	}
 
 	/**
-		* Require manage options capability or abort.
-		*
-		* @return void
-		*/
+	 * Require manage options capability or abort.
+	 *
+	 * @return void
+	 */
 	public static function require_cap() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'You do not have permission to access this page', 'bonus-hunt-guesser' ) );
@@ -76,21 +76,21 @@ class BHG_Utils {
 	}
 
 	/**
-		* Output a nonce field for the given action.
-		*
-		* @param string $action Action name.
-		* @return void
-		*/
+	 * Output a nonce field for the given action.
+	 *
+	 * @param string $action Action name.
+	 * @return void
+	 */
 	public static function nonce_field( $action ) {
 		wp_nonce_field( $action, $action . '_nonce' );
 	}
 
 	/**
-		* Verify a nonce for the given action.
-		*
-		* @param string $action Action name.
-		* @return bool Whether the nonce is valid.
-		*/
+	 * Verify a nonce for the given action.
+	 *
+	 * @param string $action Action name.
+	 * @return bool Whether the nonce is valid.
+	 */
 	public static function verify_nonce( $action ) {
 		return isset( $_POST[ $action . '_nonce' ] )
 			&& wp_verify_nonce(
@@ -100,11 +100,11 @@ class BHG_Utils {
 	}
 
 	/**
-		* Execute a callback during template redirect after conditionals are set up.
-		*
-		* @param callable $cb Callback to execute.
-		* @return void
-		*/
+	 * Execute a callback during template redirect after conditionals are set up.
+	 *
+	 * @param callable $cb Callback to execute.
+	 * @return void
+	 */
 	public static function safe_query_conditionals( callable $cb ) {
 		add_action(
 			'template_redirect',

--- a/includes/demo.php
+++ b/includes/demo.php
@@ -1,131 +1,222 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; }
 
-function bhg_seed_demo_on_activation(){
+function bhg_seed_demo_on_activation() {
 	// Only seed once
-	if (get_option('bhg_demo_seeded')) return;
+	if ( get_option( 'bhg_demo_seeded' ) ) {
+		return;
+	}
 
 	// Create demo users (if not exist)
-	$users = array(
-		array('user_login' => 'alice_demo', 'user_email' => 'alice_demo@example.com'),
-		array('user_login' => 'bob_demo', 'user_email' => 'bob_demo@example.com'),
-		array('user_login' => 'charlie_demo', 'user_email' => 'charlie_demo@example.com'),
+	$users    = array(
+		array(
+			'user_login' => 'alice_demo',
+			'user_email' => 'alice_demo@example.com',
+		),
+		array(
+			'user_login' => 'bob_demo',
+			'user_email' => 'bob_demo@example.com',
+		),
+		array(
+			'user_login' => 'charlie_demo',
+			'user_email' => 'charlie_demo@example.com',
+		),
 	);
 	$user_ids = array();
-	foreach ($users as $u){
-		$uid = username_exists($u['user_login']);
-		if (!$uid){
-			$pass = wp_generate_password(12, false);
-			$uid = wp_create_user($u['user_login'], $pass, $u['user_email']);
-			if (is_wp_error($uid)) { $uid = 0; }
+	foreach ( $users as $u ) {
+		$uid = username_exists( $u['user_login'] );
+		if ( ! $uid ) {
+			$pass = wp_generate_password( 12, false );
+			$uid  = wp_create_user( $u['user_login'], $pass, $u['user_email'] );
+			if ( is_wp_error( $uid ) ) {
+				$uid = 0; }
 		}
-		$user_ids[$u['user_login']] = $uid ? intval($uid) : 0;
+		$user_ids[ $u['user_login'] ] = $uid ? intval( $uid ) : 0;
 	}
 
 	global $wpdb;
-	$hunts = $wpdb->prefix . 'bhg_bonus_hunts';
-	$guesses = $wpdb->prefix . 'bhg_guesses';
+	$hunts       = $wpdb->prefix . 'bhg_bonus_hunts';
+	$guesses     = $wpdb->prefix . 'bhg_guesses';
 	$tournaments = $wpdb->prefix . 'bhg_tournaments';
-	$aff = $wpdb->prefix . 'bhg_affiliate_websites';
-	$ads = $wpdb->prefix . 'bhg_ads';
-	$trans = $wpdb->prefix . 'bhg_translations';
+	$aff         = $wpdb->prefix . 'bhg_affiliate_websites';
+	$ads         = $wpdb->prefix . 'bhg_ads';
+	$trans       = $wpdb->prefix . 'bhg_translations';
 
 	// Insert affiliate sites
-	$wpdb->insert($aff, array('name'=>'Demo Affiliate 1','slug'=>'demo-aff-1','url'=>'https://demo-affiliate1.test'));
-	$wpdb->insert($aff, array('name'=>'Demo Affiliate 2','slug'=>'demo-aff-2','url'=>'https://demo-affiliate2.test'));
+	$wpdb->insert(
+		$aff,
+		array(
+			'name' => 'Demo Affiliate 1',
+			'slug' => 'demo-aff-1',
+			'url'  => 'https://demo-affiliate1.test',
+		)
+	);
+	$wpdb->insert(
+		$aff,
+		array(
+			'name' => 'Demo Affiliate 2',
+			'slug' => 'demo-aff-2',
+			'url'  => 'https://demo-affiliate2.test',
+		)
+	);
 
 	// Insert a demo hunt (open) and a demo closed hunt
-	$wpdb->insert($hunts, array(
-		'title' => 'Bonus Hunt – Demo (Open)',
-		'starting_balance' => 2000.00,
-		'num_bonuses' => 10,
-		'prizes' => 'Gift Card €50, Merch',
-		'status' => 'open',
-		'created_at' => current_time('mysql')
-	));
-	$open_id = intval($wpdb->insert_id);
+	$wpdb->insert(
+		$hunts,
+		array(
+			'title'            => 'Bonus Hunt – Demo (Open)',
+			'starting_balance' => 2000.00,
+			'num_bonuses'      => 10,
+			'prizes'           => 'Gift Card €50, Merch',
+			'status'           => 'open',
+			'created_at'       => current_time( 'mysql' ),
+		)
+	);
+	$open_id = intval( $wpdb->insert_id );
 
-	$wpdb->insert($hunts, array(
-		'title' => 'Bonus Hunt – Demo (Closed)',
-		'starting_balance' => 1500.00,
-		'num_bonuses' => 8,
-		'prizes' => 'Gift Card €25',
-		'status' => 'closed',
-		'final_balance' => 2420.00,
-		'winner_user_id' => 0,
-		'winner_diff' => 0,
-		'closed_at' => current_time('mysql', true),
-		'created_at' => current_time('mysql')
-	));
-	$closed_id = intval($wpdb->insert_id);
+	$wpdb->insert(
+		$hunts,
+		array(
+			'title'            => 'Bonus Hunt – Demo (Closed)',
+			'starting_balance' => 1500.00,
+			'num_bonuses'      => 8,
+			'prizes'           => 'Gift Card €25',
+			'status'           => 'closed',
+			'final_balance'    => 2420.00,
+			'winner_user_id'   => 0,
+			'winner_diff'      => 0,
+			'closed_at'        => current_time( 'mysql', true ),
+			'created_at'       => current_time( 'mysql' ),
+		)
+	);
+	$closed_id = intval( $wpdb->insert_id );
 
 	// Add demo guesses for closed hunt
 	$grows = array(
-		array('hunt_id'=>$closed_id,'user_id'=>$user_ids['alice_demo'],'guess_amount'=>2450.00),
-		array('hunt_id'=>$closed_id,'user_id'=>$user_ids['bob_demo'],'guess_amount'=>2400.00),
-		array('hunt_id'=>$closed_id,'user_id'=>$user_ids['charlie_demo'],'guess_amount'=>1800.00),
+		array(
+			'hunt_id'      => $closed_id,
+			'user_id'      => $user_ids['alice_demo'],
+			'guess_amount' => 2450.00,
+		),
+		array(
+			'hunt_id'      => $closed_id,
+			'user_id'      => $user_ids['bob_demo'],
+			'guess_amount' => 2400.00,
+		),
+		array(
+			'hunt_id'      => $closed_id,
+			'user_id'      => $user_ids['charlie_demo'],
+			'guess_amount' => 1800.00,
+		),
 	);
-	foreach ($grows as $r){
-		if ($r['user_id']) {
-			$wpdb->insert($guesses, array(
-				'hunt_id'=>$r['hunt_id'],
-				'user_id'=>$r['user_id'],
-				'guess_amount'=>$r['guess_amount'],
-				'created_at'=> current_time('mysql')
-			));
+	foreach ( $grows as $r ) {
+		if ( $r['user_id'] ) {
+			$wpdb->insert(
+				$guesses,
+				array(
+					'hunt_id'      => $r['hunt_id'],
+					'user_id'      => $r['user_id'],
+					'guess_amount' => $r['guess_amount'],
+					'created_at'   => current_time( 'mysql' ),
+				)
+			);
 		}
 	}
 
 	// Compute winner for the closed hunt (closest)
-	$rows = $wpdb->get_results( "SELECT * FROM `{$closed_id}`" );
-	$final = 2420.00;
-	$winner_id = 0; $winner_diff = null;
-	foreach ($rows as $row){
-		$diff = abs(floatval($row->guess_amount) - $final);
-		if ($winner_diff === null || $diff < $winner_diff){
+	$rows        = $wpdb->get_results( "SELECT * FROM `{$closed_id}`" );
+	$final       = 2420.00;
+	$winner_id   = 0;
+	$winner_diff = null;
+	foreach ( $rows as $row ) {
+		$diff = abs( floatval( $row->guess_amount ) - $final );
+		if ( $winner_diff === null || $diff < $winner_diff ) {
 			$winner_diff = $diff;
-			$winner_id = intval($row->user_id);
+			$winner_id   = intval( $row->user_id );
 		}
 	}
-	$wpdb->update($hunts, array('winner_user_id'=>$winner_id, 'winner_diff'=>$winner_diff), array('id'=>$closed_id));
+	$wpdb->update(
+		$hunts,
+		array(
+			'winner_user_id' => $winner_id,
+			'winner_diff'    => $winner_diff,
+		),
+		array( 'id' => $closed_id )
+	);
 
 	// Insert a demo tournament (monthly)
-	$wpdb->insert($tournaments, array(
-		'title' => 'Monthly Tournament (Demo)',
-		'status' => 'active',
-		'created_at' => current_time('mysql')
-	));
+	$wpdb->insert(
+		$tournaments,
+		array(
+			'title'      => 'Monthly Tournament (Demo)',
+			'status'     => 'active',
+			'created_at' => current_time( 'mysql' ),
+		)
+	);
 
 	// Translations & Ads samples
-	$wpdb->insert($trans, array('tkey'=>'email_results_title', 'tvalue'=>'The Bonus Hunt has been closed!'));
-	$wpdb->insert($trans, array('tkey'=>'email_final_balance', 'tvalue'=>'Final Balance'));
-	$wpdb->insert($trans, array('tkey'=>'email_winner', 'tvalue'=>'Winner'));
-	$wpdb->insert($ads, array(
-		'title'        => '',
-		'content'      => 'Sponsored by Demo Casino – Play Now',
-		'link_url'     => 'https://example.com',
-		'placement'    => 'footer',
-		'visible_to'   => 'guests',
-		'target_pages' => '',
-		'active'       => 1,
-	));
+	$wpdb->insert(
+		$trans,
+		array(
+			'tkey'   => 'email_results_title',
+			'tvalue' => 'The Bonus Hunt has been closed!',
+		)
+	);
+	$wpdb->insert(
+		$trans,
+		array(
+			'tkey'   => 'email_final_balance',
+			'tvalue' => 'Final Balance',
+		)
+	);
+	$wpdb->insert(
+		$trans,
+		array(
+			'tkey'   => 'email_winner',
+			'tvalue' => 'Winner',
+		)
+	);
+	$wpdb->insert(
+		$ads,
+		array(
+			'title'        => '',
+			'content'      => 'Sponsored by Demo Casino – Play Now',
+			'link_url'     => 'https://example.com',
+			'placement'    => 'footer',
+			'visible_to'   => 'guests',
+			'target_pages' => '',
+			'active'       => 1,
+		)
+	);
 
 	// Create demo pages with shortcodes (with (Demo) suffix)
 	$pages = array(
-		array('title'=>'Bonus Hunt (Demo)', 'content'=>'[bhg_bonus_hunt]'),
-		array('title'=>'Leaderboard (Demo)', 'content'=>'[bhg_leaderboard]'),
-		array('title'=>'Tournaments (Demo)', 'content'=>'[bhg_tournament_leaderboard]'),
+		array(
+			'title'   => 'Bonus Hunt (Demo)',
+			'content' => '[bhg_bonus_hunt]',
+		),
+		array(
+			'title'   => 'Leaderboard (Demo)',
+			'content' => '[bhg_leaderboard]',
+		),
+		array(
+			'title'   => 'Tournaments (Demo)',
+			'content' => '[bhg_tournament_leaderboard]',
+		),
 	);
-	foreach ($pages as $p){
-		if (!get_page_by_title($p['title'])){
-			wp_insert_post(array(
-				'post_title' => $p['title'],
-				'post_content' => $p['content'],
-				'post_status' => 'publish',
-				'post_type' => 'page'
-			));
+	foreach ( $pages as $p ) {
+		if ( ! get_page_by_title( $p['title'] ) ) {
+			wp_insert_post(
+				array(
+					'post_title'   => $p['title'],
+					'post_content' => $p['content'],
+					'post_status'  => 'publish',
+					'post_type'    => 'page',
+				)
+			);
 		}
 	}
 
-	update_option('bhg_demo_seeded', 1);
+	update_option( 'bhg_demo_seeded', 1 );
 }

--- a/includes/helpers-aff-dot.php
+++ b/includes/helpers-aff-dot.php
@@ -1,9 +1,9 @@
 <?php
 /**
-	* Helper functions for rendering affiliate indicators.
-	*
-	* @package Bonus_Hunt_Guesser
-	*/
+ * Helper functions for rendering affiliate indicators.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 		exit;
@@ -11,13 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! function_exists( 'bhg_render_affiliate_dot' ) ) {
 		/**
-			* Render a green/red dot based on affiliate status for the current hunt/site.
-			*
-			* @param int $user_id               User ID.
-			* @param int $hunt_affiliate_site_id Affiliate site ID. Optional.
-			*
-			* @return string HTML span element representing the affiliate dot.
-			*/
+		 * Render a green/red dot based on affiliate status for the current hunt/site.
+		 *
+		 * @param int $user_id               User ID.
+		 * @param int $hunt_affiliate_site_id Affiliate site ID. Optional.
+		 *
+		 * @return string HTML span element representing the affiliate dot.
+		 */
 	function bhg_render_affiliate_dot( $user_id, $hunt_affiliate_site_id = 0 ) {
 			$is_aff = false;
 		if ( function_exists( 'bhg_is_user_affiliate_for_site' ) ) {

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,20 +1,20 @@
 <?php
 /**
-	* Helper functions.
-	*
-	* @package Bonus_Hunt_Guesser
-	*/
+ * Helper functions.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
-	* Log debug messages when WP_DEBUG is enabled.
-	*
-	* @param mixed $message Message to log.
-	* @return void
-	*/
+ * Log debug messages when WP_DEBUG is enabled.
+ *
+ * @param mixed $message Message to log.
+ * @return void
+ */
 function bhg_log( $message ) {
 	if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
 		return;
@@ -28,21 +28,21 @@ function bhg_log( $message ) {
 }
 
 /**
-	* Get the current user ID or 0 if not logged in.
-	*
-	* @return int
-	*/
+ * Get the current user ID or 0 if not logged in.
+ *
+ * @return int
+ */
 function bhg_current_user_id() {
 	$uid = get_current_user_id();
 	return $uid ? (int) $uid : 0;
 }
 
 /**
-	* Create a URL-friendly slug.
-	*
-	* @param string $text Text to slugify.
-	* @return string
-	*/
+ * Create a URL-friendly slug.
+ *
+ * @param string $text Text to slugify.
+ * @return string
+ */
 function bhg_slugify( $text ) {
 	$text = sanitize_title( $text );
 	if ( '' === $text ) {
@@ -52,10 +52,10 @@ function bhg_slugify( $text ) {
 }
 
 /**
-	* Get admin capability for BHG plugin.
-	*
-	* @return string
-	*/
+ * Get admin capability for BHG plugin.
+ *
+ * @return string
+ */
 function bhg_admin_cap() {
 	return apply_filters( 'bhg_admin_capability', 'manage_options' );
 }
@@ -81,22 +81,22 @@ add_filter(
 );
 
 /**
-	* Determine if code runs on the frontend.
-	*
-	* @return bool
-	*/
+ * Determine if code runs on the frontend.
+ *
+ * @return bool
+ */
 function bhg_is_frontend() {
 	return ! is_admin() && ! wp_doing_ajax() && ! wp_doing_cron();
 }
 
 if ( ! function_exists( 'bhg_t' ) ) {
 	/**
-		* Retrieve a translation value from the database.
-		*
-		* @param string $key     Translation key.
-		* @param string $default Default text if not found.
-		* @return string
-		*/
+	 * Retrieve a translation value from the database.
+	 *
+	 * @param string $key     Translation key.
+	 * @param string $default Default text if not found.
+	 * @return string
+	 */
 	function bhg_t( $key, $default = '' ) {
 		global $wpdb;
 		static $cache = array();
@@ -123,10 +123,10 @@ if ( ! function_exists( 'bhg_t' ) ) {
 
 if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 	/**
-		* Retrieve default translation key/value pairs.
-		*
-		* @return array
-		*/
+	 * Retrieve default translation key/value pairs.
+	 *
+	 * @return array
+	 */
 	function bhg_get_default_translations() {
 		return array(
 			// General / menus / labels.
@@ -139,12 +139,12 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'menu_users'                                   => 'Users',
 			'menu_affiliates'                              => 'Affiliates',
 			'menu_advertising'                             => 'Advertising',
-						'menu_translations'                            => 'Translations',
-						'menu_tools'                                   => 'Tools',
-						'menu_ads'                                     => 'Ads',
-						'bhg_menu_admin'                               => 'BHG Menu — Admin/Moderators',
-						'bhg_menu_loggedin'                            => 'BHG Menu — Logged-in Users',
-						'bhg_menu_guests'                              => 'BHG Menu — Guests',
+			'menu_translations'                            => 'Translations',
+			'menu_tools'                                   => 'Tools',
+			'menu_ads'                                     => 'Ads',
+			'bhg_menu_admin'                               => 'BHG Menu — Admin/Moderators',
+			'bhg_menu_loggedin'                            => 'BHG Menu — Logged-in Users',
+			'bhg_menu_guests'                              => 'BHG Menu — Guests',
 
 			// Form/field labels.
 			'label_start_balance'                          => 'Starting Balance',
@@ -154,9 +154,9 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'label_guess'                                  => 'Guess',
 			'label_username'                               => 'Username',
 			'label_position'                               => 'Position',
-                        'label_final_balance'                          => 'Final Balance',
-                        'label_difference'                             => 'Difference',
-                        'label_leaderboard'                            => 'Leaderboard',
+			'label_final_balance'                          => 'Final Balance',
+			'label_difference'                             => 'Difference',
+			'label_leaderboard'                            => 'Leaderboard',
 			'label_affiliate'                              => 'Affiliate',
 			'label_non_affiliate'                          => 'Non-affiliate',
 			'label_affiliate_status'                       => 'Affiliate Status',
@@ -203,50 +203,50 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'label_timeline'                               => 'Timeline',
 			'label_choose_hunt'                            => 'Choose a hunt:',
 			'label_select_hunt'                            => 'Select a hunt',
-						'label_guess_final_balance'                    => 'Your guess (final balance):',
-						'label_bonus_hunt_title'                       => 'Bonus Hunt Title',
-						'label_existing_bonus_hunts'                   => 'Existing Bonus Hunts',
-						'label_start_balance_euro'                     => 'Starting Balance (€)',
-						'label_prizes_description'                     => 'Prizes Description',
-						'label_created'                                => 'Created',
-						'label_completed'                              => 'Completed',
-						'label_upcoming'                               => 'Upcoming',
-						'label_diff_short'                             => 'Diff',
-						'label_not_set'                                => 'Not set',
-						'label_dash'                                   => '-',
-						'label_untitled'                               => '(untitled)',
-						'label_back_to_tournaments'                    => 'Back to tournaments',
-						'label_last_day'                               => 'Last day',
-						'label_last_week'                              => 'Last week',
-						'label_last_month'                             => 'Last month',
-						'label_last_year'                              => 'Last year',
-						'label_quarterly'                              => 'Quarterly',
-						'label_alltime'                                => 'Alltime',
-						'label_guests'                                 => 'Guests',
-						'label_logged_in'                              => 'Logged In',
-						'label_non_affiliates'                         => 'Non Affiliates',
-						'label_affiliate_website'                      => 'Affiliate Website',
-						'label_affiliate_websites'                     => 'Affiliate Websites',
-						'label_affiliate_user_title'                   => 'Affiliate User',
-						'label_footer'                                 => 'Footer',
-						'label_bottom'                                 => 'Bottom',
-						'label_sidebar'                                => 'Sidebar',
-						'label_shortcode'                              => 'Shortcode',
-						'label_timeline_colon'                         => 'Timeline:',
-						'label_user_hash'                              => 'user#%d',
-						'label_emdash'                                 => '—',
+			'label_guess_final_balance'                    => 'Your guess (final balance):',
+			'label_bonus_hunt_title'                       => 'Bonus Hunt Title',
+			'label_existing_bonus_hunts'                   => 'Existing Bonus Hunts',
+			'label_start_balance_euro'                     => 'Starting Balance (€)',
+			'label_prizes_description'                     => 'Prizes Description',
+			'label_created'                                => 'Created',
+			'label_completed'                              => 'Completed',
+			'label_upcoming'                               => 'Upcoming',
+			'label_diff_short'                             => 'Diff',
+			'label_not_set'                                => 'Not set',
+			'label_dash'                                   => '-',
+			'label_untitled'                               => '(untitled)',
+			'label_back_to_tournaments'                    => 'Back to tournaments',
+			'label_last_day'                               => 'Last day',
+			'label_last_week'                              => 'Last week',
+			'label_last_month'                             => 'Last month',
+			'label_last_year'                              => 'Last year',
+			'label_quarterly'                              => 'Quarterly',
+			'label_alltime'                                => 'Alltime',
+			'label_guests'                                 => 'Guests',
+			'label_logged_in'                              => 'Logged In',
+			'label_non_affiliates'                         => 'Non Affiliates',
+			'label_affiliate_website'                      => 'Affiliate Website',
+			'label_affiliate_websites'                     => 'Affiliate Websites',
+			'label_affiliate_user_title'                   => 'Affiliate User',
+			'label_footer'                                 => 'Footer',
+			'label_bottom'                                 => 'Bottom',
+			'label_sidebar'                                => 'Sidebar',
+			'label_shortcode'                              => 'Shortcode',
+			'label_timeline_colon'                         => 'Timeline:',
+			'label_user_hash'                              => 'user#%d',
+			'label_emdash'                                 => '—',
 
-						// Buttons.
-						'button_save'                                  => 'Save',
-						'button_cancel'                                => 'Cancel',
-						'button_delete'                                => 'Delete',
-						'button_edit'                                  => 'Edit',
-                                                'button_view'                                  => 'View',
-                                                'button_back'                                  => 'Back',
-                                                'button_create_new_bonus_hunt'                 => 'Create New Bonus Hunt',
-                        'button_results'                              => 'Results',
-                        'button_filter'                                => 'Filter',
-                        'button_log_in'                                => 'Log in',
+			// Buttons.
+			'button_save'                                  => 'Save',
+			'button_cancel'                                => 'Cancel',
+			'button_delete'                                => 'Delete',
+			'button_edit'                                  => 'Edit',
+			'button_view'                                  => 'View',
+			'button_back'                                  => 'Back',
+			'button_create_new_bonus_hunt'                 => 'Create New Bonus Hunt',
+			'button_results'                               => 'Results',
+			'button_filter'                                => 'Filter',
+			'button_log_in'                                => 'Log in',
 
 			// Notices / messages.
 			'notice_login_required'                        => 'You must be logged in to guess.',
@@ -279,22 +279,22 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'notice_no_winners_yet'                        => 'No winners yet.',
 			'notice_login_view_profile'                    => 'Please log in to view your profile.',
 			'notice_please_log_in'                         => 'Please log in.',
-						'notice_results_pending'                       => 'Results pending.',
-						'notice_bonus_hunt_created'                    => 'Bonus hunt created successfully!',
-						'notice_bonus_hunt_updated'                    => 'Bonus hunt updated successfully!',
-						'notice_bonus_hunt_deleted'                    => 'Bonus hunt deleted successfully!',
-						'notice_guess_removed_successfully'            => 'Guess removed successfully.',
-						'notice_no_ads_yet'                            => 'No ads yet.',
-						'notice_no_bonus_hunts_found'                  => 'No bonus hunts found.',
-						'notice_no_guesses_yet'                        => 'No guesses yet.',
-						'notice_no_tournaments_found'                  => 'No tournaments found.',
-						'notice_invalid_table'                         => 'Invalid table.',
-						'notice_required_helpers_missing'              => 'Required helper functions are missing. Please include class-bhg-bonus-hunts.php helpers.',
-						'confirm_delete_bonus_hunt'                    => 'Are you sure you want to delete this bonus hunt?',
-						'title_results_s'                              => 'Results — %s',
+			'notice_results_pending'                       => 'Results pending.',
+			'notice_bonus_hunt_created'                    => 'Bonus hunt created successfully!',
+			'notice_bonus_hunt_updated'                    => 'Bonus hunt updated successfully!',
+			'notice_bonus_hunt_deleted'                    => 'Bonus hunt deleted successfully!',
+			'notice_guess_removed_successfully'            => 'Guess removed successfully.',
+			'notice_no_ads_yet'                            => 'No ads yet.',
+			'notice_no_bonus_hunts_found'                  => 'No bonus hunts found.',
+			'notice_no_guesses_yet'                        => 'No guesses yet.',
+			'notice_no_tournaments_found'                  => 'No tournaments found.',
+			'notice_invalid_table'                         => 'Invalid table.',
+			'notice_required_helpers_missing'              => 'Required helper functions are missing. Please include class-bhg-bonus-hunts.php helpers.',
+			'confirm_delete_bonus_hunt'                    => 'Are you sure you want to delete this bonus hunt?',
+			'title_results_s'                              => 'Results — %s',
 
-						// Shortcode labels for public views.
-						'sc_hunt'                                      => 'Hunt',
+			// Shortcode labels for public views.
+			'sc_hunt'                                      => 'Hunt',
 			'sc_guess'                                     => 'Guess',
 			'sc_final'                                     => 'Final',
 			'sc_title'                                     => 'Title',
@@ -429,12 +429,12 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'period'                                       => 'Period:',
 			'placement'                                    => 'Placement',
 			'please_enter_a_guess'                         => 'Please enter a guess.',
-                        'guess_required'                               => 'Please enter a guess.',
-                        'please_enter_a_valid_number'                  => 'Please enter a valid number.',
-                        'guess_numeric'                                => 'Please enter a valid number.',
-                        'guess_range'                                  => 'Guess must be between %1$s and %2$s.',
-                        'guess_submitted'                              => 'Your guess has been submitted!',
-                        'ajax_error'                                   => 'An error occurred. Please try again.',
+			'guess_required'                               => 'Please enter a guess.',
+			'please_enter_a_valid_number'                  => 'Please enter a valid number.',
+			'guess_numeric'                                => 'Please enter a valid number.',
+			'guess_range'                                  => 'Guess must be between %1$s and %2$s.',
+			'guess_submitted'                              => 'Your guess has been submitted!',
+			'ajax_error'                                   => 'An error occurred. Please try again.',
 			'profile'                                      => 'Profile',
 			'reminder_assign_your_bhg_menus_adminmoderator_loggedin_guest_under_appearance_menus_manage_locations_use_shortcode_bhgnav_to_display' => 'Reminder: Assign your BHG menus (Admin/Moderator, Logged-in, Guest) under Appearance → Menus → Manage Locations. Use shortcode [bhg_nav] to display.',
 			'remove'                                       => 'Remove',
@@ -495,12 +495,12 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 }
 
 if ( ! function_exists( 'bhg_seed_default_translations' ) ) {
-       /**
-                * Seed default translations, inserting any missing keys.
-                *
-                * @return void
-                */
-       function bhg_seed_default_translations() {
+		/**
+		 * Seed default translations, inserting any missing keys.
+		 *
+		 * @return void
+		 */
+	function bhg_seed_default_translations() {
 		global $wpdb;
 
 		$table = $wpdb->prefix . 'bhg_translations';
@@ -528,30 +528,30 @@ if ( ! function_exists( 'bhg_seed_default_translations' ) ) {
 					),
 					array( '%s', '%s', '%s' )
 				);
-       }
-}
+			}
+		}
 	}
 }
 
 /**
-	* Format an amount as currency.
-	*
-	* Allows the currency symbol to be customized via the `bhg_currency_symbol` filter.
-	*
-	* @param float $amount Amount to format.
-	* @return string
-	*/
+ * Format an amount as currency.
+ *
+ * Allows the currency symbol to be customized via the `bhg_currency_symbol` filter.
+ *
+ * @param float $amount Amount to format.
+ * @return string
+ */
 function bhg_format_currency( $amount ) {
 	$symbol = apply_filters( 'bhg_currency_symbol', '€' );
 	return sprintf( '%s%s', $symbol, number_format_i18n( (float) $amount, 2 ) );
 }
 
 /**
-	* Validate a guess amount against settings.
-	*
-	* @param mixed $guess Guess value.
-	* @return bool
-	*/
+ * Validate a guess amount against settings.
+ *
+ * @param mixed $guess Guess value.
+ * @return bool
+ */
 function bhg_validate_guess( $guess ) {
 	$settings  = get_option( 'bhg_plugin_settings', array() );
 	$min_guess = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
@@ -566,13 +566,13 @@ function bhg_validate_guess( $guess ) {
 }
 
 /**
-	* Get a user's display name with affiliate indicator.
-	*
-	* Uses the `bhg_is_affiliate` user meta to determine affiliate status.
-	*
-	* @param int $user_id User ID.
-	* @return string Display name with optional affiliate indicator.
-	*/
+ * Get a user's display name with affiliate indicator.
+ *
+ * Uses the `bhg_is_affiliate` user meta to determine affiliate status.
+ *
+ * @param int $user_id User ID.
+ * @return string Display name with optional affiliate indicator.
+ */
 function bhg_get_user_display_name( $user_id ) {
 	$user = get_userdata( (int) $user_id );
 	if ( ! $user ) {
@@ -591,11 +591,11 @@ function bhg_get_user_display_name( $user_id ) {
 
 if ( ! function_exists( 'bhg_is_user_affiliate' ) ) {
 	/**
-		* Check if a user is an affiliate.
-		*
-		* @param int $user_id User ID.
-		* @return bool
-		*/
+	 * Check if a user is an affiliate.
+	 *
+	 * @param int $user_id User ID.
+	 * @return bool
+	 */
 	function bhg_is_user_affiliate( $user_id ) {
 		$val = get_user_meta( (int) $user_id, 'bhg_is_affiliate', true );
 		return ( '1' === $val || 1 === $val || true === $val || 'yes' === $val );
@@ -604,11 +604,11 @@ if ( ! function_exists( 'bhg_is_user_affiliate' ) ) {
 
 if ( ! function_exists( 'bhg_get_user_affiliate_sites' ) ) {
 	/**
-		* Get affiliate site IDs for a user.
-		*
-		* @param int $user_id User ID.
-		* @return array
-		*/
+	 * Get affiliate site IDs for a user.
+	 *
+	 * @param int $user_id User ID.
+	 * @return array
+	 */
 	function bhg_get_user_affiliate_sites( $user_id ) {
 		$ids = get_user_meta( (int) $user_id, 'bhg_affiliate_sites', true );
 		if ( is_array( $ids ) ) {
@@ -623,12 +623,12 @@ if ( ! function_exists( 'bhg_get_user_affiliate_sites' ) ) {
 
 if ( ! function_exists( 'bhg_set_user_affiliate_sites' ) ) {
 	/**
-		* Store affiliate site IDs for a user.
-		*
-		* @param int   $user_id  User ID.
-		* @param array $site_ids Site IDs.
-		* @return void
-		*/
+	 * Store affiliate site IDs for a user.
+	 *
+	 * @param int   $user_id  User ID.
+	 * @param array $site_ids Site IDs.
+	 * @return void
+	 */
 	function bhg_set_user_affiliate_sites( $user_id, $site_ids ) {
 		$clean = array();
 		if ( is_array( $site_ids ) ) {
@@ -645,12 +645,12 @@ if ( ! function_exists( 'bhg_set_user_affiliate_sites' ) ) {
 
 if ( ! function_exists( 'bhg_is_user_affiliate_for_site' ) ) {
 	/**
-		* Determine if a user is an affiliate for a specific site.
-		*
-		* @param int $user_id User ID.
-		* @param int $site_id Site ID.
-		* @return bool
-		*/
+	 * Determine if a user is an affiliate for a specific site.
+	 *
+	 * @param int $user_id User ID.
+	 * @param int $site_id Site ID.
+	 * @return bool
+	 */
 	function bhg_is_user_affiliate_for_site( $user_id, $site_id ) {
 		if ( ! $site_id ) {
 			return bhg_is_user_affiliate( (int) $user_id );
@@ -662,12 +662,12 @@ if ( ! function_exists( 'bhg_is_user_affiliate_for_site' ) ) {
 
 if ( ! function_exists( 'bhg_render_affiliate_dot' ) ) {
 	/**
-		* Render affiliate status dot.
-		*
-		* @param int $user_id                User ID.
-		* @param int $hunt_affiliate_site_id Hunt affiliate site ID.
-		* @return string
-		*/
+	 * Render affiliate status dot.
+	 *
+	 * @param int $user_id                User ID.
+	 * @param int $hunt_affiliate_site_id Hunt affiliate site ID.
+	 * @return string
+	 */
 	function bhg_render_affiliate_dot( $user_id, $hunt_affiliate_site_id = 0 ) {
 		$is_aff = bhg_is_user_affiliate_for_site( (int) $user_id, (int) $hunt_affiliate_site_id );
 		$cls    = $is_aff ? 'bhg-aff-green' : 'bhg-aff-red';
@@ -677,12 +677,12 @@ if ( ! function_exists( 'bhg_render_affiliate_dot' ) ) {
 }
 
 /**
-	* Render advertising blocks based on placement and user state.
-	*
-	* @param string $placement Placement location.
-	* @param int    $hunt_id   Hunt ID.
-	* @return string
-	*/
+ * Render advertising blocks based on placement and user state.
+ *
+ * @param string $placement Placement location.
+ * @param int    $hunt_id   Hunt ID.
+ * @return string
+ */
 function bhg_render_ads( $placement = 'footer', $hunt_id = 0 ) {
 	global $wpdb;
 	$tbl          = $wpdb->prefix . 'bhg_ads';
@@ -748,10 +748,10 @@ function bhg_render_ads( $placement = 'footer', $hunt_id = 0 ) {
 // Demo reset and seed data.
 if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 	/**
-		* Reset demo tables and seed sample data.
-		*
-		* @return bool
-		*/
+	 * Reset demo tables and seed sample data.
+	 *
+	 * @return bool
+	 */
 	function bhg_reset_demo_and_seed() {
 		global $wpdb;
 
@@ -883,10 +883,10 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 
 			$closed = $wpdb->get_results( "SELECT winner_user_id, closed_at FROM {$hunts_tbl} WHERE status='closed' AND winner_user_id IS NOT NULL" );
 			foreach ( $closed as $row ) {
-				$ts       = $row->closed_at ? strtotime( $row->closed_at ) : time();
-				$iso_year = gmdate( 'o', $ts );
-				$week     = str_pad( gmdate( 'W', $ts ), 2, '0', STR_PAD_LEFT );
-				$week_key = $iso_year . '-W' . $week;
+				$ts        = $row->closed_at ? strtotime( $row->closed_at ) : time();
+				$iso_year  = gmdate( 'o', $ts );
+				$week      = str_pad( gmdate( 'W', $ts ), 2, '0', STR_PAD_LEFT );
+				$week_key  = $iso_year . '-W' . $week;
 				$month_key = gmdate( 'Y-m', $ts );
 				$year_key  = gmdate( 'Y', $ts );
 


### PR DESCRIPTION
## Summary
- Run PHP_CodeSniffer and autofix WordPress Coding Standards
- Convert indentation to tabs and align docblocks across admin and includes files

## Testing
- `composer install`
- `vendor/bin/phpcs --standard=phpcs.xml bonus-hunt-guesser.php admin includes uninstall.php` *(fails: missing doc comments and direct database calls)*

------
https://chatgpt.com/codex/tasks/task_e_68bd11d11f0c833390d26267dae58a2a