### PR TITLE
Initialize translations table prefix for translations seeding

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -996,9 +996,11 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 			}
 		}
 
-		// Seed translations (upsert).
-		$tr_tbl = "{$p}bhg_translations";
-		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $tr_tbl ) ) === $tr_tbl ) {
+                // Seed translations (upsert).
+                global $wpdb;
+                $p      = $wpdb->prefix;
+                $tr_tbl = "{$p}bhg_translations";
+                if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $tr_tbl ) ) === $tr_tbl ) {
 			$pairs = array(
 				'email_results_title'    => 'The Bonus Hunt has been closed!',
 				'email_final_balance'    => 'Final Balance',


### PR DESCRIPTION
## Summary
- Initialize `$wpdb` and table prefix before accessing translations table during demo seed

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*
- `php wp-cli.phar plugin activate bonus-hunt-guesser --allow-root` *(fails: This does not seem to be a WordPress installation)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2edeb89c8333a45d30728a7aad1e