### PR TITLE
Remove extraneous closing brace in helpers

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1026,4 +1026,3 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 
 		return true;
 	}
-}


### PR DESCRIPTION
## Summary
- remove redundant closing brace at end of `helpers.php`

## Testing
- `./vendor/bin/phpcs --standard=phpcs.xml includes/helpers.php` *(fails: FOUND 225 ERRORS AND 161 WARNINGS)*

------
https://chatgpt.com/codex/tasks/task_e_68bd262931188333b86d50345b2866c9