### PR TITLE
Validate orderby whitelist in leaderboard query

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -257,8 +257,12 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
                                                                                        FROM %i g
                                                                                        LEFT JOIN %i u ON u.ID = g.user_id
                                                                                        LEFT JOIN %i h ON h.id = g.hunt_id
-                                                                                       WHERE g.hunt_id = %d
-                                                                                       ORDER BY %i %s LIMIT %d OFFSET %d';
+                                                                                       WHERE g.hunt_id = %d';
+                                       $allowed_orderby = array( 'g.guess', 'u.user_login', 'g.id' );
+                                       if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
+                                                       $orderby = 'g.guess';
+                                       }
+                                       $sql .= ' ORDER BY ' . $orderby . ' ' . $order . ' LIMIT %d OFFSET %d';
                                        $rows = $wpdb->get_results(
                                                $wpdb->prepare(
                                                        $sql,
@@ -266,8 +270,6 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
                                                        $u,
                                                        $hunts_table,
                                                        $hunt_id,
-                                                       $orderby,
-                                                       $order,
                                                        $per,
                                                        $offset
                                                )


### PR DESCRIPTION
## Summary
- whitelist leaderboard `orderby` values and construct order clause safely
- remove unused identifier placeholder from query preparation

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2f9081588333941136ebd4ef71b5