### PR TITLE
Add status label translation

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -181,6 +181,7 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
                         'label_start'                                  => 'Start',
                         'label_end'                                    => 'End',
                         'label_status'                                 => 'Status',
+                        'label_status_colon'                           => 'Status:',
                         'label_wins'                                   => 'Wins',
 			'label_last_win'                               => 'Last win',
 			'label_period'                                 => 'Period',


### PR DESCRIPTION
## Summary
- add missing `Status:` translation

## Testing
- `composer phpcs` *(fails: coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3b68d36c8333bfd20becc52c7f77