### PR TITLE
Sanitize SQL queries and clean up leaderboard

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -6,12 +6,11 @@ if ( ! current_user_can( 'manage_options' ) ) {
 }
 
 global $wpdb;
-$table          = $wpdb->prefix . 'bhg_ads';
+$ads_table      = esc_sql( $wpdb->prefix . 'bhg_ads' );
 $allowed_tables = array( $wpdb->prefix . 'bhg_ads' );
-if ( ! in_array( $table, $allowed_tables, true ) ) {
-	wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+if ( ! in_array( $ads_table, $allowed_tables, true ) ) {
+        wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
-$table = esc_sql( $table );
 
 $action  = isset( $_GET['action'] ) ? sanitize_key( wp_unslash( $_GET['action'] ) ) : '';
 $ad_id   = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
@@ -21,7 +20,7 @@ $edit_id = isset( $_GET['edit'] ) ? absint( wp_unslash( $_GET['edit'] ) ) : 0;
 if ( 'delete' === $action && $ad_id ) {
 		check_admin_referer( 'bhg_delete_ad', '_wpnonce' );
 	if ( current_user_can( 'manage_options' ) ) {
-		$wpdb->delete( $table, array( 'id' => $ad_id ), array( '%d' ) );
+                $wpdb->delete( $ads_table, array( 'id' => $ad_id ), array( '%d' ) );
 		wp_safe_redirect( remove_query_arg( array( 'action', 'id', '_wpnonce' ) ) );
 		exit;
 	}
@@ -30,7 +29,7 @@ if ( 'delete' === $action && $ad_id ) {
 // Fetch ads
 // db call ok; no-cache ok.
 $ads = $wpdb->get_results(
-	$wpdb->prepare( 'SELECT * FROM %i ORDER BY id DESC', $table )
+        $wpdb->prepare( 'SELECT * FROM %i ORDER BY id DESC', $ads_table )
 );
 ?>
 <div class="wrap">
@@ -92,9 +91,9 @@ endif;
 		$ad = null;
 	if ( $edit_id ) {
 									// db call ok; no-cache ok.
-									$ad = $wpdb->get_row(
-										$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $edit_id )
-									);
+                                                                       $ad = $wpdb->get_row(
+                                                                                $wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $ads_table, $edit_id )
+                                                                        );
 	}
 	?>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="max-width:800px">

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -14,8 +14,9 @@ global $wpdb;
 $table          = $wpdb->prefix . 'bhg_affiliates';
 $allowed_tables = array( $wpdb->prefix . 'bhg_affiliates' );
 if ( ! in_array( $table, $allowed_tables, true ) ) {
-				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+	wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
+$table = esc_sql( $table );
 
 // Load for edit.
 $edit_id = isset( $_GET['edit'] ) ? (int) $_GET['edit'] : 0;

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -22,8 +22,12 @@ $allowed_tables = array(
 	$wpdb->users,
 );
 if ( ! in_array( $hunts_table, $allowed_tables, true ) || ! in_array( $guesses_table, $allowed_tables, true ) ) {
-	wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+        wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
+
+$hunts_table   = esc_sql( $hunts_table );
+$guesses_table = esc_sql( $guesses_table );
+$users_table   = esc_sql( $wpdb->users );
 
 $view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'list';
 
@@ -216,10 +220,10 @@ if ( $view === 'add' ) :
 			<th scope="row"><label for="bhg_affiliate"><?php echo esc_html__( 'Affiliate Site', 'bonus-hunt-guesser' ); ?></label></th>
 			<td>
 			<?php
-			$aff_table = $wpdb->prefix . 'bhg_affiliates';
-			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
-				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
-			}
+                        $aff_table = esc_sql( $wpdb->prefix . 'bhg_affiliates' );
+                        if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
+                                wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+                        }
 						// db call ok; no-cache ok.
 						$affs = $wpdb->get_results(
 							$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
@@ -275,19 +279,19 @@ if ( $view === 'edit' ) :
 		echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt', 'bonus-hunt-guesser' ) . '</p></div>';
 		return;
 	}
-	$users_table = $wpdb->users;
-	if ( ! in_array( $users_table, $allowed_tables, true ) ) {
-		wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
-	}
-		// db call ok; no-cache ok.
-				$guesses = $wpdb->get_results(
-					$wpdb->prepare(
-						'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
-						$guesses_table,
-						$users_table,
-						$id
-					)
-				);
+       $users_table_local = $users_table;
+       if ( ! in_array( $users_table_local, $allowed_tables, true ) ) {
+               wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+       }
+               // db call ok; no-cache ok.
+                               $guesses = $wpdb->get_results(
+                                       $wpdb->prepare(
+                                               'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
+                                               $guesses_table,
+                                               $users_table_local,
+                                               $id
+                                       )
+                               );
 	?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Edit Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
@@ -319,10 +323,10 @@ if ( $view === 'edit' ) :
 			<th scope="row"><label for="bhg_affiliate"><?php echo esc_html__( 'Affiliate Site', 'bonus-hunt-guesser' ); ?></label></th>
 			<td>
 			<?php
-			$aff_table = $wpdb->prefix . 'bhg_affiliates';
-			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
-				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
-			}
+                        $aff_table = esc_sql( $wpdb->prefix . 'bhg_affiliates' );
+                        if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
+                                wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+                        }
 						// db call ok; no-cache ok.
 						$affs = $wpdb->get_results(
 							$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -432,9 +432,9 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
                         }
 
                         // db call ok; no-cache ok.
-                        $rows = $wpdb->get_results(
-                                $wpdb->prepare( $sql, $params )
-                        );
+                       $rows = $wpdb->get_results(
+                               $wpdb->prepare( $sql, ...$params )
+                       );
 			if ( ! $rows ) {
 				return '<p>' . esc_html__( 'No guesses found.', 'bonus-hunt-guesser' ) . '</p>';
 			}


### PR DESCRIPTION
## Summary
- use prepared statements for leaderboard totals and results
- fix shortcode query to expand parameters in `$wpdb->prepare`
- sanitize admin table names before running database queries

## Testing
- `vendor/bin/phpcs bonus-hunt-guesser.php includes/class-bhg-shortcodes.php admin/views/advertising.php admin/views/bonus-hunts.php admin/views/affiliate-websites.php`
- `vendor/bin/phpcs admin/views/affiliate-websites.php`

------
https://chatgpt.com/codex/tasks/task_e_68bd4f2071e083339a5ffba1353b2ff9