### PR TITLE
Sanitize orderby in user guesses shortcode

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -425,24 +425,16 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			$orderby_key = isset( $orderby_map[ $a['orderby'] ] ) ? $a['orderby'] : 'hunt';
 			$orderby     = $orderby_map[ $orderby_key ];
 
-			$limit_sql = '';
-			if ( 'recent' === strtolower( $a['timeline'] ) ) {
-				$limit_sql = ' LIMIT 10';
-			}
+                        $sql = "SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id FROM {$g} g INNER JOIN {$h} h ON h.id = g.hunt_id WHERE " . implode( ' AND ', $where );
+                        $sql .= ' ORDER BY ' . $orderby . ' ' . $order;
+                        if ( 'recent' === strtolower( $a['timeline'] ) ) {
+                                $sql .= ' LIMIT 10';
+                        }
 
-                                                                               $sql = "SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id
-                                                                              FROM %i g INNER JOIN %i h ON h.id = g.hunt_id
-                                                                              WHERE " . implode( ' AND ', $where ) . "
-                                                                                ORDER BY %i {$order}";
-                                       if ( 'recent' === strtolower( $a['timeline'] ) ) {
-                                               $sql .= ' LIMIT 10';
-                                       }
-
-                                       // db call ok; no-cache ok.
-                                        $prep = array_merge( array( $sql, $g, $h ), $params, array( $orderby ) );
-                                       $rows = $wpdb->get_results(
-                                               $wpdb->prepare( ...$prep )
-                                       );
+                        // db call ok; no-cache ok.
+                        $rows = $wpdb->get_results(
+                                $wpdb->prepare( $sql, $params )
+                        );
 			if ( ! $rows ) {
 				return '<p>' . esc_html__( 'No guesses found.', 'bonus-hunt-guesser' ) . '</p>';
 			}


### PR DESCRIPTION
## Summary
- sanitize user guess ordering by whitelisting columns and concatenating to query
- remove unused placeholders in user guess query

## Testing
- `php -l includes/class-bhg-shortcodes.php`
- `vendor/bin/phpcs includes/class-bhg-shortcodes.php` *(fails: 239 errors, 104 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4e0825c08333a7b5c646f9fd8e85