### PR TITLE
Use dashboard cards and refine admin styling

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -39,35 +39,35 @@ $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect: id, title, starting_balanc
 <div class="wrap bhg-dashboard">
 	<h1><?php esc_html_e( 'Dashboard', 'bonus-hunt-guesser' ); ?></h1>
 
-	<div class="bhg-dashboard-cards">
-		<div class="bhg-dashboard-card">
-			<h2 class="hndle"><span><?php esc_html_e( 'Summary', 'bonus-hunt-guesser' ); ?></span></h2>
-			<div class="inside">
-				<ul class="bhg-dashboard-meta">
-					<li><span class="dashicons dashicons-book-alt"></span> <strong><?php esc_html_e( 'Hunts:', 'bonus-hunt-guesser' ); ?></strong> <?php echo esc_html( number_format_i18n( $hunts_count ) ); ?></li>
-					<li><span class="dashicons dashicons-groups"></span> <strong><?php esc_html_e( 'Users:', 'bonus-hunt-guesser' ); ?></strong> <?php echo esc_html( number_format_i18n( $users_count ) ); ?></li>
-					<li><span class="dashicons dashicons-awards"></span> <strong><?php esc_html_e( 'Tournaments:', 'bonus-hunt-guesser' ); ?></strong> <?php echo esc_html( number_format_i18n( $tournaments_count ) ); ?></li>
-				</ul>
-			</div>
-		</div>
+        <div class="dashboard-widgets-wrap bhg-dashboard-cards">
+                <div class="card bhg-dashboard-card">
+                        <h2 class="title"><?php esc_html_e( 'Summary', 'bonus-hunt-guesser' ); ?></h2>
+                        <div class="inside">
+                                <ul class="bhg-dashboard-meta">
+                                        <li><span class="dashicons dashicons-book-alt"></span> <strong><?php esc_html_e( 'Hunts:', 'bonus-hunt-guesser' ); ?></strong> <?php echo esc_html( number_format_i18n( $hunts_count ) ); ?></li>
+                                        <li><span class="dashicons dashicons-groups"></span> <strong><?php esc_html_e( 'Users:', 'bonus-hunt-guesser' ); ?></strong> <?php echo esc_html( number_format_i18n( $users_count ) ); ?></li>
+                                        <li><span class="dashicons dashicons-awards"></span> <strong><?php esc_html_e( 'Tournaments:', 'bonus-hunt-guesser' ); ?></strong> <?php echo esc_html( number_format_i18n( $tournaments_count ) ); ?></li>
+                                </ul>
+                        </div>
+                </div>
 
-		<div class="bhg-dashboard-card">
-			<h2 class="hndle"><span><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></span></h2>
-			<div class="inside">
-				<div class="bhg-dashboard-table-wrapper">
-					<table class="wp-list-table widefat striped bhg-dashboard-table">
-						<thead>
-							<tr>
-								<th><?php esc_html_e( 'Bonushunt', 'bonus-hunt-guesser' ); ?></th>
-								<th><?php esc_html_e( 'All Winners', 'bonus-hunt-guesser' ); ?></th>
-								<th><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
-								<th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
-								<th><?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?></th>
-							</tr>
-						</thead>
-						<tbody>
-						<?php if ( ! empty( $hunts ) && is_array( $hunts ) ) : ?>
-							<?php foreach ( $hunts as $h ) : ?>
+                <div class="card bhg-dashboard-card">
+                        <h2 class="title"><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h2>
+                        <div class="inside">
+                                <div class="bhg-dashboard-table-wrapper">
+                                        <table class="wp-list-table widefat striped bhg-dashboard-table">
+                                                <thead>
+                                                        <tr>
+                                                                <th><?php esc_html_e( 'Bonushunt', 'bonus-hunt-guesser' ); ?></th>
+                                                                <th><?php esc_html_e( 'All Winners', 'bonus-hunt-guesser' ); ?></th>
+                                                                <th><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
+                                                                <th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
+                                                                <th><?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?></th>
+                                                        </tr>
+                                                </thead>
+                                                <tbody>
+                                                <?php if ( ! empty( $hunts ) && is_array( $hunts ) ) : ?>
+                                                        <?php foreach ( $hunts as $h ) : ?>
 								<?php
 								$hunt_id       = isset( $h->id ) ? (int) $h->id : 0;
 								$winners_count = isset( $h->winners_count ) ? (int) $h->winners_count : 0;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -127,9 +127,11 @@ flex: 1;
 
 /* Dashboard styles */
 :root {
-    --bhg-accent-color: #2271b1;
+    --bhg-accent-color: #ec4899;
+    --bhg-border-color: #e5e7eb;
+    --bhg-card-bg: #ffffff;
     --bhg-spacing: 16px;
-    --bhg-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    --bhg-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Inter, Arial, 'Noto Sans', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
 }
 
 .bhg-dashboard h1 {
@@ -140,9 +142,16 @@ flex: 1;
 
 .bhg-dashboard-card {
     font-family: var(--bhg-font-family);
+    background: var(--bhg-card-bg);
+    border: 1px solid var(--bhg-border-color);
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    line-height: 1.5;
+    font-size: 14px;
+    width: 100%;
 }
 
-.bhg-dashboard-card .hndle {
+.bhg-dashboard-card .title {
     background: var(--bhg-accent-color);
     color: #fff;
     padding: 12px 16px;
@@ -176,25 +185,9 @@ flex: 1;
 
 /* Enhanced dashboard layout */
 .bhg-dashboard-cards {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr;
     gap: var(--bhg-spacing);
-}
-
-@media (min-width: 600px) {
-    .bhg-dashboard-cards {
-        flex-direction: row;
-        align-items: stretch;
-    }
-}
-
-.bhg-dashboard-card {
-    border: 1px solid #e5e7eb;
-    border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
-    line-height: 1.5;
-    font-size: 14px;
-    width: 100%;
 }
 
 .bhg-dashboard-meta li + li {
@@ -236,7 +229,7 @@ flex: 1;
 
 /* Table visual accents */
 .bhg-dashboard-table-wrapper table {
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--bhg-border-color);
     border-radius: 6px;
 }
 
@@ -245,7 +238,7 @@ flex: 1;
 }
 
 .bhg-dashboard-table-wrapper tr:hover {
-    background-color: #eef2ff;
+    background-color: #fdf2f8;
 }
 
 /* Responsive tables */
@@ -266,7 +259,7 @@ flex: 1;
     }
 
     .bhg-dashboard-table-wrapper tr {
-        border: 1px solid #e5e7eb;
+        border: 1px solid var(--bhg-border-color);
         margin-bottom: 6px;
         border-radius: 6px;
         box-shadow: 0 1px 2px rgba(0,0,0,0.04);
@@ -274,7 +267,7 @@ flex: 1;
 
     .bhg-dashboard-table-wrapper td {
         border: none;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--bhg-border-color);
         position: relative;
         padding-left: 50%;
         white-space: pre-wrap;


### PR DESCRIPTION
## Summary
- Replace dashboard postboxes with WordPress-style cards for summary and latest hunts listings.
- Align admin typography and spacing with front-end, using new accent color variables.
- Refresh table borders and hover accents to match plugin design.

## Testing
- `php -l admin/views/dashboard.php`
- `composer phpcs` *(warnings: direct database calls and debug code; no errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5b628a508333837892b630a8fce2