### PR TITLE
Ensure accent color applied to buttons and headings

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -121,7 +121,9 @@ flex: 1;
 }
 
 .bhg-translation-group h3 {
-    color: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
+    border: 1px solid var(--bhg-accent-color);
+    color: #fff;
     margin-bottom: 0.5em;
 }
 
@@ -135,7 +137,8 @@ flex: 1;
 }
 
 .bhg-dashboard h1 {
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
+    border: 1px solid var(--bhg-accent-color);
     color: #fff;
     font-family: var(--bhg-font-family);
     margin-bottom: var(--bhg-spacing);
@@ -155,7 +158,8 @@ flex: 1;
 }
 
 .bhg-dashboard-card .title {
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
+    border: 1px solid var(--bhg-accent-color);
     color: #fff;
     padding: 12px 16px;
     margin: 0;
@@ -168,7 +172,7 @@ flex: 1;
 /* Buttons */
 .bhg-wrap .button,
 .bhg-wrap .button-primary {
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
     border-color: var(--bhg-accent-color);
     color: #fff;
 }
@@ -177,7 +181,7 @@ flex: 1;
 .bhg-wrap .button:focus,
 .bhg-wrap .button-primary:hover,
 .bhg-wrap .button-primary:focus {
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
     border-color: var(--bhg-accent-color);
     color: #fff;
     filter: brightness(0.9);
@@ -239,7 +243,8 @@ flex: 1;
 }
 
 .bhg-dashboard-table thead th {
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
+    border: 1px solid var(--bhg-accent-color);
     color: #fff;
 }
 

--- a/assets/css/bhg-shortcodes.css
+++ b/assets/css/bhg-shortcodes.css
@@ -46,13 +46,13 @@
 }
 
 .bhg-tabs a:hover {
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
     border-color: var(--bhg-accent-color);
     color: #fff;
 }
 
 .bhg-tabs li.active a {
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
     border-color: var(--bhg-accent-color);
     color: #fff;
     font-weight: 700;
@@ -83,7 +83,8 @@
 .bhg-tournament-details h3 {
     margin-top: 0;
     margin-bottom: 8px;
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
+    border: 1px solid var(--bhg-accent-color);
     color: #fff;
     padding: 8px;
     border-radius: 4px;
@@ -108,7 +109,7 @@
 
 .bhg-submit-btn {
     margin-top: 20px;
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
     border: 1px solid var(--bhg-accent-color);
     color: #fff;
     padding: 8px 12px;
@@ -118,7 +119,7 @@
 
 .bhg-submit-btn:hover,
 .bhg-submit-btn:focus {
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
     border-color: var(--bhg-accent-color);
     color: #fff;
     filter: brightness(0.9);
@@ -138,7 +139,7 @@
 
 .bhg-filter-button {
     margin-left: 8px;
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
     border: 1px solid var(--bhg-accent-color);
     color: #fff;
     padding: 6px 10px;
@@ -148,7 +149,7 @@
 
 .bhg-filter-button:hover,
 .bhg-filter-button:focus {
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
     border-color: var(--bhg-accent-color);
     color: #fff;
     filter: brightness(0.9);
@@ -167,9 +168,10 @@
 .bhg-leaderboard th,
 .bhg-tournaments th {
     text-align: left;
+    border: 1px solid var(--bhg-accent-color);
     border-bottom: 2px solid var(--bhg-accent-color);
     padding: 6px;
-    background: var(--bhg-accent-color);
+    background-color: var(--bhg-accent-color);
     color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- Use `background-color` and matching border color for admin headings, buttons, and table headers
- Apply accent background and border styling to shortcode tabs, forms, and tables

## Testing
- `composer phpcs` *(fails: Use placeholders and $wpdb->prepare(); found interpolated variable {$table} at "SHOW INDEX FROM `{$table}` WHERE Key_name=%s"; plus additional warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7ebb353c8333b811ac48275684d7