### PR TITLE
Use wpdb prepare for dynamic queries

### DIFF
--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -18,11 +18,12 @@ if ( ! $hunt ) {
 
 $aff_table = $wpdb->prefix . 'bhg_affiliates';
 if ( isset( $allowed_tables ) && ! in_array( $aff_table, $allowed_tables, true ) ) {
-		wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+                wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
-$aff_table = esc_sql( $aff_table );
-$affs      = $wpdb->get_results( "SELECT id, name FROM {$aff_table} ORDER BY name ASC" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table name is sanitized and query uses no dynamic values.
-$sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
+$affs = $wpdb->get_results(
+                $wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
+);
+$sel  = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
 
 $paged    = max( 1, absint( wp_unslash( $_GET['ppaged'] ?? '' ) ) );
 $per_page = 30;

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -22,8 +22,6 @@ $allowed_tables = array(
 if ( ! in_array( $hunts_table, $allowed_tables, true ) || ! in_array( $guesses_table, $allowed_tables, true ) ) {
 	wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
-$hunts_table   = esc_sql( $hunts_table );
-$guesses_table = esc_sql( $guesses_table );
 
 $view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'list';
 
@@ -220,11 +218,10 @@ if ( $view === 'add' ) :
 			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
 				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 			}
-			$aff_table = esc_sql( $aff_table );
-						// db call ok; no-cache ok.
-						$affs = $wpdb->get_results(
-							$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
-						);
+                        // db call ok; no-cache ok.
+                        $affs = $wpdb->get_results(
+                                $wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
+                        );
 			$sel              = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
 			?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
@@ -280,16 +277,15 @@ if ( $view === 'edit' ) :
 	if ( ! in_array( $users_table, $allowed_tables, true ) ) {
 		wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 	}
-	$users_table = esc_sql( $users_table );
-		// db call ok; no-cache ok.
-		$guesses = $wpdb->get_results(
-			$wpdb->prepare(
-				'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
-				$guesses_table,
-				$users_table,
-				$id
-			)
-		);
+        // db call ok; no-cache ok.
+                $guesses = $wpdb->get_results(
+                        $wpdb->prepare(
+                                'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
+                                $guesses_table,
+                                $users_table,
+                                $id
+                        )
+                );
 	?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Edit Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
@@ -325,11 +321,10 @@ if ( $view === 'edit' ) :
 			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
 				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 			}
-			$aff_table = esc_sql( $aff_table );
-						// db call ok; no-cache ok.
-						$affs = $wpdb->get_results(
-							$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
-						);
+                        // db call ok; no-cache ok.
+                        $affs = $wpdb->get_results(
+                                $wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
+                        );
 			$sel              = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
 			?>
 			<select id="bhg_affiliate" name="affiliate_site_id">

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -251,24 +251,25 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 							$total = $ranking;
 					}
 
-					$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-					// db call ok; no-cache ok.
-											$rows = $wpdb->get_results(
-												$wpdb->prepare(
-													'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id
+                                        $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+                                        // db call ok; no-cache ok.
+                                        $rows = $wpdb->get_results(
+                                                $wpdb->prepare(
+                                                        'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id
                                                                                         FROM %i g
                                                                                         LEFT JOIN %i u ON u.ID = g.user_id
                                                                                         LEFT JOIN %i h ON h.id = g.hunt_id
                                                                                         WHERE g.hunt_id = %d
-                                                                                        ORDER BY ' . $orderby . ' ' . $order . ' LIMIT %d OFFSET %d',
-													$g,
-													$u,
-													$hunts_table,
-													$hunt_id,
-													$per,
-													$offset
-												)
-											);
+                                                                                        ORDER BY %i ' . $order . ' LIMIT %d OFFSET %d',
+                                                        $g,
+                                                        $u,
+                                                        $hunts_table,
+                                                        $hunt_id,
+                                                        $orderby,
+                                                        $per,
+                                                        $offset
+                                                )
+                                        );
 
 					wp_enqueue_style(
 						'bhg-shortcodes',
@@ -409,13 +410,13 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				$limit_sql = ' LIMIT 10';
 			}
 
-											$sql = 'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id
+                                                                                        $sql = 'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id
                                                                                FROM %i g INNER JOIN %i h ON h.id = g.hunt_id
                                                                                WHERE ' . implode( ' AND ', $where ) . '
-                                                                               ORDER BY ' . $orderby . ' ' . $order . $limit_sql;
+                                                                               ORDER BY %i ' . $order . $limit_sql;
 
-											$prep_params = array_merge( array( $sql, $g, $h ), $params );
-											$query       = call_user_func_array( array( $wpdb, 'prepare' ), $prep_params );
+                                                                                        $prep_params = array_merge( array( $sql, $g, $h ), $params, array( $orderby ) );
+                                                                                        $query       = call_user_func_array( array( $wpdb, 'prepare' ), $prep_params );
 					// db call ok; no-cache ok.
 					$rows = $wpdb->get_results( $query );
 			if ( ! $rows ) {
@@ -729,21 +730,23 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				if ( 'asc' !== $order && 'desc' !== $order ) {
 					$order = 'desc';
 				}
-				$order_by_sql = $allowed[ $orderby ] . ' ' . strtoupper( $order );
+                                $orderby_column = $allowed[ $orderby ];
+                                $order          = strtoupper( $order );
 
-							// db call ok; no-cache ok.
-															$rows = $wpdb->get_results(
-																$wpdb->prepare(
-																	'SELECT r.user_id, r.wins, r.last_win_date, u.user_login
+                                // db call ok; no-cache ok.
+                                $rows = $wpdb->get_results(
+                                        $wpdb->prepare(
+                                                'SELECT r.user_id, r.wins, r.last_win_date, u.user_login
                                                                                                        FROM %i r
                                                                                                        INNER JOIN %i u ON u.ID = r.user_id
                                                                                                        WHERE r.tournament_id = %d
-                                                                                                       ORDER BY ' . $order_by_sql . ', r.user_id ASC',
-																	$r,
-																	$u,
-																	$tournament->id
-																)
-															);
+                                                                                                       ORDER BY %i ' . $order . ', r.user_id ASC',
+                                                $r,
+                                                $u,
+                                                $tournament->id,
+                                                $orderby_column
+                                        )
+                                );
 
 				$base   = remove_query_arg( array( 'orderby', 'order' ) );
 				$toggle = function ( $key ) use ( $orderby, $order, $base ) {


### PR DESCRIPTION
## Summary
- use `$wpdb->prepare()` for affiliate list query
- drop manual `esc_sql()` sanitization in bonus hunt admin views
- prepare leaderboard and tournament queries with placeholders instead of interpolation

## Testing
- `php -l admin/views/bonus-hunts-edit.php`
- `php -l admin/views/bonus-hunts.php`
- `php -l includes/class-bhg-shortcodes.php`
- `composer phpcs` *(fails: coding standard violations in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68bd12c743c883338d7a80b463775f63