### PR TITLE
Whitelist table names and prepare SQL values

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -6,11 +6,12 @@ if ( ! current_user_can( 'manage_options' ) ) {
 }
 
 global $wpdb;
-$ads_table      = esc_sql( $wpdb->prefix . 'bhg_ads' );
+$ads_table      = $wpdb->prefix . 'bhg_ads';
 $allowed_tables = array( $wpdb->prefix . 'bhg_ads' );
 if ( ! in_array( $ads_table, $allowed_tables, true ) ) {
         wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
+$ads_table = esc_sql( $ads_table );
 
 $action  = isset( $_GET['action'] ) ? sanitize_key( wp_unslash( $_GET['action'] ) ) : '';
 $ad_id   = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -13,21 +13,26 @@ if ( ! current_user_can( 'manage_options' ) ) {
 }
 
 global $wpdb;
-$hunts_table    = $wpdb->prefix . 'bhg_bonus_hunts';
-$guesses_table  = $wpdb->prefix . 'bhg_guesses';
+$hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
+$guesses_table = $wpdb->prefix . 'bhg_guesses';
+$users_table   = $wpdb->users;
 $allowed_tables = array(
-	$wpdb->prefix . 'bhg_bonus_hunts',
-	$wpdb->prefix . 'bhg_guesses',
-	$wpdb->prefix . 'bhg_affiliates',
-	$wpdb->users,
+        $wpdb->prefix . 'bhg_bonus_hunts',
+        $wpdb->prefix . 'bhg_guesses',
+        $wpdb->prefix . 'bhg_affiliates',
+        $wpdb->users,
 );
-if ( ! in_array( $hunts_table, $allowed_tables, true ) || ! in_array( $guesses_table, $allowed_tables, true ) ) {
+if (
+        ! in_array( $hunts_table, $allowed_tables, true ) ||
+        ! in_array( $guesses_table, $allowed_tables, true ) ||
+        ! in_array( $users_table, $allowed_tables, true )
+) {
         wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
 
 $hunts_table   = esc_sql( $hunts_table );
 $guesses_table = esc_sql( $guesses_table );
-$users_table   = esc_sql( $wpdb->users );
+$users_table   = esc_sql( $users_table );
 
 $view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'list';
 
@@ -219,17 +224,18 @@ if ( $view === 'add' ) :
 		<tr>
 			<th scope="row"><label for="bhg_affiliate"><?php echo esc_html__( 'Affiliate Site', 'bonus-hunt-guesser' ); ?></label></th>
 			<td>
-			<?php
-                        $aff_table = esc_sql( $wpdb->prefix . 'bhg_affiliates' );
+                        <?php
+                        $aff_table = $wpdb->prefix . 'bhg_affiliates';
                         if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
                                 wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
                         }
-						// db call ok; no-cache ok.
-						$affs = $wpdb->get_results(
-							$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
-						);
-			$sel              = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
-			?>
+                        $aff_table = esc_sql( $aff_table );
+                                                // db call ok; no-cache ok.
+                                                $affs = $wpdb->get_results(
+                                                        $wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
+                                                );
+                        $sel              = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
+                        ?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
 				<option value="0"><?php echo esc_html__( 'None', 'bonus-hunt-guesser' ); ?></option>
 				<?php foreach ( $affs as $a ) : ?>
@@ -322,17 +328,18 @@ if ( $view === 'edit' ) :
 		<tr>
 			<th scope="row"><label for="bhg_affiliate"><?php echo esc_html__( 'Affiliate Site', 'bonus-hunt-guesser' ); ?></label></th>
 			<td>
-			<?php
-                        $aff_table = esc_sql( $wpdb->prefix . 'bhg_affiliates' );
+                        <?php
+                        $aff_table = $wpdb->prefix . 'bhg_affiliates';
                         if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
                                 wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
                         }
-						// db call ok; no-cache ok.
-						$affs = $wpdb->get_results(
-							$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
-						);
-			$sel              = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
-			?>
+                        $aff_table = esc_sql( $aff_table );
+                                                // db call ok; no-cache ok.
+                                                $affs = $wpdb->get_results(
+                                                        $wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
+                                                );
+                        $sel              = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
+                        ?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
 				<option value="0"><?php echo esc_html__( 'None', 'bonus-hunt-guesser' ); ?></option>
 				<?php foreach ( $affs as $a ) : ?>

--- a/includes/demo.php
+++ b/includes/demo.php
@@ -48,13 +48,35 @@ function bhg_seed_demo_on_activation() {
 				$user_ids[ $u['user_login'] ] = $uid ? intval( $uid ) : 0;
 		}
 
-		global $wpdb;
-		$hunts       = $wpdb->prefix . 'bhg_bonus_hunts';
-		$guesses     = $wpdb->prefix . 'bhg_guesses';
-		$tournaments = $wpdb->prefix . 'bhg_tournaments';
-		$aff         = $wpdb->prefix . 'bhg_affiliate_websites';
-		$ads         = $wpdb->prefix . 'bhg_ads';
-		$trans       = $wpdb->prefix . 'bhg_translations';
+                global $wpdb;
+                $hunts       = $wpdb->prefix . 'bhg_bonus_hunts';
+                $guesses     = $wpdb->prefix . 'bhg_guesses';
+                $tournaments = $wpdb->prefix . 'bhg_tournaments';
+                $aff         = $wpdb->prefix . 'bhg_affiliate_websites';
+                $ads         = $wpdb->prefix . 'bhg_ads';
+                $trans       = $wpdb->prefix . 'bhg_translations';
+
+                $allowed_tables = array(
+                        $wpdb->prefix . 'bhg_bonus_hunts',
+                        $wpdb->prefix . 'bhg_guesses',
+                        $wpdb->prefix . 'bhg_tournaments',
+                        $wpdb->prefix . 'bhg_affiliate_websites',
+                        $wpdb->prefix . 'bhg_ads',
+                        $wpdb->prefix . 'bhg_translations',
+                );
+
+                foreach ( array( $hunts, $guesses, $tournaments, $aff, $ads, $trans ) as $tbl ) {
+                        if ( ! in_array( $tbl, $allowed_tables, true ) ) {
+                                return;
+                        }
+                }
+
+                $hunts       = esc_sql( $hunts );
+                $guesses     = esc_sql( $guesses );
+                $tournaments = esc_sql( $tournaments );
+                $aff         = esc_sql( $aff );
+                $ads         = esc_sql( $ads );
+                $trans       = esc_sql( $trans );
 
 		// Insert affiliate sites.
 		$wpdb->insert(
@@ -137,14 +159,14 @@ function bhg_seed_demo_on_activation() {
 		}
 	}
 
-	// Compute winner for the closed hunt (closest).
-	$rows = $wpdb->get_results(
-		$wpdb->prepare(
-// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			"SELECT * FROM {$guesses} WHERE hunt_id = %d",
-			$closed_id
-		)
-	);
+        // Compute winner for the closed hunt (closest).
+        $rows = $wpdb->get_results(
+                $wpdb->prepare(
+                        'SELECT * FROM %i WHERE hunt_id = %d',
+                        $guesses,
+                        $closed_id
+                )
+        );
 	$final       = 2420.00;
 	$winner_id   = 0;
 	$winner_diff = null;


### PR DESCRIPTION
## Summary
- Whitelist database table names before executing SQL queries
- Sanitize SQL values with `$wpdb->prepare()` and remove unneeded PHPCS ignores

## Testing
- `composer phpcs` *(fails: Tabs must be used to indent lines; spaces are not allowed, and other coding standard warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5a1b9b7c8333867cf5295e291bfa