### PR TITLE
Seed default translation keys

### DIFF
--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -15,8 +15,8 @@ if ( ! current_user_can( 'manage_options' ) ) {
 global $wpdb;
 $table = $wpdb->prefix . 'bhg_translations';
 
-if ( function_exists( 'bhg_seed_default_translations' ) ) {
-		bhg_seed_default_translations();
+if ( function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
+       bhg_seed_default_translations_if_empty();
 }
 
 $default_translations = function_exists( 'bhg_get_default_translations' ) ? bhg_get_default_translations() : array();

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -174,6 +174,9 @@ spl_autoload_register(
 require_once BHG_PLUGIN_DIR . 'includes/helpers.php';
 require_once BHG_PLUGIN_DIR . 'includes/class-bhg-bonus-hunts-helpers.php';
 
+// Ensure translation keys exist early.
+bhg_seed_default_translations_if_empty();
+
 // Activation hook: create tables and set default options.
 /**
  * Activation callback for setting up the plugin.

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -162,6 +162,7 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
                         'label_affiliate_status'                       => 'Affiliate Status',
                         'label_actions'                                => 'Actions',
                         'label_id'                                     => 'ID',
+                        'label_key'                                    => 'Key',
                         'label_name'                                   => 'Name',
                         'label_winners'                                => 'Winners',
                         'label_title_content'                          => 'Title/Content',


### PR DESCRIPTION
## Summary
- ensure translation keys are seeded on load and in admin view
- add missing label for translation key column

## Testing
- `composer phpcs` *(fails: existing coding standard issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5e2c49308333a3842da1b5155c56