### PR TITLE
Improve translation management with grouping and pagination

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -68,7 +68,11 @@ flex: 1;
 }
 
 .bhg-default-row {
-background-color: #fff8e5;
+    background-color: #fff8e5;
+}
+
+.bhg-custom-row {
+    background-color: #e5fff1;
 }
 
 /* Dashboard styles */


### PR DESCRIPTION
## Summary
- group translation keys by context and show default vs custom values
- highlight customised translations and clarify update buttons
- add pagination for large translation lists

## Testing
- `vendor/bin/phpcs admin/views/translations.php assets/css/admin.css`


------
https://chatgpt.com/codex/tasks/task_e_68bd231c6d80833396e576f04d8201dd