### PR TITLE
Ensure explicit nonce handling in admin forms

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -203,7 +203,7 @@ class BHG_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
-		check_admin_referer( 'bhg_delete_guess' );
+				check_admin_referer( 'bhg_delete_guess', 'bhg_delete_guess_nonce' );
 		global $wpdb;
 		$guesses_table = $wpdb->prefix . 'bhg_guesses';
 		$guess_id      = isset( $_POST['guess_id'] ) ? absint( wp_unslash( $_POST['guess_id'] ) ) : 0;
@@ -222,7 +222,7 @@ class BHG_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
-		check_admin_referer( 'bhg_save_hunt' );
+				check_admin_referer( 'bhg_save_hunt', 'bhg_save_hunt_nonce' );
 		global $wpdb;
 		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
 
@@ -343,7 +343,7 @@ class BHG_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
-		check_admin_referer( 'bhg_close_hunt' );
+				check_admin_referer( 'bhg_close_hunt', 'bhg_close_hunt_nonce' );
 
 		$hunt_id           = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
 		$final_balance_raw = isset( $_POST['final_balance'] ) ? sanitize_text_field( wp_unslash( $_POST['final_balance'] ) ) : '';
@@ -370,7 +370,7 @@ class BHG_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
-		check_admin_referer( 'bhg_save_ad' );
+				check_admin_referer( 'bhg_save_ad', 'bhg_save_ad_nonce' );
 		global $wpdb;
 		$table = $wpdb->prefix . 'bhg_ads';
 
@@ -415,7 +415,7 @@ class BHG_Admin {
 			wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 			exit;
 		}
-		if ( ! check_admin_referer( 'bhg_tournament_save_action' ) ) {
+		if ( ! check_admin_referer( 'bhg_tournament_save_action', 'bhg_tournament_save_nonce' ) ) {
 			wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 			exit;
 		}

--- a/admin/class-bhg-bonus-hunts-controller.php
+++ b/admin/class-bhg-bonus-hunts-controller.php
@@ -167,7 +167,7 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 						wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 			}
 
-				check_admin_referer( 'bhg_delete_guess' );
+								check_admin_referer( 'bhg_delete_guess', 'bhg_delete_guess_nonce' );
 
 				$guess_id = isset( $_GET['guess_id'] ) ? absint( $_GET['guess_id'] ) : 0;
 

--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -23,13 +23,13 @@ class BHG_Demo {
 		echo '<div class="wrap"><h1>Demo Tools</h1>';
 				echo '<form method="post" action="' . admin_url( 'admin-post.php' ) . '">';
 				echo '<input type="hidden" name="action" value="bhg_demo_reseed" />';
-				wp_nonce_field( 'bhg_demo_reseed' );
+								wp_nonce_field( 'bhg_demo_reseed', 'bhg_demo_reseed_nonce' );
 				submit_button( __( 'Reset & Reseed Demo', 'bonus-hunt-guesser' ) );
 				echo '</form></div>';
 	}
 
 	public function reseed() {
-			check_admin_referer( 'bhg_demo_reseed' );
+						check_admin_referer( 'bhg_demo_reseed', 'bhg_demo_reseed_nonce' );
 			global $wpdb;
 
 			// Wipe demo data

--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -19,7 +19,7 @@ $edit_id = isset( $_GET['edit'] ) ? absint( wp_unslash( $_GET['edit'] ) ) : 0;
 
 // Delete action
 if ( 'delete' === $action && $ad_id ) {
-	check_admin_referer( 'bhg_delete_ad' );
+		check_admin_referer( 'bhg_delete_ad', '_wpnonce' );
 	if ( current_user_can( 'manage_options' ) ) {
 		$wpdb->delete( $table, array( 'id' => $ad_id ), array( '%d' ) );
 		wp_safe_redirect( remove_query_arg( array( 'action', 'id', '_wpnonce' ) ) );
@@ -98,7 +98,7 @@ endif;
 	}
 	?>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="max-width:800px">
-	<?php wp_nonce_field( 'bhg_save_ad' ); ?>
+		<?php wp_nonce_field( 'bhg_save_ad', 'bhg_save_ad_nonce' ); ?>
 	<input type="hidden" name="action" value="bhg_save_ad">
 	<?php if ( $ad ) : ?>
 		<input type="hidden" name="id" value="<?php echo (int) $ad->id; ?>">

--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -18,10 +18,10 @@ if ( ! $hunt ) {
 
 $aff_table = $wpdb->prefix . 'bhg_affiliates';
 if ( isset( $allowed_tables ) && ! in_array( $aff_table, $allowed_tables, true ) ) {
-                wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
 $affs = $wpdb->get_results(
-                $wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
+	$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
 );
 $sel  = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
 
@@ -45,7 +45,7 @@ $base     = remove_query_arg( 'ppaged' );
 		<h1 class="wp-heading-inline"><?php echo esc_html__( 'Edit Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
 
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
-		<?php wp_nonce_field( 'bhg_save_hunt' ); ?>
+				<?php wp_nonce_field( 'bhg_save_hunt', 'bhg_save_hunt_nonce' ); ?>
 		<input type="hidden" name="action" value="bhg_save_hunt" />
 		<input type="hidden" name="id" value="<?php echo (int) $hunt->id; ?>" />
 
@@ -135,7 +135,8 @@ $base     = remove_query_arg( 'ppaged' );
 														),
 														admin_url( 'admin-post.php' )
 													),
-													'bhg_delete_guess'
+													'bhg_delete_guess',
+													'bhg_delete_guess_nonce'
 												);
 												?>
 												<a href="<?php echo esc_url( $delete_url ); ?>" class="button-link-delete" onclick="return confirm('<?php echo esc_js( __( 'Delete this guess?', 'bonus-hunt-guesser' ) ); ?>');"><?php esc_html_e( 'Remove', 'bonus-hunt-guesser' ); ?></a>

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -163,7 +163,7 @@ if ( 'close' === $view ) :
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Close Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-400 bhg-margin-top-small">
-		<?php wp_nonce_field( 'bhg_close_hunt' ); ?>
+				<?php wp_nonce_field( 'bhg_close_hunt', 'bhg_close_hunt_nonce' ); ?>
 	<input type="hidden" name="action" value="bhg_close_hunt" />
 	<input type="hidden" name="hunt_id" value="<?php echo (int) $hunt->id; ?>" />
 	<table class="form-table" role="presentation">
@@ -189,7 +189,7 @@ if ( $view === 'add' ) :
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Add New Bonus Hunt', 'bonus-hunt-guesser' ); ?></h1>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
-	<?php wp_nonce_field( 'bhg_save_hunt' ); ?>
+		<?php wp_nonce_field( 'bhg_save_hunt', 'bhg_save_hunt_nonce' ); ?>
 	<input type="hidden" name="action" value="bhg_save_hunt" />
 
 	<table class="form-table" role="presentation">
@@ -218,10 +218,10 @@ if ( $view === 'add' ) :
 			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
 				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 			}
-                        // db call ok; no-cache ok.
-                        $affs = $wpdb->get_results(
-                                $wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
-                        );
+						// db call ok; no-cache ok.
+						$affs = $wpdb->get_results(
+							$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
+						);
 			$sel              = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
 			?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
@@ -277,21 +277,21 @@ if ( $view === 'edit' ) :
 	if ( ! in_array( $users_table, $allowed_tables, true ) ) {
 		wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 	}
-        // db call ok; no-cache ok.
-                $guesses = $wpdb->get_results(
-                        $wpdb->prepare(
-                                'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
-                                $guesses_table,
-                                $users_table,
-                                $id
-                        )
-                );
+		// db call ok; no-cache ok.
+				$guesses = $wpdb->get_results(
+					$wpdb->prepare(
+						'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
+						$guesses_table,
+						$users_table,
+						$id
+					)
+				);
 	?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Edit Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
 
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
-	<?php wp_nonce_field( 'bhg_save_hunt' ); ?>
+		<?php wp_nonce_field( 'bhg_save_hunt', 'bhg_save_hunt_nonce' ); ?>
 	<input type="hidden" name="action" value="bhg_save_hunt" />
 	<input type="hidden" name="id" value="<?php echo (int) $hunt->id; ?>" />
 
@@ -321,10 +321,10 @@ if ( $view === 'edit' ) :
 			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
 				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 			}
-                        // db call ok; no-cache ok.
-                        $affs = $wpdb->get_results(
-                                $wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
-                        );
+						// db call ok; no-cache ok.
+						$affs = $wpdb->get_results(
+							$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
+						);
 			$sel              = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
 			?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
@@ -390,7 +390,7 @@ if ( $view === 'edit' ) :
 			<td><?php echo esc_html( number_format_i18n( (float) ( $g->guess ?? 0 ), 2 ) ); ?></td>
 			<td>
 			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( __( 'Delete this guess?', 'bonus-hunt-guesser' ) ); ?>');" class="bhg-inline-form">
-				<?php wp_nonce_field( 'bhg_delete_guess' ); ?>
+								<?php wp_nonce_field( 'bhg_delete_guess', 'bhg_delete_guess_nonce' ); ?>
 				<input type="hidden" name="action" value="bhg_delete_guess">
 				<input type="hidden" name="guess_id" value="<?php echo (int) $g->id; ?>">
 				<button type="submit" class="button-link-delete"><?php echo esc_html__( 'Remove', 'bonus-hunt-guesser' ); ?></button>

--- a/admin/views/tools.php
+++ b/admin/views/tools.php
@@ -13,8 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<h1><?php echo esc_html__( 'BHG Tools', 'bonus-hunt-guesser' ); ?></h1>
 
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-		<input type="hidden" name="action" value="bhg_demo_reseed" />
-		<?php wp_nonce_field( 'bhg_demo_reseed' ); ?>
+				<input type="hidden" name="action" value="bhg_demo_reseed" />
+				<?php wp_nonce_field( 'bhg_demo_reseed', 'bhg_demo_reseed_nonce' ); ?>
 		<p><?php esc_html_e( 'This will delete all demo data and pages, then recreate fresh demo content.', 'bonus-hunt-guesser' ); ?></p>
 		<p><input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Reset & Reseed Demo Data', 'bonus-hunt-guesser' ); ?>" /></p>
 	</form>

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -70,7 +70,7 @@ endif;
 
 	<h2 class="bhg-margin-top-large"><?php echo $row ? esc_html__( 'Edit Tournament', 'bonus-hunt-guesser' ) : esc_html__( 'Add Tournament', 'bonus-hunt-guesser' ); ?></h2>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900">
-	<?php wp_nonce_field( 'bhg_tournament_save_action' ); ?>
+		<?php wp_nonce_field( 'bhg_tournament_save_action', 'bhg_tournament_save_nonce' ); ?>
 	<input type="hidden" name="action" value="bhg_tournament_save" />
 	<?php
 	if ( $row ) :


### PR DESCRIPTION
## Summary
- Add named nonce fields to admin forms for tools, advertising, bonus hunts, and tournaments
- Verify matching nonces in form handlers for guess deletion, hunt management, ad saving, and tournament saving
- Update guess deletion links to pass nonce field names explicitly

## Testing
- `composer install`
- `vendor/bin/phpcs admin/views/tools.php admin/class-bhg-demo.php admin/views/advertising.php admin/class-bhg-admin.php admin/views/bonus-hunts.php admin/views/bonus-hunts-edit.php admin/views/tournaments.php admin/class-bhg-bonus-hunts-controller.php` *(fails: coding standard errors remain)*
- `php -l admin/views/tools.php admin/class-bhg-demo.php admin/views/advertising.php admin/class-bhg-admin.php admin/views/bonus-hunts.php admin/views/bonus-hunts-edit.php admin/views/tournaments.php admin/class-bhg-bonus-hunts-controller.php`

------
https://chatgpt.com/codex/tasks/task_e_68bd33196c288333aace0375e106f972