### PR TITLE
Add nonce checks for admin forms

### DIFF
--- a/admin/class-bhg-bonus-hunts-controller.php
+++ b/admin/class-bhg-bonus-hunts-controller.php
@@ -78,12 +78,9 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 			}
 
 			$action       = sanitize_text_field( wp_unslash( $_POST['bhg_action'] ) );
-			$nonce        = isset( $_POST['bhg_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['bhg_nonce'] ) ) : '';
 			$nonce_action = 'bhg_' . $action;
 
-			if ( ! wp_verify_nonce( $nonce, $nonce_action ) ) {
-				wp_die( 'Security check failed' );
-			}
+			check_admin_referer( $nonce_action, 'bhg_nonce' );
 
 			$db      = new BHG_DB();
 			$message = 'error';

--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -18,9 +18,9 @@ $ad_id   = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
 $edit_id = isset( $_GET['edit'] ) ? absint( wp_unslash( $_GET['edit'] ) ) : 0;
 
 // Delete action
-if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
-	$nonce = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );
-	if ( wp_verify_nonce( $nonce, 'bhg_delete_ad' ) && current_user_can( 'manage_options' ) ) {
+if ( 'delete' === $action && $ad_id ) {
+	check_admin_referer( 'bhg_delete_ad' );
+	if ( current_user_can( 'manage_options' ) ) {
 		$wpdb->delete( $table, array( 'id' => $ad_id ), array( '%d' ) );
 		wp_safe_redirect( remove_query_arg( array( 'action', 'id', '_wpnonce' ) ) );
 		exit;

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -8,18 +8,14 @@ if ( ! current_user_can( 'manage_options' ) ) {
 
 // Handle form submissions
 if ( isset( $_POST['bhg_action'] ) ) {
-	if ( $_POST['bhg_action'] === 'db_cleanup' && isset( $_POST['bhg_db_cleanup'] ) ) {
-		if ( ! wp_verify_nonce( $_POST['bhg_nonce'], 'bhg_db_cleanup_action' ) ) {
-			wp_die( esc_html__( 'Security check failed', 'bonus-hunt-guesser' ) );
-		}
+	if ( 'db_cleanup' === $_POST['bhg_action'] && isset( $_POST['bhg_db_cleanup'] ) ) {
+		check_admin_referer( 'bhg_db_cleanup_action', 'bhg_nonce' );
 
 		// Perform database cleanup
 		bhg_database_cleanup();
 		$cleanup_completed = true;
-	} elseif ( $_POST['bhg_action'] === 'db_optimize' && isset( $_POST['bhg_db_optimize'] ) ) {
-		if ( ! wp_verify_nonce( $_POST['bhg_nonce'], 'bhg_db_optimize_action' ) ) {
-			wp_die( esc_html__( 'Security check failed', 'bonus-hunt-guesser' ) );
-		}
+	} elseif ( 'db_optimize' === $_POST['bhg_action'] && isset( $_POST['bhg_db_optimize'] ) ) {
+		check_admin_referer( 'bhg_db_optimize_action', 'bhg_nonce' );
 
 		// Perform database optimization
 		bhg_database_optimize();

--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -18,9 +18,7 @@ if ( isset( $_POST['bhg_action'] ) ) {
 
 	// Verify nonce based on action
 	$nonce_action = 'bhg_' . $action;
-	if ( ! isset( $_POST['bhg_nonce'] ) || ! wp_verify_nonce( $_POST['bhg_nonce'], $nonce_action ) ) {
-		wp_die( 'Security check failed' );
-	}
+	check_admin_referer( $nonce_action, 'bhg_nonce' );
 
 	switch ( $action ) {
 		case 'create_bonus_hunt':

--- a/admin/views/hunts-edit.php
+++ b/admin/views/hunts-edit.php
@@ -11,7 +11,8 @@ if ( ! $hunt_id ) {
 check_admin_referer( 'bhg_edit_hunt_' . $hunt_id, 'bhg_nonce' );
 
 // Handle delete guess action
-if ( isset( $_POST['bhg_remove_guess'] ) && isset( $_POST['bhg_remove_guess_nonce'] ) && wp_verify_nonce( $_POST['bhg_remove_guess_nonce'], 'bhg_remove_guess_action' ) ) {
+if ( isset( $_POST['bhg_remove_guess'] ) ) {
+	check_admin_referer( 'bhg_remove_guess_action', 'bhg_remove_guess_nonce' );
 	$guess_id = (int) ( $_POST['guess_id'] ?? 0 );
 	if ( $guess_id > 0 && function_exists( 'bhg_remove_guess' ) ) {
 		bhg_remove_guess( $guess_id );

--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -26,14 +26,11 @@ $default_keys         = array_keys( $default_translations );
 $search_term = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
 
 // Handle form submission.
-if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['bhg_save_translation'] ) ) {
-		// Verify nonce.
-		$nonce = isset( $_POST['bhg_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['bhg_nonce'] ) ) : '';
-	if ( ! $nonce || ! wp_verify_nonce( $nonce, 'bhg_save_translation_action' ) ) {
-			wp_die( esc_html__( 'Security check failed.', 'bonus-hunt-guesser' ) );
-	}
 
-		// Sanitize input.
+if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['bhg_save_translation'] ) ) {
+	check_admin_referer( 'bhg_save_translation_action', 'bhg_nonce' );
+
+	// Sanitize input.
 		$tkey   = isset( $_POST['tkey'] ) ? sanitize_text_field( wp_unslash( $_POST['tkey'] ) ) : '';
 		$tvalue = isset( $_POST['tvalue'] ) ? sanitize_textarea_field( wp_unslash( $_POST['tvalue'] ) ) : '';
 

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -361,8 +361,8 @@ function bhg_handle_settings_save() {
 		wp_die( esc_html__( 'You do not have sufficient permissions to perform this action.', 'bonus-hunt-guesser' ) );
 	}
 
-		// Verify nonce.
-	if ( ! isset( $_POST['bhg_settings_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['bhg_settings_nonce'] ) ), 'bhg_save_settings_nonce' ) ) {
+	// Verify nonce.
+	if ( ! check_admin_referer( 'bhg_save_settings_nonce', 'bhg_settings_nonce' ) ) {
 		wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg-settings&error=nonce_failed' ) ) );
 		exit;
 	}

--- a/includes/class-bhg-login-redirect.php
+++ b/includes/class-bhg-login-redirect.php
@@ -1,11 +1,23 @@
 <?php
+/**
+ * Login redirect handling for Bonus Hunt Guesser.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
+	/**
+	 * Manage login redirection.
+	 */
 	class BHG_Login_Redirect {
 
+		/**
+		 * Setup hooks.
+		 */
 		public function __construct() {
 			add_filter( 'login_redirect', array( $this, 'core_login_redirect' ), 10, 3 );
 
@@ -15,6 +27,14 @@ if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
 			}
 		}
 
+		/**
+		 * Core login redirect handler.
+		 *
+		 * @param string  $redirect_to Default redirect destination.
+		 * @param string  $requested   Requested redirect URL.
+		 * @param WP_User $user        Logged-in user object.
+		 * @return string Sanitized redirect URL.
+		 */
 		public function core_login_redirect( $redirect_to, $requested, $user ) {
 			if ( ! empty( $_REQUEST['redirect_to'] ) ) {
 				$requested_redirect = sanitize_text_field( wp_unslash( $_REQUEST['redirect_to'] ) );
@@ -33,6 +53,14 @@ if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
 			return esc_url_raw( $validated_default );
 		}
 
+		/**
+		 * Handle Nextend Social Login redirect.
+		 *
+		 * @param string  $redirect_to Requested redirect URL.
+		 * @param WP_User $user       WP_User object of the logged-in user.
+		 * @param string  $provider    Social login provider slug.
+		 * @return string Sanitized redirect URL.
+		 */
 		public function nextend_redirect( $redirect_to, $user, $provider ) {
 			if ( ! empty( $_REQUEST['redirect_to'] ) ) {
 				$requested_redirect = sanitize_text_field( wp_unslash( $_REQUEST['redirect_to'] ) );


### PR DESCRIPTION
## Summary
- ensure settings handler uses `check_admin_referer`
- verify nonce on translation, database, advertising and hunt forms
- document login redirect helper for phpcs compliance

## Testing
- `composer install`
- `vendor/bin/phpcs admin/class-bhg-bonus-hunts-controller.php admin/views/advertising.php admin/views/database.php admin/views/header.php admin/views/hunts-edit.php admin/views/translations.php bonus-hunt-guesser.php includes/class-bhg-login-redirect.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd1653699c8333b19ec94537080f85