### PR TITLE
Add docblock for winners limit upgrade routine

### DIFF
--- a/includes/upgrade/add-winners-limit.php
+++ b/includes/upgrade/add-winners-limit.php
@@ -1,7 +1,19 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+/**
+ * Upgrade routine to add a winners limit column.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Add the winners_count column to the bonus hunts table.
+ *
+ * @return void
+ */
 function bhg_upgrade_add_winners_limit_column() {
 	global $wpdb;
 	$hunts           = $wpdb->prefix . 'bhg_bonus_hunts';
@@ -9,23 +21,23 @@ function bhg_upgrade_add_winners_limit_column() {
 
 	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-	// Ensure table exists & has winners_count column
+	// Ensure table exists and has winners_count column.
 	$sql = "CREATE TABLE {$hunts} (
-		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-		title VARCHAR(190) NOT NULL,
-		starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
-		num_bonuses INT UNSIGNED NOT NULL DEFAULT 0,
-		prizes TEXT NULL,
-		affiliate_site_id BIGINT UNSIGNED NULL,
-		winners_count INT UNSIGNED NOT NULL DEFAULT 3,
-		final_balance DECIMAL(12,2) NULL,
-		status VARCHAR(20) NOT NULL DEFAULT 'open',
-		created_at DATETIME NULL,
-		updated_at DATETIME NULL,
-		closed_at DATETIME NULL,
-		PRIMARY KEY  (id),
-		KEY status (status)
-	) {$charset_collate};";
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            title VARCHAR(190) NOT NULL,
+            starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+            num_bonuses INT UNSIGNED NOT NULL DEFAULT 0,
+            prizes TEXT NULL,
+            affiliate_site_id BIGINT UNSIGNED NULL,
+            winners_count INT UNSIGNED NOT NULL DEFAULT 3,
+            final_balance DECIMAL(12,2) NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'open',
+            created_at DATETIME NULL,
+            updated_at DATETIME NULL,
+            closed_at DATETIME NULL,
+            PRIMARY KEY  (id),
+            KEY status (status)
+    ) {$charset_collate};";
 
 	dbDelta( $sql );
 }


### PR DESCRIPTION
## Summary
- document and format the winners limit upgrade routine for clarity

## Testing
- `vendor/bin/phpcs -p --standard=phpcs.xml includes/upgrade/add-winners-limit.php`
- `vendor/bin/phpcs --standard=phpcs.xml --report=summary`


------
https://chatgpt.com/codex/tasks/task_e_68bd4c195ee083338cc651c6cd514f76