### PR TITLE
Add Submit Guess button translation

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -264,6 +264,7 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
                         'button_back'                                  => 'Back',
                         'button_create_new_bonus_hunt'                 => 'Create New Bonus Hunt',
                         'button_results'                               => 'Results',
+                        'button_submit_guess'                          => 'Submit Guess',
                         'button_filter'                                => 'Filter',
                         'button_log_in'                                => 'Log in',
                         'button_view_edit'                             => 'View / Edit',


### PR DESCRIPTION
## Summary
- add default translation key for Submit Guess button so front-end text is editable

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*
- `php -r "define('ABSPATH', __DIR__.'/'); require 'includes/helpers.php'; bhg_seed_default_translations_if_empty();"` *(fails: Call to undefined function add_filter())*

------
https://chatgpt.com/codex/tasks/task_e_68bd63e8cba88333930b97c574ea835a