### PR TITLE
Use concatenated ORDER BY fields in shortcodes

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -253,23 +253,22 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 
                                         $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
                                         // db call ok; no-cache ok.
-                                        $rows = $wpdb->get_results(
-                                                $wpdb->prepare(
-                                                        'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id
-                                                                                        FROM %i g
-                                                                                        LEFT JOIN %i u ON u.ID = g.user_id
-                                                                                        LEFT JOIN %i h ON h.id = g.hunt_id
-                                                                                        WHERE g.hunt_id = %d
-                                                                                        ORDER BY %i ' . $order . ' LIMIT %d OFFSET %d',
-                                                        $g,
-                                                        $u,
-                                                        $hunts_table,
-                                                        $hunt_id,
-                                                        $orderby,
-                                                        $per,
-                                                        $offset
-                                                )
-                                        );
+                                       $rows = $wpdb->get_results(
+                                               $wpdb->prepare(
+                                                       'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id
+                                                                                       FROM %i g
+                                                                                       LEFT JOIN %i u ON u.ID = g.user_id
+                                                                                       LEFT JOIN %i h ON h.id = g.hunt_id
+                                                                                       WHERE g.hunt_id = %d
+                                                                                       ORDER BY ' . $orderby . ' ' . $order . ' LIMIT %d OFFSET %d',
+                                                       $g,
+                                                       $u,
+                                                       $hunts_table,
+                                                       $hunt_id,
+                                                       $per,
+                                                       $offset
+                                               )
+                                       );
 
 					wp_enqueue_style(
 						'bhg-shortcodes',
@@ -410,15 +409,15 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				$limit_sql = ' LIMIT 10';
 			}
 
-                                                                                        $sql = 'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id
+                                                                                $sql = 'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id
                                                                                FROM %i g INNER JOIN %i h ON h.id = g.hunt_id
                                                                                WHERE ' . implode( ' AND ', $where ) . '
-                                                                               ORDER BY %i ' . $order . $limit_sql;
+                                                                               ORDER BY ' . $orderby . ' ' . $order . $limit_sql;
 
-                                                                                        $prep_params = array_merge( array( $sql, $g, $h ), $params, array( $orderby ) );
-                                                                                        $query       = call_user_func_array( array( $wpdb, 'prepare' ), $prep_params );
-					// db call ok; no-cache ok.
-					$rows = $wpdb->get_results( $query );
+                                                                                $prep_params = array_merge( array( $sql, $g, $h ), $params );
+                                                                                $query       = call_user_func_array( array( $wpdb, 'prepare' ), $prep_params );
+                                       // db call ok; no-cache ok.
+                                       $rows = $wpdb->get_results( $query );
 			if ( ! $rows ) {
 				return '<p>' . esc_html__( 'No guesses found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
@@ -734,19 +733,18 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
                                 $order          = strtoupper( $order );
 
                                 // db call ok; no-cache ok.
-                                $rows = $wpdb->get_results(
-                                        $wpdb->prepare(
-                                                'SELECT r.user_id, r.wins, r.last_win_date, u.user_login
-                                                                                                       FROM %i r
-                                                                                                       INNER JOIN %i u ON u.ID = r.user_id
-                                                                                                       WHERE r.tournament_id = %d
-                                                                                                       ORDER BY %i ' . $order . ', r.user_id ASC',
-                                                $r,
-                                                $u,
-                                                $tournament->id,
-                                                $orderby_column
-                                        )
-                                );
+                               $rows = $wpdb->get_results(
+                                       $wpdb->prepare(
+                                               'SELECT r.user_id, r.wins, r.last_win_date, u.user_login
+                                                                                                      FROM %i r
+                                                                                                      INNER JOIN %i u ON u.ID = r.user_id
+                                                                                                      WHERE r.tournament_id = %d
+                                                                                                      ORDER BY ' . $orderby_column . ' ' . $order . ', r.user_id ASC',
+                                               $r,
+                                               $u,
+                                               $tournament->id
+                                       )
+                               );
 
 				$base   = remove_query_arg( array( 'orderby', 'order' ) );
 				$toggle = function ( $key ) use ( $orderby, $order, $base ) {


### PR DESCRIPTION
## Summary
- avoid `%i` placeholders in ORDER BY for leaderboard, user guess, and tournament queries
- build ORDER BY clauses by concatenating whitelisted columns and directions

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bd19f551308333a689e99856e9db29