### PR TITLE
Sanitize ad queries and tidy affiliate view

### DIFF
--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -1,18 +1,23 @@
 <?php
+/**
+ * Admin view for affiliate websites.
+ *
+ * @package BonusHuntGuesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+		exit; }
 if ( ! current_user_can( 'manage_options' ) ) {
-		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
+				wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 global $wpdb;
 $table          = $wpdb->prefix . 'bhg_affiliates';
 $allowed_tables = array( $wpdb->prefix . 'bhg_affiliates' );
 if ( ! in_array( $table, $allowed_tables, true ) ) {
-		wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
-$table = esc_sql( $table );
 
-// Load for edit
+// Load for edit.
 $edit_id = isset( $_GET['edit'] ) ? (int) $_GET['edit'] : 0;
 $row     = $edit_id ? $wpdb->get_row(
 	$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $edit_id )

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -1,13 +1,15 @@
 <?php
+/**
+ * Admin view for managing bonus hunts.
+ *
+ * @package BonusHuntGuesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; }
 
-/**
-	* Admin view for managing bonus hunts.
-	*/
-
 if ( ! current_user_can( 'manage_options' ) ) {
-	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
+		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
 global $wpdb;

--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -138,17 +138,22 @@ class BHG_Ads {
 	 * @return array
 	 */
 	protected static function get_ads_for_placement( $placement = 'footer' ) {
-		global $wpdb;
-		$table     = $wpdb->prefix . 'bhg_ads';
-		$placement = sanitize_text_field( $placement );
+				global $wpdb;
+				$table          = $wpdb->prefix . 'bhg_ads';
+				$allowed_tables = array( $wpdb->prefix . 'bhg_ads' );
+		if ( ! in_array( $table, $allowed_tables, true ) ) {
+				return array();
+		}
 
-		return $wpdb->get_results(
-			$wpdb->prepare(
-                // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is fixed.
-				"SELECT id, content, link_url, placement, visible_to, target_pages FROM {$table} WHERE active = 1 AND placement = %s ORDER BY id DESC",
-				$placement
-			)
-		);
+				$placement = sanitize_text_field( $placement );
+
+				return $wpdb->get_results(
+					$wpdb->prepare(
+						'SELECT id, content, link_url, placement, visible_to, target_pages FROM %i WHERE active = 1 AND placement = %s ORDER BY id DESC',
+						$table,
+						$placement
+					)
+				);
 	}
 
 	/**
@@ -218,15 +223,20 @@ class BHG_Ads {
 
 		$status = strtolower( trim( $a['status'] ) );
 
-		global $wpdb;
-		$table = esc_sql( $wpdb->prefix . 'bhg_ads' );
-		$row   = $wpdb->get_row(
-			$wpdb->prepare(
-                // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is fixed.
-				"SELECT id, content, placement, visible_to, target_pages, active, link_url FROM {$table} WHERE id = %d",
-				$id
-			)
-		);
+				global $wpdb;
+				$table          = $wpdb->prefix . 'bhg_ads';
+				$allowed_tables = array( $wpdb->prefix . 'bhg_ads' );
+		if ( ! in_array( $table, $allowed_tables, true ) ) {
+				return '';
+		}
+
+				$row = $wpdb->get_row(
+					$wpdb->prepare(
+						'SELECT id, content, placement, visible_to, target_pages, active, link_url FROM %i WHERE id = %d',
+						$table,
+						$id
+					)
+				);
 		if ( ! $row ) {
 			return '';
 		}


### PR DESCRIPTION
## Summary
- secure ad queries with `$wpdb->prepare()` and explicit table whitelisting
- document affiliate and bonus-hunt admin views and clean up table handling

## Testing
- `vendor/bin/phpcs includes/class-bhg-ads.php admin/views/affiliate-websites.php admin/views/bonus-hunts.php` *(fails: warnings/errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68bd44b839d48333b2e84f8c239bf5ef