### PR TITLE
feat: improve translations admin with pagination

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -99,6 +99,7 @@ padding: 8px 10px;
 .bhg-translations-table .bhg-inline-form {
 display: flex;
 gap: 8px;
+align-items: center;
 }
 
 .bhg-translations-table .bhg-inline-form input[type="text"] {
@@ -107,10 +108,16 @@ flex: 1;
 
 .bhg-default-row {
     background-color: #fff8e5;
+    border-left: 4px solid #f59e0b;
 }
 
 .bhg-custom-row {
     background-color: #e5fff1;
+    border-left: 4px solid #16a34a;
+}
+
+.bhg-translation-group {
+    margin-bottom: 2em;
 }
 
 /* Dashboard styles */


### PR DESCRIPTION
## Summary
- enhance translations admin with per-page controls and grouped inline edits
- style translations table spacing and highlight custom values

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpcs admin/views/translations.php assets/css/admin.css`


------
https://chatgpt.com/codex/tasks/task_e_68bd48eba87083338729f95737aaffb2