### PR TITLE
style: apply accent color to tabs

### DIFF
--- a/assets/css/bhg-shortcodes.css
+++ b/assets/css/bhg-shortcodes.css
@@ -42,10 +42,19 @@
     background: #f7fafc;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
+    color: var(--bhg-accent-color);
+}
+
+.bhg-tabs a:hover {
+    background: var(--bhg-accent-color);
+    border-color: var(--bhg-accent-color);
+    color: #fff;
 }
 
 .bhg-tabs li.active a {
-    background: #fff;
+    background: var(--bhg-accent-color);
+    border-color: var(--bhg-accent-color);
+    color: #fff;
     font-weight: 700;
 }
 


### PR DESCRIPTION
## Summary
- use `--bhg-accent-color` for tab text, hover, and active state styling
- ensure front-end tab controls match accent color scheme

## Testing
- `composer phpcs` *(fails: PHPCBF CAN FIX THE 210 MARKED SNIFF VIOLATIONS AUTOMATICALLY)*

------
https://chatgpt.com/codex/tasks/task_e_68bd665eeef48333ae722d5b5acf3307