### PR TITLE
Use prepared queries for dashboard counts

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -26,8 +26,10 @@ if ( ! function_exists( 'bhg_get_latest_closed_hunts' ) ) {
 
 global $wpdb;
 
-$hunts_count       = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_bonus_hunts" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-$tournaments_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_tournaments" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+$hunts_table       = $wpdb->prefix . 'bhg_bonus_hunts';
+$hunts_count       = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $hunts_table ) );
+$tournaments_table = $wpdb->prefix . 'bhg_tournaments';
+$tournaments_count = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $tournaments_table ) );
 
 $user_counts = count_users();
 $users_count = isset( $user_counts['total_users'] ) ? (int) $user_counts['total_users'] : 0;


### PR DESCRIPTION
## Summary
- Use `$wpdb->prepare()` for dashboard count queries to satisfy coding standards

## Testing
- `composer run phpcs admin/views/dashboard.php`

------
https://chatgpt.com/codex/tasks/task_e_68bd3a184a748333941bf7178784bcc4