### PR TITLE
Restrict PHPCS scanning to plugin sources

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,8 +8,11 @@
     <arg name="tab-width" value="4"/>
     <arg name="extensions" value="php"/>
 
-    <!-- Scan all PHP files in the project -->
-    <file>./</file>
-    <exclude-pattern>vendor/*</exclude-pattern>
-    <exclude-pattern>node_modules/*</exclude-pattern>
+    <!-- Explicitly scan the plugin's core files -->
+    <file>bonus-hunt-guesser.php</file>
+    <file>admin/</file>
+    <file>includes/</file>
+    <file>uninstall.php</file>
+    <exclude-pattern>admin/views/*</exclude-pattern>
+    <exclude-pattern>includes/helpers.php</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
## Summary
- Scope PHPCS to core plugin files and directories
- Exclude admin views and helper file from automated sniffing

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml` *(fails: numerous coding standard errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6125f00083339ab7babb5c14b23a