### PR TITLE
Improve translations management with inline editing

### DIFF
--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -1,6 +1,12 @@
 <?php
+/**
+ * Admin view for managing plugin translations.
+ *
+ * @package BonusHuntGuesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+		exit; }
 
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
@@ -16,82 +22,105 @@ if ( function_exists( 'bhg_seed_default_translations' ) ) {
 $default_translations = function_exists( 'bhg_get_default_translations' ) ? bhg_get_default_translations() : array();
 $default_keys         = array_keys( $default_translations );
 
-// Handle form submission
-if ( $_SERVER['REQUEST_METHOD'] === 'POST' && isset( $_POST['bhg_save_translation'] ) ) {
-	// Verify nonce
-	if ( ! isset( $_POST['bhg_nonce'] ) || ! wp_verify_nonce( $_POST['bhg_nonce'], 'bhg_save_translation_action' ) ) {
-		wp_die( esc_html__( 'Security check failed.', 'bonus-hunt-guesser' ) );
+// Current search term.
+$search_term = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+
+// Handle form submission.
+if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['bhg_save_translation'] ) ) {
+		// Verify nonce.
+		$nonce = isset( $_POST['bhg_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['bhg_nonce'] ) ) : '';
+	if ( ! $nonce || ! wp_verify_nonce( $nonce, 'bhg_save_translation_action' ) ) {
+			wp_die( esc_html__( 'Security check failed.', 'bonus-hunt-guesser' ) );
 	}
 
-	// Sanitize input
-	$tkey   = isset( $_POST['tkey'] ) ? sanitize_text_field( wp_unslash( $_POST['tkey'] ) ) : '';
-	$tvalue = isset( $_POST['tvalue'] ) ? sanitize_textarea_field( wp_unslash( $_POST['tvalue'] ) ) : '';
+		// Sanitize input.
+		$tkey   = isset( $_POST['tkey'] ) ? sanitize_text_field( wp_unslash( $_POST['tkey'] ) ) : '';
+		$tvalue = isset( $_POST['tvalue'] ) ? sanitize_textarea_field( wp_unslash( $_POST['tvalue'] ) ) : '';
 
-	// Validate input
-	if ( $tkey === '' ) {
-		$error = __( 'Key field is required.', 'bonus-hunt-guesser' );
+		// Validate input.
+	if ( '' === $tkey ) {
+			$form_error = __( 'Key field is required.', 'bonus-hunt-guesser' );
 	} else {
-		$wpdb->replace(
-			$table,
-			array(
-				'tkey'   => $tkey,
-				'tvalue' => $tvalue,
-			),
-			array( '%s', '%s' )
-		);
-		$notice = __( 'Translation saved.', 'bonus-hunt-guesser' );
+			$wpdb->replace(
+				$table,
+				array(
+					'tkey'   => $tkey,
+					'tvalue' => $tvalue,
+				),
+				array( '%s', '%s' )
+			);
+			$notice = __( 'Translation saved.', 'bonus-hunt-guesser' );
 	}
 }
 
-// Fetch rows
-$rows = $wpdb->get_results( "SELECT tkey, tvalue FROM {$table} ORDER BY tkey ASC" );
+// Fetch rows.
+$query = "SELECT tkey, tvalue FROM {$table}";
+if ( $search_term ) {
+	$like   = '%' . $wpdb->esc_like( $search_term ) . '%';
+	$query .= $wpdb->prepare( ' WHERE tkey LIKE %s OR tvalue LIKE %s', $like, $like );
+}
+$query .= ' ORDER BY tkey ASC';
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+$rows = $wpdb->get_results( $query );
 ?>
 <div class="wrap">
-	<h1><?php esc_html_e( 'Translations', 'bonus-hunt-guesser' ); ?></h1>
+<h1><?php esc_html_e( 'Translations', 'bonus-hunt-guesser' ); ?></h1>
 
-	<style>
-	.bhg-default-row td { background-color: #fffbcc; }
-	</style>
+<?php if ( ! empty( $notice ) ) : ?>
+<div class="notice notice-success"><p><?php echo esc_html( $notice ); ?></p></div>
+<?php endif; ?>
+<?php if ( ! empty( $form_error ) ) : ?>
+<div class="notice notice-error"><p><?php echo esc_html( $form_error ); ?></p></div>
+<?php endif; ?>
 
-	<?php if ( ! empty( $notice ) ) : ?>
-	<div class="notice notice-success"><p><?php echo esc_html( $notice ); ?></p></div>
-	<?php endif; ?>
-	<?php if ( ! empty( $error ) ) : ?>
-	<div class="notice notice-error"><p><?php echo esc_html( $error ); ?></p></div>
-	<?php endif; ?>
+<form method="post">
+<?php wp_nonce_field( 'bhg_save_translation_action', 'bhg_nonce' ); ?>
+<table class="form-table" role="presentation">
+<tbody>
+<tr>
+<th scope="row"><label for="tkey"><?php esc_html_e( 'Key', 'bonus-hunt-guesser' ); ?></label></th>
+<td><input name="tkey" id="tkey" type="text" class="regular-text" required></td>
+</tr>
+<tr>
+<th scope="row"><label for="tvalue"><?php esc_html_e( 'Value', 'bonus-hunt-guesser' ); ?></label></th>
+<td><textarea name="tvalue" id="tvalue" class="large-text" rows="4"></textarea></td>
+</tr>
+</tbody>
+</table>
+<p class="submit"><button type="submit" name="bhg_save_translation" class="button button-primary"><?php esc_html_e( 'Save', 'bonus-hunt-guesser' ); ?></button></p>
+</form>
 
-	<form method="post">
-	<?php wp_nonce_field( 'bhg_save_translation_action', 'bhg_nonce' ); ?>
-	<table class="form-table" role="presentation">
-		<tbody>
-		<tr>
-			<th scope="row"><label for="tkey"><?php esc_html_e( 'Key', 'bonus-hunt-guesser' ); ?></label></th>
-			<td><input name="tkey" id="tkey" type="text" class="regular-text" required></td>
-		</tr>
-		<tr>
-			<th scope="row"><label for="tvalue"><?php esc_html_e( 'Value', 'bonus-hunt-guesser' ); ?></label></th>
-			<td><textarea name="tvalue" id="tvalue" class="large-text" rows="4"></textarea></td>
-		</tr>
-		</tbody>
-	</table>
-			<p class="submit"><button type="submit" name="bhg_save_translation" class="button button-primary"><?php esc_html_e( 'Save', 'bonus-hunt-guesser' ); ?></button></p>
-	</form>
+<form method="get" class="bhg-translations-search">
+<input type="hidden" name="page" value="bhg-translations" />
+<p class="search-box">
+<label class="screen-reader-text" for="bhg-translation-search-input"><?php esc_html_e( 'Search translations', 'bonus-hunt-guesser' ); ?></label>
+<input type="search" id="bhg-translation-search-input" name="s" value="<?php echo esc_attr( $search_term ); ?>" />
+<button class="button"><?php esc_html_e( 'Search', 'bonus-hunt-guesser' ); ?></button>
+</p>
+</form>
 
-	<h2><?php esc_html_e( 'Existing keys', 'bonus-hunt-guesser' ); ?></h2>
-	<table class="widefat striped">
-	<thead><tr><th><?php esc_html_e( 'Key', 'bonus-hunt-guesser' ); ?></th><th><?php esc_html_e( 'Value', 'bonus-hunt-guesser' ); ?></th></tr></thead>
-	<tbody>
-		<?php
-		if ( $rows ) :
-			foreach ( $rows as $r ) :
-				?>
-		<tr<?php echo in_array( $r->tkey, $default_keys, true ) ? ' class="bhg-default-row"' : ''; ?>>
-			<td><code><?php echo esc_html( $r->tkey ); ?></code></td>
-			<td><?php echo esc_html( $r->tvalue ); ?></td>
-		</tr>
-					<?php endforeach; else : ?>
-		<tr><td colspan="2"><?php esc_html_e( 'No translations yet.', 'bonus-hunt-guesser' ); ?></td></tr>
-		<?php endif; ?>
-	</tbody>
-	</table>
+<h2><?php esc_html_e( 'Existing keys', 'bonus-hunt-guesser' ); ?></h2>
+<table class="widefat striped bhg-translations-table">
+<thead><tr><th><?php esc_html_e( 'Key', 'bonus-hunt-guesser' ); ?></th><th><?php esc_html_e( 'Value', 'bonus-hunt-guesser' ); ?></th></tr></thead>
+<tbody>
+<?php
+if ( $rows ) :
+	foreach ( $rows as $r ) :
+		?>
+<tr<?php echo in_array( $r->tkey, $default_keys, true ) ? ' class="bhg-default-row"' : ''; ?>>
+<td><code><?php echo esc_html( $r->tkey ); ?></code></td>
+<td>
+<form method="post" class="bhg-inline-form">
+		<?php wp_nonce_field( 'bhg_save_translation_action', 'bhg_nonce' ); ?>
+<input type="hidden" name="tkey" value="<?php echo esc_attr( $r->tkey ); ?>" />
+<input type="text" name="tvalue" value="<?php echo esc_attr( $r->tvalue ); ?>" class="regular-text" />
+<button type="submit" name="bhg_save_translation" class="button"><?php esc_html_e( 'Update', 'bonus-hunt-guesser' ); ?></button>
+</form>
+</td>
+</tr>
+<?php endforeach; else : ?>
+<tr><td colspan="2"><?php esc_html_e( 'No translations yet.', 'bonus-hunt-guesser' ); ?></td></tr>
+<?php endif; ?>
+</tbody>
+</table>
 </div>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -49,6 +49,28 @@
     text-align: center;
 }
 
+/* Translations page */
+.bhg-translations-search {
+margin-bottom: 1em;
+}
+
+.bhg-translations-table td {
+padding: 8px 10px;
+}
+
+.bhg-translations-table .bhg-inline-form {
+display: flex;
+gap: 8px;
+}
+
+.bhg-translations-table .bhg-inline-form input[type="text"] {
+flex: 1;
+}
+
+.bhg-default-row {
+background-color: #fff8e5;
+}
+
 /* Dashboard styles */
 :root {
     --bhg-accent-color: #2271b1;


### PR DESCRIPTION
## Summary
- Allow searching plugin translations and edit each row inline with nonce protection
- Style translations table for spacing and highlight default strings

## Testing
- `composer install`
- `vendor/bin/phpcbf --standard=phpcs.xml admin/views/translations.php`
- `composer phpcs admin/views/translations.php assets/css/admin.css` *(fails: Use of a direct database call is discouraged)*

------
https://chatgpt.com/codex/tasks/task_e_68bd146222408333b0de19dbf332a3eb