### PR TITLE
Use WordPress dashboard widgets and responsive tables

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -37,28 +37,29 @@ $users_count = isset( $user_counts['total_users'] ) ? (int) $user_counts['total_
 $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect: id, title, starting_balance, final_balance, winners_count, closed_at.
 ?>
 <div class="wrap bhg-dashboard">
-				<h1><?php esc_html_e( 'Dashboard', 'bonus-hunt-guesser' ); ?></h1>
+								<h1><?php esc_html_e( 'Dashboard', 'bonus-hunt-guesser' ); ?></h1>
 
-				<div class="bhg-dashboard-cards">
-								<div class="bhg-dashboard-card">
-												<h2 class="hndle"><span><?php esc_html_e( 'Summary', 'bonus-hunt-guesser' ); ?></span></h2>
-												<div class="inside">
-																<ul class="bhg-dashboard-meta">
-																				<li><span class="dashicons dashicons-book-alt"></span> <strong><?php esc_html_e( 'Hunts:', 'bonus-hunt-guesser' ); ?></strong> <?php echo esc_html( number_format_i18n( $hunts_count ) ); ?></li>
-																				<li><span class="dashicons dashicons-groups"></span> <strong><?php esc_html_e( 'Users:', 'bonus-hunt-guesser' ); ?></strong> <?php echo esc_html( number_format_i18n( $users_count ) ); ?></li>
-																				<li><span class="dashicons dashicons-awards"></span> <strong><?php esc_html_e( 'Tournaments:', 'bonus-hunt-guesser' ); ?></strong> <?php echo esc_html( number_format_i18n( $tournaments_count ) ); ?></li>
-																</ul>
-												</div>
-								</div>
+								<div id="dashboard-widgets" class="metabox-holder bhg-dashboard-cards">
+																<div class="postbox-container">
+																				<div class="postbox bhg-dashboard-card">
+																								<h2 class="hndle"><span><?php esc_html_e( 'Summary', 'bonus-hunt-guesser' ); ?></span></h2>
+																								<div class="inside">
+																														<ul class="bhg-dashboard-meta">
+																														<li><span class="dashicons dashicons-book-alt"></span> <strong><?php esc_html_e( 'Hunts:', 'bonus-hunt-guesser' ); ?></strong> <?php echo esc_html( number_format_i18n( $hunts_count ) ); ?></li>
+																														<li><span class="dashicons dashicons-groups"></span> <strong><?php esc_html_e( 'Users:', 'bonus-hunt-guesser' ); ?></strong> <?php echo esc_html( number_format_i18n( $users_count ) ); ?></li>
+																														<li><span class="dashicons dashicons-awards"></span> <strong><?php esc_html_e( 'Tournaments:', 'bonus-hunt-guesser' ); ?></strong> <?php echo esc_html( number_format_i18n( $tournaments_count ) ); ?></li>
+																														</ul>
+																								</div>
+																				</div>
 
-								<div class="bhg-dashboard-card">
-												<h2 class="hndle"><span><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></span></h2>
-												<div class="inside">
-																<div class="bhg-dashboard-table-wrapper">
-																				<table class="wp-list-table widefat striped">
-																								<thead>
-																												<tr>
-																												<th><?php esc_html_e( 'Bonushunt', 'bonus-hunt-guesser' ); ?></th>
+																				<div class="postbox bhg-dashboard-card">
+																								<h2 class="hndle"><span><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></span></h2>
+																								<div class="inside">
+																														<div class="bhg-dashboard-table-wrapper">
+																														<table class="wp-list-table widefat striped">
+																														<thead>
+																														<tr>
+																														<th><?php esc_html_e( 'Bonushunt', 'bonus-hunt-guesser' ); ?></th>
 																												<th><?php esc_html_e( 'All Winners', 'bonus-hunt-guesser' ); ?></th>
 																												<th><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
 																												<th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
@@ -83,9 +84,9 @@ $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect: id, title, starting_balanc
 																														$hunt_title = isset( $h->title ) ? (string) $h->title : '';
 																														$start      = isset( $h->starting_balance ) ? (float) $h->starting_balance : 0.0;
 																														?>
-																												<tr>
-				<td><?php echo '' !== $hunt_title ? esc_html( $hunt_title ) : esc_html__( '(untitled)', 'bonus-hunt-guesser' ); ?></td>
-																												<td>
+<tr>
+								<td data-label="<?php esc_attr_e( 'Bonushunt', 'bonus-hunt-guesser' ); ?>"><?php echo '' !== $hunt_title ? esc_html( $hunt_title ) : esc_html__( '(untitled)', 'bonus-hunt-guesser' ); ?></td>
+								<td data-label="<?php esc_attr_e( 'All Winners', 'bonus-hunt-guesser' ); ?>">
 																														<?php
 																														if ( ! empty( $winners ) ) {
 																															$out = array();
@@ -101,15 +102,15 @@ $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect: id, title, starting_balanc
 																																	$user_id
 																																);
 
-																																// Compose: "name — 1,234.00 (diff 12.34)".
-																																$out[] = sprintf(
-																																	'%1$s %2$s %3$s (%4$s %5$s)',
-																																	esc_html( $nm ),
-																																	esc_html_x( '—', 'name/guess separator', 'bonus-hunt-guesser' ),
-																																	esc_html( number_format_i18n( $guess, 2 ) ),
-																																	esc_html__( 'diff', 'bonus-hunt-guesser' ),
-																																	esc_html( number_format_i18n( $diff, 2 ) )
-																																);
+																																	// Compose: "name — 1,234.00 (diff 12.34)".
+																																	$out[] = sprintf(
+																																		'%1$s %2$s %3$s (%4$s %5$s)',
+																																		esc_html( $nm ),
+																																		esc_html_x( '—', 'name/guess separator', 'bonus-hunt-guesser' ),
+																																		esc_html( number_format_i18n( $guess, 2 ) ),
+																																		esc_html__( 'diff', 'bonus-hunt-guesser' ),
+																																		esc_html( number_format_i18n( $diff, 2 ) )
+																																	);
 																															}
 																															// Implode to a single, safely-escaped string separated by dots.
 																															echo esc_html( implode( ' • ', $out ) );
@@ -117,9 +118,9 @@ $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect: id, title, starting_balanc
 																															esc_html_e( 'No winners yet', 'bonus-hunt-guesser' );
 																														}
 																														?>
-																												</td>
-																												<td><?php echo esc_html( number_format_i18n( $start, 2 ) ); ?></td>
-																												<td>
+								</td>
+								<td data-label="<?php esc_attr_e( 'Start Balance', 'bonus-hunt-guesser' ); ?>"><?php echo esc_html( number_format_i18n( $start, 2 ) ); ?></td>
+								<td data-label="<?php esc_attr_e( 'Final Balance', 'bonus-hunt-guesser' ); ?>">
 																														<?php
 																														if ( isset( $h->final_balance ) && null !== $h->final_balance ) {
 																															echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
@@ -127,8 +128,8 @@ $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect: id, title, starting_balanc
 																															esc_html_e( '—', 'bonus-hunt-guesser' );
 																														}
 																														?>
-																												</td>
-																												<td>
+								</td>
+								<td data-label="<?php esc_attr_e( 'Closed At', 'bonus-hunt-guesser' ); ?>">
 																														<?php
 																														if ( ! empty( $h->closed_at ) ) {
 																															$ts = strtotime( (string) $h->closed_at );
@@ -144,18 +145,19 @@ $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect: id, title, starting_balanc
 																															esc_html_e( '—', 'bonus-hunt-guesser' );
 																														}
 																														?>
-																												</td>
-																												</tr>
-																												<?php endforeach; ?>
-																												<?php else : ?>
-																												<tr>
+</td>
+</tr>
+<?php endforeach; ?>
+<?php else : ?>
+<tr>
 																												<td colspan="5"><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></td>
 																												</tr>
 																												<?php endif; ?>
-																								</tbody>
-																				</table>
-																</div>
-												</div>
-								</div>
-				</div>
+</tbody>
+</table>
+</div>
+																								</div>
+																				</div>
+								</div><!-- .postbox-container -->
+</div><!-- #dashboard-widgets -->
 </div>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -217,4 +217,66 @@ flex: 1;
     padding: 8px 10px;
 }
 
+/* Table visual accents */
+.bhg-dashboard-table-wrapper table {
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+}
+
+.bhg-dashboard-table-wrapper tr:nth-child(even) {
+    background-color: #f9fafb;
+}
+
+.bhg-dashboard-table-wrapper tr:hover {
+    background-color: #eef2ff;
+}
+
+/* Responsive tables */
+@media screen and (max-width: 782px) {
+    .bhg-dashboard-table-wrapper table,
+    .bhg-dashboard-table-wrapper thead,
+    .bhg-dashboard-table-wrapper tbody,
+    .bhg-dashboard-table-wrapper th,
+    .bhg-dashboard-table-wrapper td,
+    .bhg-dashboard-table-wrapper tr {
+        display: block;
+    }
+
+    .bhg-dashboard-table-wrapper thead tr {
+        position: absolute;
+        top: -9999px;
+        left: -9999px;
+    }
+
+    .bhg-dashboard-table-wrapper tr {
+        border: 1px solid #e5e7eb;
+        margin-bottom: 6px;
+        border-radius: 6px;
+        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+    }
+
+    .bhg-dashboard-table-wrapper td {
+        border: none;
+        border-bottom: 1px solid #e5e7eb;
+        position: relative;
+        padding-left: 50%;
+        white-space: pre-wrap;
+    }
+
+    .bhg-dashboard-table-wrapper td::before {
+        position: absolute;
+        top: 8px;
+        left: 10px;
+        width: calc(50% - 20px);
+        white-space: nowrap;
+        font-weight: 600;
+        color: var(--bhg-accent-color);
+        content: attr(data-label);
+    }
+
+    .bhg-dashboard-table-wrapper td:last-child {
+        border-bottom: 0;
+    }
+}
+
 


### PR DESCRIPTION
## Summary
- adapt dashboard page to WordPress postbox widgets and add responsive data-label cells
- style admin tables with responsive layout, zebra striping, and hover accents

## Testing
- `vendor/bin/phpcs admin/views/dashboard.php`

------
https://chatgpt.com/codex/tasks/task_e_68bd4a53a69483339a30b44051ed0176