### PR TITLE
Rename affiliates table to bhg_affiliate_websites

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -452,50 +452,52 @@ class BHG_Admin {
 		}
 	}
 
-	/**
-	 * Save or update an affiliate record.
-	 */
+		/**
+		 * Save or update an affiliate website record.
+		 */
 	public function handle_save_affiliate() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html( bhg_t( 'no_permission', 'No permission' ) ) );
 		}
 		check_admin_referer( 'bhg_save_affiliate' );
-		global $wpdb;
-		$table  = $wpdb->prefix . 'bhg_affiliates';
-		$id     = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-		$name   = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
-		$url    = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : '';
-		$status = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'active';
+			global $wpdb;
+			$table  = $wpdb->prefix . 'bhg_affiliate_websites';
+			$id     = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+			$name   = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+			$slug   = isset( $_POST['slug'] ) ? sanitize_title( wp_unslash( $_POST['slug'] ) ) : sanitize_title( $name );
+			$url    = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : '';
+			$status = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'active';
 
-		$data   = array(
+		$data       = array(
 			'name'       => $name,
+			'slug'       => $slug,
 			'url'        => $url,
 			'status'     => $status,
 			'updated_at' => current_time( 'mysql' ),
 		);
-		$format = array( '%s', '%s', '%s', '%s' );
+			$format = array( '%s', '%s', '%s', '%s', '%s' );
 		if ( $id ) {
-			$wpdb->update( $table, $data, array( 'id' => $id ), $format, array( '%d' ) );
+				$wpdb->update( $table, $data, array( 'id' => $id ), $format, array( '%d' ) );
 		} else {
-			$data['created_at'] = current_time( 'mysql' );
-			$format[]           = '%s';
-			$wpdb->insert( $table, $data, $format );
+				$data['created_at'] = current_time( 'mysql' );
+				$format[]           = '%s';
+				$wpdb->insert( $table, $data, $format );
 		}
-		wp_safe_redirect( admin_url( 'admin.php?page=bhg-affiliates' ) );
-		exit;
+			wp_safe_redirect( admin_url( 'admin.php?page=bhg-affiliates' ) );
+			exit;
 	}
 
-	/**
-	 * Delete an affiliate.
-	 */
+		/**
+		 * Delete an affiliate website.
+		 */
 	public function handle_delete_affiliate() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html( bhg_t( 'no_permission', 'No permission' ) ) );
 		}
 				check_admin_referer( 'bhg_delete_affiliate' );
-		global $wpdb;
-		$table = $wpdb->prefix . 'bhg_affiliates';
-		$id    = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+				global $wpdb;
+				$table = $wpdb->prefix . 'bhg_affiliate_websites';
+		$id            = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
 		if ( $id ) {
 			$wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
 		}

--- a/admin/class-bhg-bonus-hunts-controller.php
+++ b/admin/class-bhg-bonus-hunts-controller.php
@@ -56,10 +56,10 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 		public function get_admin_view_vars() {
 			$db = new BHG_DB();
 
-			return array(
-				'bonus_hunts'     => $db->get_all_bonus_hunts(),
-				'affiliate_sites' => $db->get_affiliate_websites(),
-			);
+						return array(
+							'bonus_hunts'        => $db->get_all_bonus_hunts(),
+							'affiliate_websites' => $db->get_affiliate_websites(),
+						);
 		}
 
 
@@ -80,7 +80,7 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 			$action       = sanitize_text_field( wp_unslash( $_POST['bhg_action'] ) );
 			$nonce_action = 'bhg_' . $action;
 
-                        check_admin_referer( $nonce_action, 'bhg_nonce' );
+						check_admin_referer( $nonce_action, 'bhg_nonce' );
 
 			$db      = new BHG_DB();
 			$message = 'error';
@@ -167,7 +167,7 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 						wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 			}
 
-                                check_admin_referer( 'bhg_delete_guess' );
+								check_admin_referer( 'bhg_delete_guess' );
 
 				$guess_id = isset( $_GET['guess_id'] ) ? absint( $_GET['guess_id'] ) : 0;
 

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -11,8 +11,8 @@ if ( ! current_user_can( 'manage_options' ) ) {
 				wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
 }
 global $wpdb;
-$table          = $wpdb->prefix . 'bhg_affiliates';
-$allowed_tables = array( $wpdb->prefix . 'bhg_affiliates' );
+$table          = $wpdb->prefix . 'bhg_affiliate_websites';
+$allowed_tables = array( $wpdb->prefix . 'bhg_affiliate_websites' );
 if ( ! in_array( $table, $allowed_tables, true ) ) {
 	wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
 }
@@ -31,38 +31,76 @@ $rows = $wpdb->get_results(
 );
 ?>
 <div class="wrap">
-	<h1 class="wp-heading-inline"><?php echo esc_html( bhg_t( 'menu_affiliates', 'Affiliates' ) ); ?></h1>
+		<h1 class="wp-heading-inline"><?php echo esc_html( bhg_t( 'menu_affiliates', 'Affiliate Websites' ) ); ?></h1>
 
 	<h2 style="margin-top:1em"><?php echo esc_html( bhg_t( 'all_affiliate_websites', 'All Affiliate Websites' ) ); ?></h2>
 	<table class="widefat striped">
 	<thead>
 		<tr>
-		<th><?php echo esc_html( bhg_t( 'id', 'ID' ) );; ?></th>
-		<th><?php echo esc_html( bhg_t( 'name', 'Name' ) );; ?></th>
-		<th><?php echo esc_html( bhg_t( 'url', 'URL' ) );; ?></th>
-		<th><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) );; ?></th>
-		<th><?php echo esc_html( bhg_t( 'label_actions', 'Actions' ) );; ?></th>
+		<th>
+		<?php
+		echo esc_html( bhg_t( 'id', 'ID' ) );
+		?>
+</th>
+				<th>
+				<?php
+				echo esc_html( bhg_t( 'name', 'Name' ) );
+				?>
+</th>
+				<th>
+				<?php
+				echo esc_html( bhg_t( 'slug', 'Slug' ) );
+				?>
+</th>
+				<th>
+				<?php
+				echo esc_html( bhg_t( 'url', 'URL' ) );
+				?>
+</th>
+				<th>
+				<?php
+				echo esc_html( bhg_t( 'sc_status', 'Status' ) );
+				?>
+</th>
+				<th>
+				<?php
+				echo esc_html( bhg_t( 'label_actions', 'Actions' ) );
+				?>
+</th>
 		</tr>
 	</thead>
 	<tbody>
 		<?php if ( empty( $rows ) ) : ?>
-		<tr><td colspan="5"><em><?php echo esc_html( bhg_t( 'no_affiliates_yet', 'No affiliates yet.' ) );; ?></em></td></tr>
+				<tr><td colspan="6"><em>
+				<?php
+				echo esc_html( bhg_t( 'no_affiliates_yet', 'No affiliate websites yet.' ) );
+				?>
+</em></td></tr>
 			<?php
 		else :
 			foreach ( $rows as $r ) :
 				?>
 		<tr>
 			<td><?php echo (int) $r->id; ?></td>
-			<td><?php echo esc_html( $r->name ); ?></td>
-			<td><?php echo esc_html( $r->url ); ?></td>
-			<td><?php echo esc_html( $r->status ); ?></td>
+						<td><?php echo esc_html( $r->name ); ?></td>
+						<td><?php echo esc_html( $r->slug ); ?></td>
+						<td><?php echo esc_html( $r->url ); ?></td>
+						<td><?php echo esc_html( $r->status ); ?></td>
 			<td>
-			<a class="button" href="<?php echo esc_url( add_query_arg( array( 'edit' => (int) $r->id ) ) ); ?>"><?php echo esc_html( bhg_t( 'button_edit', 'Edit' ) );; ?></a>
-			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline" onsubmit="return confirm('<?php echo esc_js( bhg_t( 'delete_this_affiliate', 'Delete this affiliate?' ) ); ?>');">
+			<a class="button" href="<?php echo esc_url( add_query_arg( array( 'edit' => (int) $r->id ) ) ); ?>">
+				<?php
+				echo esc_html( bhg_t( 'button_edit', 'Edit' ) );
+				?>
+</a>
+						<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline" onsubmit="return confirm('<?php echo esc_js( bhg_t( 'delete_this_affiliate', 'Delete this affiliate website?' ) ); ?>');">
 							<?php wp_nonce_field( 'bhg_delete_affiliate' ); ?>
 				<input type="hidden" name="action" value="bhg_delete_affiliate">
 				<input type="hidden" name="id" value="<?php echo (int) $r->id; ?>">
-				<button class="button-link-delete" type="submit"><?php echo esc_html( bhg_t( 'remove', 'Remove' ) );; ?></button>
+				<button class="button-link-delete" type="submit">
+				<?php
+				echo esc_html( bhg_t( 'remove', 'Remove' ) );
+				?>
+</button>
 			</form>
 			</td>
 		</tr>
@@ -73,25 +111,45 @@ endif;
 	</tbody>
 	</table>
 
-	<h2 style="margin-top:2em"><?php echo $row ? esc_html( bhg_t( 'edit_affiliate', 'Edit Affiliate' ) ) : esc_html( bhg_t( 'add_affiliate', 'Add Affiliate' ) ); ?></h2>
+		<h2 style="margin-top:2em"><?php echo $row ? esc_html( bhg_t( 'edit_affiliate', 'Edit Affiliate Website' ) ) : esc_html( bhg_t( 'add_affiliate', 'Add Affiliate Website' ) ); ?></h2>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="max-width:800px">
-	<?php wp_nonce_field( 'bhg_save_affiliate' ); ?>
-	<input type="hidden" name="action" value="bhg_save_affiliate">
+		<?php wp_nonce_field( 'bhg_save_affiliate' ); ?>
+		<input type="hidden" name="action" value="bhg_save_affiliate">
 	<?php
 	if ( $row ) :
 		?>
 		<input type="hidden" name="id" value="<?php echo (int) $row->id; ?>"><?php endif; ?>
 	<table class="form-table">
 		<tr>
-		<th><label for="aff_name"><?php echo esc_html( bhg_t( 'name', 'Name' ) );; ?></label></th>
-		<td><input class="regular-text" id="aff_name" name="name" value="<?php echo esc_attr( $row->name ?? '' ); ?>" required></td>
-		</tr>
+				<th><label for="aff_name">
+				<?php
+				echo esc_html( bhg_t( 'name', 'Name' ) );
+				?>
+</label></th>
+				<td><input class="regular-text" id="aff_name" name="name" value="<?php echo esc_attr( $row->name ?? '' ); ?>" required></td>
+				</tr>
+				<tr>
+				<th><label for="aff_slug">
+				<?php
+				echo esc_html( bhg_t( 'slug', 'Slug' ) );
+				?>
+</label></th>
+				<td><input class="regular-text" id="aff_slug" name="slug" value="<?php echo esc_attr( $row->slug ?? '' ); ?>" required></td>
+				</tr>
 		<tr>
-		<th><label for="aff_url"><?php echo esc_html( bhg_t( 'url', 'URL' ) );; ?></label></th>
+		<th><label for="aff_url">
+		<?php
+		echo esc_html( bhg_t( 'url', 'URL' ) );
+		?>
+</label></th>
 		<td><input class="regular-text" id="aff_url" name="url" value="<?php echo esc_attr( $row->url ?? '' ); ?>" placeholder="https://example.com"></td>
 		</tr>
 		<tr>
-		<th><label for="aff_status"><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) );; ?></label></th>
+		<th><label for="aff_status">
+		<?php
+		echo esc_html( bhg_t( 'sc_status', 'Status' ) );
+		?>
+</label></th>
 		<td>
 			<select id="aff_status" name="status">
 			<?php
@@ -104,6 +162,6 @@ endif;
 		</td>
 		</tr>
 	</table>
-	<?php submit_button( $row ? bhg_t( 'update_affiliate', 'Update Affiliate' ) : bhg_t( 'create_affiliate', 'Create Affiliate' ) ); ?>
+		<?php submit_button( $row ? bhg_t( 'update_affiliate', 'Update Affiliate Website' ) : bhg_t( 'create_affiliate', 'Create Affiliate Website' ) ); ?>
 	</form>
 </div>

--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -16,7 +16,7 @@ if ( ! $hunt ) {
 		return;
 }
 
-$aff_table = $wpdb->prefix . 'bhg_affiliates';
+$aff_table = $wpdb->prefix . 'bhg_affiliate_websites';
 if ( isset( $allowed_tables ) && ! in_array( $aff_table, $allowed_tables, true ) ) {
 				wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
 }
@@ -44,9 +44,9 @@ $base     = remove_query_arg( 'ppaged' );
 		?>
 		<h1 class="wp-heading-inline"><?php echo esc_html( bhg_t( 'edit_bonus_hunt', 'Edit Bonus Hunt' ) ); ?> <?php echo esc_html( bhg_t( 'label_emdash', '—' ) ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
 
-        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
-                <?php wp_nonce_field( 'bhg_save_hunt' ); ?>
-                <input type="hidden" name="action" value="bhg_save_hunt" />
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
+				<?php wp_nonce_field( 'bhg_save_hunt' ); ?>
+				<input type="hidden" name="action" value="bhg_save_hunt" />
 		<input type="hidden" name="id" value="<?php echo (int) $hunt->id; ?>" />
 
 		<table class="form-table" role="presentation">
@@ -100,21 +100,45 @@ $base     = remove_query_arg( 'ppaged' );
 				<?php submit_button( esc_html( bhg_t( 'save_hunt', 'Save Hunt' ) ) ); ?>
 	</form>
 
-	<h2 class="bhg-margin-top-large"><?php echo esc_html( bhg_t( 'participants', 'Participants' ) );; ?></h2>
+	<h2 class="bhg-margin-top-large">
+	<?php
+	echo esc_html( bhg_t( 'participants', 'Participants' ) );
+	?>
+</h2>
 	<p><?php echo esc_html( sprintf( _n( '%s participant', '%s participants', $total, 'bonus-hunt-guesser' ), number_format_i18n( $total ) ) ); ?></p>
 
 	<table class="widefat striped">
 		<thead>
 			<tr>
-				<th><?php echo esc_html( bhg_t( 'sc_user', 'User' ) );; ?></th>
-				<th><?php echo esc_html( bhg_t( 'sc_guess', 'Guess' ) );; ?></th>
-				<th><?php echo esc_html( bhg_t( 'date', 'Date' ) );; ?></th>
-				<th><?php echo esc_html( bhg_t( 'label_actions', 'Actions' ) );; ?></th>
+				<th>
+				<?php
+				echo esc_html( bhg_t( 'sc_user', 'User' ) );
+				?>
+</th>
+				<th>
+				<?php
+				echo esc_html( bhg_t( 'sc_guess', 'Guess' ) );
+				?>
+</th>
+				<th>
+				<?php
+				echo esc_html( bhg_t( 'date', 'Date' ) );
+				?>
+</th>
+				<th>
+				<?php
+				echo esc_html( bhg_t( 'label_actions', 'Actions' ) );
+				?>
+</th>
 			</tr>
 		</thead>
 		<tbody>
 			<?php if ( empty( $rows ) ) : ?>
-				<tr><td colspan="4"><?php echo esc_html( bhg_t( 'no_participants_yet', 'No participants yet.' ) );; ?></td></tr>
+				<tr><td colspan="4">
+				<?php
+				echo esc_html( bhg_t( 'no_participants_yet', 'No participants yet.' ) );
+				?>
+</td></tr>
 				<?php
 			else :
 				foreach ( $rows as $r ) :
@@ -127,18 +151,22 @@ $base     = remove_query_arg( 'ppaged' );
 										<td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html( bhg_t( 'label_dash', '-' ) ); ?></td>
 										<td>
 												<?php
-                                                                                                $delete_url = wp_nonce_url(
-                                                                                                        add_query_arg(
-                                                                                                                array(
-                                                                                                                        'action'   => 'bhg_delete_guess',
-                                                                                                                        'guess_id' => (int) $r->id,
-                                                                                                                ),
-                                                                                                                admin_url( 'admin-post.php' )
-                                                                                                        ),
-                                                                                                        'bhg_delete_guess'
-                                                                                                );
+																								$delete_url = wp_nonce_url(
+																									add_query_arg(
+																										array(
+																											'action'   => 'bhg_delete_guess',
+																											'guess_id' => (int) $r->id,
+																										),
+																										admin_url( 'admin-post.php' )
+																									),
+																									'bhg_delete_guess'
+																								);
 												?>
-												<a href="<?php echo esc_url( $delete_url ); ?>" class="button-link-delete" onclick="return confirm('<?php echo esc_js( bhg_t( 'delete_this_guess', 'Delete this guess?' ) ); ?>');"><?php echo esc_html( bhg_t( 'remove', 'Remove' ) );; ?></a>
+												<a href="<?php echo esc_url( $delete_url ); ?>" class="button-link-delete" onclick="return confirm('<?php echo esc_js( bhg_t( 'delete_this_guess', 'Delete this guess?' ) ); ?>');">
+												<?php
+												echo esc_html( bhg_t( 'remove', 'Remove' ) );
+												?>
+</a>
 										</td>
 								</tr>
 							<?php

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -13,21 +13,21 @@ if ( ! current_user_can( 'manage_options' ) ) {
 }
 
 global $wpdb;
-$hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
-$guesses_table = $wpdb->prefix . 'bhg_guesses';
-$users_table   = $wpdb->users;
+$hunts_table    = $wpdb->prefix . 'bhg_bonus_hunts';
+$guesses_table  = $wpdb->prefix . 'bhg_guesses';
+$users_table    = $wpdb->users;
 $allowed_tables = array(
-        $wpdb->prefix . 'bhg_bonus_hunts',
-        $wpdb->prefix . 'bhg_guesses',
-        $wpdb->prefix . 'bhg_affiliates',
-        $wpdb->users,
+	$wpdb->prefix . 'bhg_bonus_hunts',
+	$wpdb->prefix . 'bhg_guesses',
+	$wpdb->prefix . 'bhg_affiliate_websites',
+	$wpdb->users,
 );
 if (
-        ! in_array( $hunts_table, $allowed_tables, true ) ||
-        ! in_array( $guesses_table, $allowed_tables, true ) ||
-        ! in_array( $users_table, $allowed_tables, true )
+		! in_array( $hunts_table, $allowed_tables, true ) ||
+		! in_array( $guesses_table, $allowed_tables, true ) ||
+		! in_array( $users_table, $allowed_tables, true )
 ) {
-        wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
+		wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
 }
 
 $hunts_table   = esc_sql( $hunts_table );
@@ -173,9 +173,9 @@ if ( 'close' === $view ) :
 		?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html( bhg_t( 'close_bonus_hunt', 'Close Bonus Hunt' ) ); ?> <?php echo esc_html( bhg_t( 'label_emdash', '—' ) ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
-        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-400 bhg-margin-top-small">
-                <?php wp_nonce_field( 'bhg_close_hunt' ); ?>
-        <input type="hidden" name="action" value="bhg_close_hunt" />
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-400 bhg-margin-top-small">
+				<?php wp_nonce_field( 'bhg_close_hunt' ); ?>
+		<input type="hidden" name="action" value="bhg_close_hunt" />
 	<input type="hidden" name="hunt_id" value="<?php echo (int) $hunt->id; ?>" />
 	<table class="form-table" role="presentation">
 		<tbody>
@@ -199,9 +199,9 @@ if ( $view === 'add' ) :
 	?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html( bhg_t( 'add_new_bonus_hunt', 'Add New Bonus Hunt' ) ); ?></h1>
-        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
-                <?php wp_nonce_field( 'bhg_save_hunt' ); ?>
-        <input type="hidden" name="action" value="bhg_save_hunt" />
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
+				<?php wp_nonce_field( 'bhg_save_hunt' ); ?>
+		<input type="hidden" name="action" value="bhg_save_hunt" />
 
 	<table class="form-table" role="presentation">
 		<tbody>
@@ -224,18 +224,18 @@ if ( $view === 'add' ) :
 		<tr>
 			<th scope="row"><label for="bhg_affiliate"><?php echo esc_html( bhg_t( 'affiliate_site', 'Affiliate Site' ) ); ?></label></th>
 			<td>
-                        <?php
-                        $aff_table = $wpdb->prefix . 'bhg_affiliates';
-                        if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
-                                wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
-                        }
-                        $aff_table = esc_sql( $aff_table );
-                                                // db call ok; no-cache ok.
-                                                $affs = $wpdb->get_results(
-                                                        $wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
-                                                );
-                        $sel              = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
-                        ?>
+						<?php
+						$aff_table = $wpdb->prefix . 'bhg_affiliate_websites';
+						if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
+								wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
+						}
+						$aff_table = esc_sql( $aff_table );
+												// db call ok; no-cache ok.
+												$affs = $wpdb->get_results(
+													$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
+												);
+						$sel                          = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
+						?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
 				<option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
 				<?php foreach ( $affs as $a ) : ?>
@@ -285,26 +285,26 @@ if ( $view === 'edit' ) :
 		echo '<div class="notice notice-error"><p>' . esc_html( bhg_t( 'invalid_hunt', 'Invalid hunt' ) ) . '</p></div>';
 		return;
 	}
-       $users_table_local = $users_table;
-       if ( ! in_array( $users_table_local, $allowed_tables, true ) ) {
-               wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
-       }
-               // db call ok; no-cache ok.
-                               $guesses = $wpdb->get_results(
-                                       $wpdb->prepare(
-                                               "SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC",
-                                               $guesses_table,
-                                               $users_table_local,
-                                               $id
-                                       )
-                               );
+		$users_table_local = $users_table;
+	if ( ! in_array( $users_table_local, $allowed_tables, true ) ) {
+			wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
+	}
+				// db call ok; no-cache ok.
+								$guesses = $wpdb->get_results(
+									$wpdb->prepare(
+										'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
+										$guesses_table,
+										$users_table_local,
+										$id
+									)
+								);
 	?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html( bhg_t( 'edit_bonus_hunt', 'Edit Bonus Hunt' ) ); ?> <?php echo esc_html( bhg_t( 'label_emdash', '—' ) ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
 
-        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
-                <?php wp_nonce_field( 'bhg_save_hunt' ); ?>
-        <input type="hidden" name="action" value="bhg_save_hunt" />
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
+				<?php wp_nonce_field( 'bhg_save_hunt' ); ?>
+		<input type="hidden" name="action" value="bhg_save_hunt" />
 	<input type="hidden" name="id" value="<?php echo (int) $hunt->id; ?>" />
 
 	<table class="form-table" role="presentation">
@@ -328,18 +328,18 @@ if ( $view === 'edit' ) :
 		<tr>
 			<th scope="row"><label for="bhg_affiliate"><?php echo esc_html( bhg_t( 'affiliate_site', 'Affiliate Site' ) ); ?></label></th>
 			<td>
-                        <?php
-                        $aff_table = $wpdb->prefix . 'bhg_affiliates';
-                        if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
-                                wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
-                        }
-                        $aff_table = esc_sql( $aff_table );
-                                                // db call ok; no-cache ok.
-                                                $affs = $wpdb->get_results(
-                                                        $wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
-                                                );
-                        $sel              = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
-                        ?>
+						<?php
+						$aff_table = $wpdb->prefix . 'bhg_affiliate_websites';
+						if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
+								wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
+						}
+						$aff_table = esc_sql( $aff_table );
+												// db call ok; no-cache ok.
+												$affs = $wpdb->get_results(
+													$wpdb->prepare( 'SELECT id, name FROM %i ORDER BY name ASC', $aff_table )
+												);
+						$sel                          = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
+						?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
 				<option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
 				<?php foreach ( $affs as $a ) : ?>
@@ -402,9 +402,9 @@ if ( $view === 'edit' ) :
 			</td>
 			<td><?php echo esc_html( number_format_i18n( (float) ( $g->guess ?? 0 ), 2 ) ); ?></td>
 			<td>
-                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( bhg_t( 'delete_this_guess', 'Delete this guess?' ) ); ?>');" class="bhg-inline-form">
-                                <?php wp_nonce_field( 'bhg_delete_guess' ); ?>
-                                <input type="hidden" name="action" value="bhg_delete_guess">
+						<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( bhg_t( 'delete_this_guess', 'Delete this guess?' ) ); ?>');" class="bhg-inline-form">
+								<?php wp_nonce_field( 'bhg_delete_guess' ); ?>
+								<input type="hidden" name="action" value="bhg_delete_guess">
 				<input type="hidden" name="guess_id" value="<?php echo (int) $g->id; ?>">
 				<button type="submit" class="button-link-delete"><?php echo esc_html( bhg_t( 'remove', 'Remove' ) ); ?></button>
 			</form>

--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -106,8 +106,8 @@ if ( isset( $_POST['bhg_action'] ) ) {
 }
 
 // Get all bonus hunts
-$bonus_hunts     = $bhg_db->get_all_bonus_hunts();
-$affiliate_sites = $bhg_db->get_affiliate_websites();
+$bonus_hunts        = $bhg_db->get_all_bonus_hunts();
+$affiliate_websites = $bhg_db->get_affiliate_websites();
 
 // Display status messages
 if ( isset( $_GET['message'] ) ) {
@@ -138,39 +138,63 @@ if ( isset( $_GET['message'] ) ) {
 ?>
 
 <div class="wrap bhg-admin">
-	<h1><?php echo esc_html( bhg_t( 'bonus_hunt_guesser', 'Bonus Hunt Guesser' ) );; ?></h1>
+	<h1>
+	<?php
+	echo esc_html( bhg_t( 'bonus_hunt_guesser', 'Bonus Hunt Guesser' ) );
+	?>
+</h1>
 	<hr/>
 	
 	<div class="bhg-admin-content">
-		<h2><?php echo esc_html( bhg_t( 'button_create_new_bonus_hunt', 'Create New Bonus Hunt' ) );; ?></h2>
+		<h2>
+		<?php
+		echo esc_html( bhg_t( 'button_create_new_bonus_hunt', 'Create New Bonus Hunt' ) );
+		?>
+</h2>
 		<form method="post" action="">
 			<?php wp_nonce_field( 'bhg_create_bonus_hunt', 'bhg_nonce' ); ?>
 			<input type="hidden" name="bhg_action" value="create_bonus_hunt">
 			
 			<table class="form-table">
 				<tr>
-					<th scope="row"><label for="title"><?php echo esc_html( bhg_t( 'label_bonus_hunt_title', 'Bonus Hunt Title' ) );; ?></label></th>
+					<th scope="row"><label for="title">
+					<?php
+					echo esc_html( bhg_t( 'label_bonus_hunt_title', 'Bonus Hunt Title' ) );
+					?>
+</label></th>
 					<td>
 						<input type="text" name="title" id="title" class="regular-text" required 
 								value="<?php echo isset( $_POST['title'] ) ? esc_attr( $_POST['title'] ) : ''; ?>">
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="starting_balance"><?php echo esc_html( bhg_t( 'label_start_balance_euro', 'Starting Balance (€)' ) );; ?></label></th>
+					<th scope="row"><label for="starting_balance">
+					<?php
+					echo esc_html( bhg_t( 'label_start_balance_euro', 'Starting Balance (€)' ) );
+					?>
+</label></th>
 					<td>
 						<input type="number" name="starting_balance" id="starting_balance" step="0.01" min="0"
 								value="<?php echo esc_attr( isset( $_POST['starting_balance'] ) ? floatval( $_POST['starting_balance'] ) : '0' ); ?>" required>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="num_bonuses"><?php echo esc_html( bhg_t( 'label_number_bonuses', 'Number of Bonuses' ) );; ?></label></th>
+					<th scope="row"><label for="num_bonuses">
+					<?php
+					echo esc_html( bhg_t( 'label_number_bonuses', 'Number of Bonuses' ) );
+					?>
+</label></th>
 					<td>
 						<input type="number" name="num_bonuses" id="num_bonuses" min="1"
 								value="<?php echo esc_attr( isset( $_POST['num_bonuses'] ) ? intval( $_POST['num_bonuses'] ) : '10' ); ?>" required>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="prizes"><?php echo esc_html( bhg_t( 'label_prizes_description', 'Prizes Description' ) );; ?></label></th>
+					<th scope="row"><label for="prizes">
+					<?php
+					echo esc_html( bhg_t( 'label_prizes_description', 'Prizes Description' ) );
+					?>
+</label></th>
 					<td>
 						<textarea name="prizes" id="prizes" rows="5" class="large-text">
 						<?php
@@ -180,23 +204,47 @@ if ( isset( $_GET['message'] ) ) {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="status"><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) );; ?></label></th>
+					<th scope="row"><label for="status">
+					<?php
+					echo esc_html( bhg_t( 'sc_status', 'Status' ) );
+					?>
+</label></th>
 					<td>
 						<select name="status" id="status" required>
-							<option value="active"><?php echo esc_html( bhg_t( 'label_active', 'Active' ) );; ?></option>
-							<option value="upcoming"><?php echo esc_html( bhg_t( 'label_upcoming', 'Upcoming' ) );; ?></option>
-							<option value="completed"><?php echo esc_html( bhg_t( 'label_completed', 'Completed' ) );; ?></option>
+							<option value="active">
+							<?php
+							echo esc_html( bhg_t( 'label_active', 'Active' ) );
+							?>
+</option>
+							<option value="upcoming">
+							<?php
+							echo esc_html( bhg_t( 'label_upcoming', 'Upcoming' ) );
+							?>
+</option>
+							<option value="completed">
+							<?php
+							echo esc_html( bhg_t( 'label_completed', 'Completed' ) );
+							?>
+</option>
 						</select>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="affiliate_site_id"><?php echo esc_html( bhg_t( 'label_affiliate_website', 'Affiliate Website' ) );; ?></label></th>
+					<th scope="row"><label for="affiliate_site_id">
+					<?php
+					echo esc_html( bhg_t( 'label_affiliate_website', 'Affiliate Website' ) );
+					?>
+</label></th>
 					<td>
 						<select name="affiliate_site_id" id="affiliate_site_id">
-							<option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) );; ?></option>
-							<?php foreach ( $affiliate_sites as $site ) : ?>
+							<option value="0">
+							<?php
+							echo esc_html( bhg_t( 'none', 'None' ) );
+							?>
+</option>
+													<?php foreach ( $affiliate_websites as $site ) : ?>
 								<option value="<?php echo esc_attr( $site->id ); ?>">
-									<?php echo esc_html( $site->name ); ?>
+														<?php echo esc_html( $site->name ); ?>
 								</option>
 							<?php endforeach; ?>
 						</select>
@@ -209,18 +257,54 @@ if ( isset( $_GET['message'] ) ) {
 		
 		<hr>
 		
-		<h2><?php echo esc_html( bhg_t( 'label_existing_bonus_hunts', 'Existing Bonus Hunts' ) );; ?></h2>
+		<h2>
+		<?php
+		echo esc_html( bhg_t( 'label_existing_bonus_hunts', 'Existing Bonus Hunts' ) );
+		?>
+</h2>
 		<table class="wp-list-table widefat fixed striped">
 			<thead>
 				<tr>
-					<th><?php echo esc_html( bhg_t( 'id', 'ID' ) );; ?></th>
-					<th><?php echo esc_html( bhg_t( 'sc_title', 'Title' ) );; ?></th>
-					<th><?php echo esc_html( bhg_t( 'label_start_balance', 'Starting Balance' ) );; ?></th>
-					<th><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) );; ?></th>
-					<th><?php echo esc_html( bhg_t( 'label_number_bonuses', 'Number of Bonuses' ) );; ?></th>
-					<th><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) );; ?></th>
-					<th><?php echo esc_html( bhg_t( 'label_created', 'Created' ) );; ?></th>
-					<th><?php echo esc_html( bhg_t( 'label_actions', 'Actions' ) );; ?></th>
+					<th>
+					<?php
+					echo esc_html( bhg_t( 'id', 'ID' ) );
+					?>
+</th>
+					<th>
+					<?php
+					echo esc_html( bhg_t( 'sc_title', 'Title' ) );
+					?>
+</th>
+					<th>
+					<?php
+					echo esc_html( bhg_t( 'label_start_balance', 'Starting Balance' ) );
+					?>
+</th>
+					<th>
+					<?php
+					echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) );
+					?>
+</th>
+					<th>
+					<?php
+					echo esc_html( bhg_t( 'label_number_bonuses', 'Number of Bonuses' ) );
+					?>
+</th>
+					<th>
+					<?php
+					echo esc_html( bhg_t( 'sc_status', 'Status' ) );
+					?>
+</th>
+					<th>
+					<?php
+					echo esc_html( bhg_t( 'label_created', 'Created' ) );
+					?>
+</th>
+					<th>
+					<?php
+					echo esc_html( bhg_t( 'label_actions', 'Actions' ) );
+					?>
+</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -234,7 +318,11 @@ if ( isset( $_GET['message'] ) ) {
 								<?php if ( $hunt->final_balance !== null ) : ?>
 									€<?php echo esc_html( number_format( $hunt->final_balance, 2 ) ); ?>
 								<?php else : ?>
-									<em><?php echo esc_html( bhg_t( 'label_not_set', 'Not set' ) );; ?></em>
+									<em>
+									<?php
+									echo esc_html( bhg_t( 'label_not_set', 'Not set' ) );
+									?>
+</em>
 								<?php endif; ?>
 							</td>
 							<td><?php echo esc_html( $hunt->num_bonuses ); ?></td>
@@ -246,7 +334,9 @@ if ( isset( $_GET['message'] ) ) {
 							<td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $hunt->created_at ) ) ); ?></td>
 							<td>
 								<a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg_bonus_hunts&action=edit&id=' . intval( $hunt->id ) ) ); ?>" class="button button-small">
-									<?php echo esc_html( bhg_t( 'button_edit', 'Edit' ) );; ?>
+									<?php
+									echo esc_html( bhg_t( 'button_edit', 'Edit' ) );
+									?>
 								</a>
 								<form method="post" style="display:inline;">
 									<?php wp_nonce_field( 'bhg_delete_bonus_hunt', 'bhg_nonce' ); ?>
@@ -254,7 +344,9 @@ if ( isset( $_GET['message'] ) ) {
 									<input type="hidden" name="id" value="<?php echo esc_attr( $hunt->id ); ?>">
 									<button type="submit" class="button button-small button-danger"
 											onclick="return confirm('<?php echo esc_js( bhg_t( 'confirm_delete_bonus_hunt', 'Are you sure you want to delete this bonus hunt?' ) ); ?>');">
-										<?php echo esc_html( bhg_t( 'button_delete', 'Delete' ) );; ?>
+										<?php
+										echo esc_html( bhg_t( 'button_delete', 'Delete' ) );
+										?>
 									</button>
 								</form>
 							</td>
@@ -262,7 +354,11 @@ if ( isset( $_GET['message'] ) ) {
 					<?php endforeach; ?>
 				<?php else : ?>
 					<tr>
-						<td colspan="8"><?php echo esc_html( bhg_t( 'notice_no_bonus_hunts_found', 'No bonus hunts found.' ) );; ?></td>
+						<td colspan="8">
+						<?php
+						echo esc_html( bhg_t( 'notice_no_bonus_hunts_found', 'No bonus hunts found.' ) );
+						?>
+</td>
 					</tr>
 				<?php endif; ?>
 			</tbody>

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -29,15 +29,14 @@ class BHG_DB {
 
 		$charset_collate = $wpdb->get_charset_collate();
 
-               $hunts_table       = $wpdb->prefix . 'bhg_bonus_hunts';
-               $guesses_table     = $wpdb->prefix . 'bhg_guesses';
-               $tours_table       = $wpdb->prefix . 'bhg_tournaments';
-               $tres_table        = $wpdb->prefix . 'bhg_tournament_results';
-               $ads_table         = $wpdb->prefix . 'bhg_ads';
-               $trans_table       = $wpdb->prefix . 'bhg_translations';
-               $aff_table         = $wpdb->prefix . 'bhg_affiliates';
-               $aff_sites_table   = $wpdb->prefix . 'bhg_affiliate_websites';
-               $winners_table     = $wpdb->prefix . 'bhg_hunt_winners';
+				$hunts_table        = $wpdb->prefix . 'bhg_bonus_hunts';
+				$guesses_table      = $wpdb->prefix . 'bhg_guesses';
+				$tours_table        = $wpdb->prefix . 'bhg_tournaments';
+				$tres_table         = $wpdb->prefix . 'bhg_tournament_results';
+				$ads_table          = $wpdb->prefix . 'bhg_ads';
+				$trans_table        = $wpdb->prefix . 'bhg_translations';
+				$aff_websites_table = $wpdb->prefix . 'bhg_affiliate_websites';
+				$winners_table      = $wpdb->prefix . 'bhg_hunt_winners';
 
 		$sql = array();
 
@@ -128,20 +127,8 @@ class BHG_DB {
 			UNIQUE KEY tkey_locale (tkey, locale)
 		) {$charset_collate};";
 
-               // Affiliates
-               $sql[] = "CREATE TABLE {$aff_table} (
-                       id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-                       name VARCHAR(190) NOT NULL,
-                       url VARCHAR(255) NULL,
-                       status VARCHAR(20) NOT NULL DEFAULT 'active',
-                       created_at DATETIME NULL,
-                       updated_at DATETIME NULL,
-                       PRIMARY KEY  (id),
-                       UNIQUE KEY name_unique (name)
-               ) {$charset_collate};";
-
-               // Affiliate Websites
-               $sql[] = "CREATE TABLE {$aff_sites_table} (
+				// Affiliate Websites
+				$sql[] = "CREATE TABLE {$aff_websites_table} (
                        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
                        name VARCHAR(190) NOT NULL,
                        slug VARCHAR(190) NOT NULL,
@@ -153,8 +140,8 @@ class BHG_DB {
                        UNIQUE KEY slug_unique (slug)
                ) {$charset_collate};";
 
-               // Hunt Winners
-               $sql[] = "CREATE TABLE {$winners_table} (
+				// Hunt Winners
+				$sql[] = "CREATE TABLE {$winners_table} (
                        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
                        hunt_id BIGINT UNSIGNED NOT NULL,
                        user_id BIGINT UNSIGNED NOT NULL,
@@ -256,75 +243,77 @@ class BHG_DB {
 							$wpdb->query( "ALTER TABLE `{$trans_table}` ADD UNIQUE KEY tkey_locale (tkey, locale)" );
 						}
 
-						// Affiliates columns / unique index
-						$afneed = array(
-							'name'       => "ALTER TABLE `{$aff_table}` ADD COLUMN name VARCHAR(190) NOT NULL",
-							'url'        => "ALTER TABLE `{$aff_table}` ADD COLUMN url VARCHAR(255) NULL",
-							'status'     => "ALTER TABLE `{$aff_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
-							'created_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN created_at DATETIME NULL",
-							'updated_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN updated_at DATETIME NULL",
-						);
-						foreach ( $afneed as $c => $alter ) {
-							if ( ! $this->column_exists( $aff_table, $c ) ) {
-								$wpdb->query( $alter );
-							}
-						}
-                                               if ( ! $this->index_exists( $aff_table, 'name_unique' ) ) {
-                                                       $wpdb->query( "ALTER TABLE `{$aff_table}` ADD UNIQUE KEY name_unique (name)" );
-                                               }
+												// Affiliate websites columns / unique index
+												$afw_need = array(
+													'name' => "ALTER TABLE `{$aff_websites_table}` ADD COLUMN name VARCHAR(190) NOT NULL",
+													'slug' => "ALTER TABLE `{$aff_websites_table}` ADD COLUMN slug VARCHAR(190) NOT NULL",
+													'url'  => "ALTER TABLE `{$aff_websites_table}` ADD COLUMN url VARCHAR(255) NULL",
+													'status' => "ALTER TABLE `{$aff_websites_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
+													'created_at' => "ALTER TABLE `{$aff_websites_table}` ADD COLUMN created_at DATETIME NULL",
+													'updated_at' => "ALTER TABLE `{$aff_websites_table}` ADD COLUMN updated_at DATETIME NULL",
+												);
+												foreach ( $afw_need as $c => $alter ) {
+													if ( ! $this->column_exists( $aff_websites_table, $c ) ) {
+															$wpdb->query( $alter );
+													}
+												}
+												if ( ! $this->index_exists( $aff_websites_table, 'slug_unique' ) ) {
+														$wpdb->query( "ALTER TABLE `{$aff_websites_table}` ADD UNIQUE KEY slug_unique (slug)" );
+												}
 
-                                               // Affiliate websites columns / unique index
-                                               $afsitesneed = array(
-                                                       'name'       => "ALTER TABLE `{$aff_sites_table}` ADD COLUMN name VARCHAR(190) NOT NULL",
-                                                       'slug'       => "ALTER TABLE `{$aff_sites_table}` ADD COLUMN slug VARCHAR(190) NOT NULL",
-                                                       'url'        => "ALTER TABLE `{$aff_sites_table}` ADD COLUMN url VARCHAR(255) NULL",
-                                                       'status'     => "ALTER TABLE `{$aff_sites_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
-                                                       'created_at' => "ALTER TABLE `{$aff_sites_table}` ADD COLUMN created_at DATETIME NULL",
-                                                       'updated_at' => "ALTER TABLE `{$aff_sites_table}` ADD COLUMN updated_at DATETIME NULL",
-                                               );
-                                               foreach ( $afsitesneed as $c => $alter ) {
-                                                       if ( ! $this->column_exists( $aff_sites_table, $c ) ) {
-                                                               $wpdb->query( $alter );
-                                                       }
-                                               }
-                                               if ( ! $this->index_exists( $aff_sites_table, 'slug_unique' ) ) {
-                                                       $wpdb->query( "ALTER TABLE `{$aff_sites_table}` ADD UNIQUE KEY slug_unique (slug)" );
-                                               }
-
-                                               // Hunt winners columns / indexes
-                                               $hwneed = array(
-                                                       'hunt_id'   => "ALTER TABLE `{$winners_table}` ADD COLUMN hunt_id BIGINT UNSIGNED NOT NULL",
-                                                       'user_id'   => "ALTER TABLE `{$winners_table}` ADD COLUMN user_id BIGINT UNSIGNED NOT NULL",
-                                                       'position'  => "ALTER TABLE `{$winners_table}` ADD COLUMN position INT UNSIGNED NOT NULL",
-                                                       'guess'     => "ALTER TABLE `{$winners_table}` ADD COLUMN guess DECIMAL(12,2) NOT NULL",
-                                                       'diff'      => "ALTER TABLE `{$winners_table}` ADD COLUMN diff DECIMAL(12,2) NOT NULL",
-                                                       'created_at'=> "ALTER TABLE `{$winners_table}` ADD COLUMN created_at DATETIME NULL",
-                                               );
-                                               foreach ( $hwneed as $c => $alter ) {
-                                                       if ( ! $this->column_exists( $winners_table, $c ) ) {
-                                                               $wpdb->query( $alter );
-                                                       }
-                                               }
-                                               if ( ! $this->index_exists( $winners_table, 'hunt_id' ) ) {
-                                                       $wpdb->query( "ALTER TABLE `{$winners_table}` ADD KEY hunt_id (hunt_id)" );
-                                               }
-                                               if ( ! $this->index_exists( $winners_table, 'user_id' ) ) {
-                                                       $wpdb->query( "ALTER TABLE `{$winners_table}` ADD KEY user_id (user_id)" );
-                                               }
+												// Hunt winners columns / indexes
+												$hwneed = array(
+													'hunt_id' => "ALTER TABLE `{$winners_table}` ADD COLUMN hunt_id BIGINT UNSIGNED NOT NULL",
+													'user_id' => "ALTER TABLE `{$winners_table}` ADD COLUMN user_id BIGINT UNSIGNED NOT NULL",
+													'position' => "ALTER TABLE `{$winners_table}` ADD COLUMN position INT UNSIGNED NOT NULL",
+													'guess' => "ALTER TABLE `{$winners_table}` ADD COLUMN guess DECIMAL(12,2) NOT NULL",
+													'diff' => "ALTER TABLE `{$winners_table}` ADD COLUMN diff DECIMAL(12,2) NOT NULL",
+													'created_at' => "ALTER TABLE `{$winners_table}` ADD COLUMN created_at DATETIME NULL",
+												);
+												foreach ( $hwneed as $c => $alter ) {
+													if ( ! $this->column_exists( $winners_table, $c ) ) {
+															$wpdb->query( $alter );
+													}
+												}
+												if ( ! $this->index_exists( $winners_table, 'hunt_id' ) ) {
+														$wpdb->query( "ALTER TABLE `{$winners_table}` ADD KEY hunt_id (hunt_id)" );
+												}
+												if ( ! $this->index_exists( $winners_table, 'user_id' ) ) {
+														$wpdb->query( "ALTER TABLE `{$winners_table}` ADD KEY user_id (user_id)" );
+												}
 		} catch ( Throwable $e ) {
 			if ( function_exists( 'error_log' ) ) {
-				error_log( '[BHG] Schema ensure error: ' . $e->getMessage() );
+						error_log( '[BHG] Schema ensure error: ' . $e->getMessage() );
 			}
 		}
 	}
 
-	/**
-	 * Check if a column exists, falling back when information_schema is not accessible.
-	 *
-	 * @param string $table  Table name.
-	 * @param string $column Column to check.
-	 * @return bool
-	 */
+		/**
+		 * Retrieve all affiliate websites.
+		 *
+		 * @return array List of affiliate website objects.
+		 */
+	public function get_affiliate_websites() {
+			global $wpdb;
+
+			$table = $wpdb->prefix . 'bhg_affiliate_websites';
+
+			// db call ok; no-cache ok.
+			return $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT id, name, slug, url, status FROM %i ORDER BY name ASC',
+					$table
+				)
+			);
+	}
+
+		/**
+		 * Check if a column exists, falling back when information_schema is not accessible.
+		 *
+		 * @param string $table  Table name.
+		 * @param string $column Column to check.
+		 * @return bool
+		 */
 	private function column_exists( $table, $column ) {
 		global $wpdb;
 

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -41,7 +41,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				$wpdb->prefix . 'bhg_guesses',
 				$wpdb->prefix . 'bhg_tournaments',
 				$wpdb->prefix . 'bhg_tournament_results',
-				$wpdb->prefix . 'bhg_affiliates',
+				$wpdb->prefix . 'bhg_affiliate_websites',
 				$wpdb->users,
 			);
 			return in_array( $table, $allowed, true ) ? esc_sql( $table ) : '';
@@ -266,27 +266,27 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 
 										$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
 										// db call ok; no-cache ok.
-                                                                               $sql             = 'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id
+																				$sql             = 'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id
                                                                                       FROM %i g
                                                                                       LEFT JOIN %i u ON u.ID = g.user_id
                                                                                       LEFT JOIN %i h ON h.id = g.hunt_id
                                                                                       WHERE g.hunt_id = %d ORDER BY %i ' . $order . ' LIMIT %d OFFSET %d';
-                                                                               $allowed_orderby = array( 'g.guess', 'u.user_login', 'g.id' );
-                                       if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
-                                                                       $orderby = 'g.guess';
-                                       }
-                                                                               $rows = $wpdb->get_results(
-                                                                                        $wpdb->prepare(
-                                                                                                $sql,
-                                                                                                $g,
-                                                                                                $u,
-                                                                                                  $hunts_table,
-                                                                                                  $hunt_id,
-                                                                                                  $orderby,
-                                                                                                  $per,
-                                                                                                  $offset
-                                                                                        )
-                                                                               );
+																				$allowed_orderby = array( 'g.guess', 'u.user_login', 'g.id' );
+					if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
+													$orderby = 'g.guess';
+					}
+																				$rows = $wpdb->get_results(
+																					$wpdb->prepare(
+																						$sql,
+																						$g,
+																						$u,
+																						$hunts_table,
+																						$hunt_id,
+																						$orderby,
+																						$per,
+																						$offset
+																					)
+																				);
 
 					wp_enqueue_style(
 						'bhg-shortcodes',
@@ -446,16 +446,16 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			$orderby_key = isset( $orderby_map[ $a['orderby'] ] ) ? $a['orderby'] : 'hunt';
 			$orderby     = $orderby_map[ $orderby_key ];
 
-                                               $sql = 'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id FROM %i g INNER JOIN %i h ON h.id = g.hunt_id WHERE ' . implode( ' AND ', $where ) . ' ORDER BY %i ' . $order;
-                                               if ( 'recent' === strtolower( $a['timeline'] ) ) {
-                                                       $sql .= ' LIMIT 10';
-                                               }
+												$sql = 'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id FROM %i g INNER JOIN %i h ON h.id = g.hunt_id WHERE ' . implode( ' AND ', $where ) . ' ORDER BY %i ' . $order;
+			if ( 'recent' === strtolower( $a['timeline'] ) ) {
+					$sql .= ' LIMIT 10';
+			}
 
-                                               // db call ok; no-cache ok.
-                                               $params = array_merge( array( $g, $h ), $params, array( $orderby ) );
-                                               $rows   = $wpdb->get_results(
-                                                       $wpdb->prepare( $sql, ...$params )
-                                               );
+												// db call ok; no-cache ok.
+												$params = array_merge( array( $g, $h ), $params, array( $orderby ) );
+												$rows   = $wpdb->get_results(
+													$wpdb->prepare( $sql, ...$params )
+												);
 			if ( ! $rows ) {
 				return '<p>' . esc_html( bhg_t( 'notice_no_guesses_found', 'No guesses found.' ) ) . '</p>';
 			}
@@ -525,8 +525,8 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			}
 
 			global $wpdb;
-			$h         = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-			$aff_table = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliates' );
+			$h                     = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+						$aff_table = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliate_websites' );
 
 			$where  = array();
 			$params = array();

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -107,10 +107,10 @@ if ( ! function_exists( 'bhg_t' ) ) {
 			return $cache[ $key ];
 		}
 
-               $table = $wpdb->prefix . 'bhg_translations';
-               $row   = $wpdb->get_row(
-                       $wpdb->prepare( 'SELECT tvalue FROM %i WHERE tkey = %s', $table, $key )
-               );
+				$table = $wpdb->prefix . 'bhg_translations';
+				$row   = $wpdb->get_row(
+					$wpdb->prepare( 'SELECT tvalue FROM %i WHERE tkey = %s', $table, $key )
+				);
 
 		if ( $row && isset( $row->tvalue ) ) {
 			$cache[ $key ] = (string) $row->tvalue;
@@ -137,7 +137,7 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'menu_results'                                 => 'Results',
 			'menu_tournaments'                             => 'Tournaments',
 			'menu_users'                                   => 'Users',
-			'menu_affiliates'                              => 'Affiliates',
+			'menu_affiliates'                              => 'Affiliate Websites',
 			'menu_advertising'                             => 'Advertising',
 			'menu_translations'                            => 'Translations',
 			'menu_tools'                                   => 'Tools',
@@ -159,35 +159,35 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'label_leaderboard'                            => 'Leaderboard',
 			'label_affiliate'                              => 'Affiliate',
 			'label_non_affiliate'                          => 'Non-affiliate',
-                        'label_affiliate_status'                       => 'Affiliate Status',
-                        'label_actions'                                => 'Actions',
-                        'label_id'                                     => 'ID',
-                        'label_key'                                    => 'Key',
-                        'label_name'                                   => 'Name',
-                        'label_winners'                                => 'Winners',
-                        'label_title_content'                          => 'Title/Content',
-                        'label_placement'                              => 'Placement',
-                        'label_placements'                             => 'Placements',
-                        'label_visible_to'                             => 'Visible To',
-                        'label_target_page_slugs'                      => 'Target Page Slugs',
-                        'label_existing_ads'                           => 'Existing Ads',
-                        'label_yes'                                    => 'Yes',
-                        'label_no'                                     => 'No',
-                        'label_default'                                => 'Default',
-                        'label_custom'                                 => 'Custom',
-                        'label_items_per_page'                         => 'Items per page',
-                        'label_search_translations'                    => 'Search translations',
-                        'label_start_date'                             => 'Start Date',
-                        'label_end_date'                               => 'End Date',
-                        'label_email'                                  => 'Email',
-                        'label_real_name'                              => 'Real Name',
-                        'label_search'                                 => 'Search',
-                        'label_user'                                   => 'User',
-                        'label_start'                                  => 'Start',
-                        'label_end'                                    => 'End',
-                        'label_status'                                 => 'Status',
-                        'label_status_colon'                           => 'Status:',
-                        'label_wins'                                   => 'Wins',
+			'label_affiliate_status'                       => 'Affiliate Status',
+			'label_actions'                                => 'Actions',
+			'label_id'                                     => 'ID',
+			'label_key'                                    => 'Key',
+			'label_name'                                   => 'Name',
+			'label_winners'                                => 'Winners',
+			'label_title_content'                          => 'Title/Content',
+			'label_placement'                              => 'Placement',
+			'label_placements'                             => 'Placements',
+			'label_visible_to'                             => 'Visible To',
+			'label_target_page_slugs'                      => 'Target Page Slugs',
+			'label_existing_ads'                           => 'Existing Ads',
+			'label_yes'                                    => 'Yes',
+			'label_no'                                     => 'No',
+			'label_default'                                => 'Default',
+			'label_custom'                                 => 'Custom',
+			'label_items_per_page'                         => 'Items per page',
+			'label_search_translations'                    => 'Search translations',
+			'label_start_date'                             => 'Start Date',
+			'label_end_date'                               => 'End Date',
+			'label_email'                                  => 'Email',
+			'label_real_name'                              => 'Real Name',
+			'label_search'                                 => 'Search',
+			'label_user'                                   => 'User',
+			'label_start'                                  => 'Start',
+			'label_end'                                    => 'End',
+			'label_status'                                 => 'Status',
+			'label_status_colon'                           => 'Status:',
+			'label_wins'                                   => 'Wins',
 			'label_last_win'                               => 'Last win',
 			'label_period'                                 => 'Period',
 			'label_all'                                    => 'All',
@@ -211,7 +211,6 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'label_closed_at'                              => 'Closed At',
 			'label_hunt'                                   => 'Hunt',
 			'label_title'                                  => 'Title',
-			'label_affiliate_sites'                        => 'Affiliate Sites',
 			'label_your_hunts'                             => 'Your Hunts',
 			'label_your_guesses'                           => 'Your Guesses',
 			'label_winner_notifications'                   => 'Winner Notifications',
@@ -237,11 +236,11 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'label_last_year'                              => 'Last year',
 			'label_quarterly'                              => 'Quarterly',
 			'label_alltime'                                => 'Alltime',
-                        'label_guests'                                 => 'Guests',
-                        'label_logged_in'                              => 'Logged In',
-                        'label_log_in'                                 => 'Log in',
-                        'label_log_out'                                => 'Log out',
-                        'label_non_affiliates'                         => 'Non Affiliates',
+			'label_guests'                                 => 'Guests',
+			'label_logged_in'                              => 'Logged In',
+			'label_log_in'                                 => 'Log in',
+			'label_log_out'                                => 'Log out',
+			'label_non_affiliates'                         => 'Non Affiliates',
 			'label_affiliate_website'                      => 'Affiliate Website',
 			'label_affiliate_websites'                     => 'Affiliate Websites',
 			'label_affiliate_user_title'                   => 'Affiliate User',
@@ -249,50 +248,50 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'label_bottom'                                 => 'Bottom',
 			'label_sidebar'                                => 'Sidebar',
 			'label_shortcode'                              => 'Shortcode',
-                        'label_timeline_colon'                         => 'Timeline:',
-                        'label_user_hash'                              => 'user#%d',
-                        'label_emdash'                                 => '—',
-                        'placeholder_enter_guess'                      => 'Enter your guess',
-                        'placeholder_custom_value'                     => 'Custom value',
+			'label_timeline_colon'                         => 'Timeline:',
+			'label_user_hash'                              => 'user#%d',
+			'label_emdash'                                 => '—',
+			'placeholder_enter_guess'                      => 'Enter your guess',
+			'placeholder_custom_value'                     => 'Custom value',
 
-                        // Buttons.
-                        'button_save'                                  => 'Save',
-                        'button_cancel'                                => 'Cancel',
-                        'button_delete'                                => 'Delete',
-                        'button_edit'                                  => 'Edit',
-                        'button_view'                                  => 'View',
-                        'button_back'                                  => 'Back',
-                        'button_create_new_bonus_hunt'                 => 'Create New Bonus Hunt',
-                        'button_results'                               => 'Results',
-                        'button_submit_guess'                          => 'Submit Guess',
-                        'button_filter'                                => 'Filter',
-                        'button_log_in'                                => 'Log in',
-                        'button_view_edit'                             => 'View / Edit',
-                        'button_update'                                => 'Update',
+			// Buttons.
+			'button_save'                                  => 'Save',
+			'button_cancel'                                => 'Cancel',
+			'button_delete'                                => 'Delete',
+			'button_edit'                                  => 'Edit',
+			'button_view'                                  => 'View',
+			'button_back'                                  => 'Back',
+			'button_create_new_bonus_hunt'                 => 'Create New Bonus Hunt',
+			'button_results'                               => 'Results',
+			'button_submit_guess'                          => 'Submit Guess',
+			'button_filter'                                => 'Filter',
+			'button_log_in'                                => 'Log in',
+			'button_view_edit'                             => 'View / Edit',
+			'button_update'                                => 'Update',
 
 			// Notices / messages.
 			'notice_login_required'                        => 'You must be logged in to guess.',
 			'notice_guess_saved'                           => 'Your guess has been saved.',
 			'notice_guess_updated'                         => 'Your guess has been updated.',
 			'notice_hunt_closed'                           => 'This bonus hunt is closed.',
-                        'notice_invalid_guess'                         => 'Please enter a valid guess.',
-                        'notice_ajax_error'                            => 'An error occurred. Please try again.',
-                        'notice_not_authorized'                        => 'You are not authorized to perform this action.',
-                        'notice_translations_saved'                    => 'Translations saved.',
-                        'notice_translations_reset'                    => 'Translations reset.',
-                        'notice_security_check_failed'                 => 'Security check failed.',
-                        'notice_invalid_hunt'                          => 'Invalid hunt.',
-                        'notice_invalid_hunt_id'                       => 'Invalid hunt id.',
-                        'notice_hunt_not_found'                        => 'Hunt not found.',
-                        'notice_invalid_guess_amount'                  => 'Invalid guess amount.',
-                        'notice_max_guesses_reached'                   => 'You have reached the maximum number of guesses.',
-                        'notice_no_data_available'                     => 'No data available.',
-                        'notice_guess_removed'                         => 'Guess removed.',
-                        'notice_hunt_closed_successfully'              => 'Hunt closed successfully.',
-                        'notice_missing_hunt_id'                       => 'Missing hunt id.',
-                        'notice_no_active_hunt'                        => 'No active bonus hunt found.',
-                        'notice_no_results'                            => 'No results available.',
-                        'notice_user_removed'                          => 'User removed.',
+			'notice_invalid_guess'                         => 'Please enter a valid guess.',
+			'notice_ajax_error'                            => 'An error occurred. Please try again.',
+			'notice_not_authorized'                        => 'You are not authorized to perform this action.',
+			'notice_translations_saved'                    => 'Translations saved.',
+			'notice_translations_reset'                    => 'Translations reset.',
+			'notice_security_check_failed'                 => 'Security check failed.',
+			'notice_invalid_hunt'                          => 'Invalid hunt.',
+			'notice_invalid_hunt_id'                       => 'Invalid hunt id.',
+			'notice_hunt_not_found'                        => 'Hunt not found.',
+			'notice_invalid_guess_amount'                  => 'Invalid guess amount.',
+			'notice_max_guesses_reached'                   => 'You have reached the maximum number of guesses.',
+			'notice_no_data_available'                     => 'No data available.',
+			'notice_guess_removed'                         => 'Guess removed.',
+			'notice_hunt_closed_successfully'              => 'Hunt closed successfully.',
+			'notice_missing_hunt_id'                       => 'Missing hunt id.',
+			'notice_no_active_hunt'                        => 'No active bonus hunt found.',
+			'notice_no_results'                            => 'No results available.',
+			'notice_user_removed'                          => 'User removed.',
 			'notice_ad_saved'                              => 'Advertisement saved.',
 			'notice_ad_deleted'                            => 'Advertisement deleted.',
 			'notice_settings_saved'                        => 'Settings saved.',
@@ -333,14 +332,14 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'sc_title'                                     => 'Title',
 			'sc_start_balance'                             => 'Start Balance',
 			'sc_final_balance'                             => 'Final Balance',
-                        'sc_status'                                    => 'Status',
-                        'sc_affiliate'                                 => 'Affiliate',
-                        'sc_position'                                  => 'Position',
-                        'sc_user'                                      => 'User',
-                        'sc_wins'                                      => 'Wins',
-                        'sc_start'                                     => 'Start',
-                        'sc_end'                                       => 'End',
-                        'sc_prizes'                                    => 'Prizes',
+			'sc_status'                                    => 'Status',
+			'sc_affiliate'                                 => 'Affiliate',
+			'sc_position'                                  => 'Position',
+			'sc_user'                                      => 'User',
+			'sc_wins'                                      => 'Wins',
+			'sc_start'                                     => 'Start',
+			'sc_end'                                       => 'End',
+			'sc_prizes'                                    => 'Prizes',
 
 			// Extended admin/UI strings.
 			's_participant'                                => '%s participant',
@@ -350,7 +349,7 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'add_new_bonus_hunt'                           => 'Add New Bonus Hunt',
 			'add_tournament'                               => 'Add Tournament',
 			'ads'                                          => 'Ads:',
-			'affiliate_site'                               => 'Affiliate Site',
+			'affiliate_site'                               => 'Affiliate Website',
 			'affiliate_user'                               => 'Affiliate',
 			'non_affiliate_user'                           => 'Non-affiliate',
 			'affiliate_management_ui_not_provided_yet'     => 'Affiliate management UI not provided yet.',
@@ -469,12 +468,12 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'guess_required'                               => 'Please enter a guess.',
 			'please_enter_a_valid_number'                  => 'Please enter a valid number.',
 			'guess_numeric'                                => 'Please enter a valid number.',
-                        'guess_range'                                  => 'Guess must be between %1$s and %2$s.',
-                        'guess_submitted'                              => 'Your guess has been submitted!',
-                        'msg_thank_you'                                => 'Thank you!',
-                        'msg_error'                                    => 'An error occurred.',
-                        'ajax_error'                                   => 'An error occurred. Please try again.',
-                        'profile'                                      => 'Profile',
+			'guess_range'                                  => 'Guess must be between %1$s and %2$s.',
+			'guess_submitted'                              => 'Your guess has been submitted!',
+			'msg_thank_you'                                => 'Thank you!',
+			'msg_error'                                    => 'An error occurred.',
+			'ajax_error'                                   => 'An error occurred. Please try again.',
+			'profile'                                      => 'Profile',
 			'reminder_assign_your_bhg_menus_adminmoderator_loggedin_guest_under_appearance_menus_manage_locations_use_shortcode_bhgnav_to_display' => 'Reminder: Assign your BHG menus (Admin/Moderator, Logged-in, Guest) under Appearance → Menus → Manage Locations. Use shortcode [bhg_nav] to display.',
 			'remove'                                       => 'Remove',
 			'remove_this_guess'                            => 'Remove this guess?',
@@ -493,9 +492,9 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'security_check_failed_2'                      => 'Security check failed.',
 			'security_check_failed_please_retry'           => 'Security check failed. Please retry.',
 			'security_check_failed_please_try_again'       => 'Security check failed. Please try again.',
-                        'settings'                                     => 'Settings',
-                        'settings_saved_successfully'                  => 'Settings saved successfully.',
-                        'settings_currently_unavailable'               => 'Settings management is currently unavailable.',
+			'settings'                                     => 'Settings',
+			'settings_saved_successfully'                  => 'Settings saved successfully.',
+			'settings_currently_unavailable'               => 'Settings management is currently unavailable.',
 			'show_ads_block_on_selected_pages'             => 'Show ads block on selected pages.',
 			'status'                                       => 'Status:',
 			'tshirt'                                       => 'T-shirt',
@@ -506,13 +505,13 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'this_will_delete_all_demo_data_and_pages_then_recreate_fresh_demo_content' => 'This will delete all demo data and pages, then recreate fresh demo content.',
 			'titlecontent'                                 => 'Title/Content',
 			'tournament_saved'                             => 'Tournament saved.',
-                        'tournaments'                                  => 'Tournaments:',
-                        'translation_saved'                            => 'Translation saved.',
-                        'tools_action_completed'                       => 'Tools action completed.',
-                        'summary'                                      => 'Summary',
-                        'view_all_hunts'                               => 'View All Hunts',
-                        'url'                                          => 'URL',
-                        'unknown_user'                                 => 'Unknown User',
+			'tournaments'                                  => 'Tournaments:',
+			'translation_saved'                            => 'Translation saved.',
+			'tools_action_completed'                       => 'Tools action completed.',
+			'summary'                                      => 'Summary',
+			'view_all_hunts'                               => 'View All Hunts',
+			'url'                                          => 'URL',
+			'unknown_user'                                 => 'Unknown User',
 			'update_ad'                                    => 'Update Ad',
 			'update_affiliate'                             => 'Update Affiliate',
 			'update_tournament'                            => 'Update Tournament',
@@ -548,22 +547,22 @@ if ( ! function_exists( 'bhg_seed_default_translations' ) ) {
 
 		$table = $wpdb->prefix . 'bhg_translations';
 
-               foreach ( bhg_get_default_translations() as $tkey => $tvalue ) {
-                       $tkey = trim( (string) $tkey );
-                       if ( '' === $tkey ) {
-                               continue; // Skip invalid keys.
-                       }
+		foreach ( bhg_get_default_translations() as $tkey => $tvalue ) {
+				$tkey = trim( (string) $tkey );
+			if ( '' === $tkey ) {
+						continue; // Skip invalid keys.
+			}
 
-                       $exists = (int) $wpdb->get_var(
-                               $wpdb->prepare(
-                                       'SELECT COUNT(*) FROM %i WHERE tkey = %s',
-                                       $table,
-                                       $tkey
-                               )
-                       );
+				$exists = (int) $wpdb->get_var(
+					$wpdb->prepare(
+						'SELECT COUNT(*) FROM %i WHERE tkey = %s',
+						$table,
+						$tkey
+					)
+				);
 
-                       if ( 0 === $exists ) {
-                               $wpdb->insert(
+			if ( 0 === $exists ) {
+				$wpdb->insert(
 					$table,
 					array(
 						'tkey'   => $tkey,
@@ -574,26 +573,26 @@ if ( ! function_exists( 'bhg_seed_default_translations' ) ) {
 				);
 			}
 		}
-        }
+	}
 }
 
 if ( ! function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
-               /**
-                * Ensure default translations exist.
-                *
-                * Inserts any missing translation keys so they appear in the admin.
-                *
-                * @return void
-                */
-       function bhg_seed_default_translations_if_empty() {
-               global $wpdb;
+				/**
+				 * Ensure default translations exist.
+				 *
+				 * Inserts any missing translation keys so they appear in the admin.
+				 *
+				 * @return void
+				 */
+	function bhg_seed_default_translations_if_empty() {
+			global $wpdb;
 
-               $table = $wpdb->prefix . 'bhg_translations';
+			$table = $wpdb->prefix . 'bhg_translations';
 
-               if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
-                       bhg_seed_default_translations();
-               }
-       }
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
+				bhg_seed_default_translations();
+		}
+	}
 }
 
 /**
@@ -665,44 +664,44 @@ if ( ! function_exists( 'bhg_is_user_affiliate' ) ) {
 	}
 }
 
-if ( ! function_exists( 'bhg_get_user_affiliate_sites' ) ) {
-	/**
-	 * Get affiliate site IDs for a user.
-	 *
-	 * @param int $user_id User ID.
-	 * @return array
-	 */
-	function bhg_get_user_affiliate_sites( $user_id ) {
-		$ids = get_user_meta( (int) $user_id, 'bhg_affiliate_sites', true );
+if ( ! function_exists( 'bhg_get_user_affiliate_websites' ) ) {
+		/**
+		 * Get affiliate website IDs for a user.
+		 *
+		 * @param int $user_id User ID.
+		 * @return array
+		 */
+	function bhg_get_user_affiliate_websites( $user_id ) {
+			$ids = get_user_meta( (int) $user_id, 'bhg_affiliate_websites', true );
 		if ( is_array( $ids ) ) {
-			return array_map( 'absint', $ids );
+				return array_map( 'absint', $ids );
 		}
 		if ( is_string( $ids ) && '' !== $ids ) {
-			return array_map( 'absint', array_filter( array_map( 'trim', explode( ',', $ids ) ) ) );
+				return array_map( 'absint', array_filter( array_map( 'trim', explode( ',', $ids ) ) ) );
 		}
-		return array();
+			return array();
 	}
 }
 
-if ( ! function_exists( 'bhg_set_user_affiliate_sites' ) ) {
-	/**
-	 * Store affiliate site IDs for a user.
-	 *
-	 * @param int   $user_id  User ID.
-	 * @param array $site_ids Site IDs.
-	 * @return void
-	 */
-	function bhg_set_user_affiliate_sites( $user_id, $site_ids ) {
-		$clean = array();
+if ( ! function_exists( 'bhg_set_user_affiliate_websites' ) ) {
+		/**
+		 * Store affiliate website IDs for a user.
+		 *
+		 * @param int   $user_id  User ID.
+		 * @param array $site_ids Site IDs.
+		 * @return void
+		 */
+	function bhg_set_user_affiliate_websites( $user_id, $site_ids ) {
+			$clean = array();
 		if ( is_array( $site_ids ) ) {
 			foreach ( $site_ids as $sid ) {
 				$sid = absint( $sid );
 				if ( $sid ) {
-					$clean[] = $sid;
+						$clean[] = $sid;
 				}
 			}
 		}
-		update_user_meta( (int) $user_id, 'bhg_affiliate_sites', $clean );
+			update_user_meta( (int) $user_id, 'bhg_affiliate_websites', $clean );
 	}
 }
 
@@ -718,8 +717,8 @@ if ( ! function_exists( 'bhg_is_user_affiliate_for_site' ) ) {
 		if ( ! $site_id ) {
 			return bhg_is_user_affiliate( (int) $user_id );
 		}
-		$sites = bhg_get_user_affiliate_sites( (int) $user_id );
-		return in_array( absint( $site_id ), array_map( 'absint', (array) $sites ), true );
+				$sites = bhg_get_user_affiliate_websites( (int) $user_id );
+				return in_array( absint( $site_id ), array_map( 'absint', (array) $sites ), true );
 	}
 }
 
@@ -748,26 +747,26 @@ if ( ! function_exists( 'bhg_render_affiliate_dot' ) ) {
  */
 function bhg_render_ads( $placement = 'footer', $hunt_id = 0 ) {
 	global $wpdb;
-       $tbl          = $wpdb->prefix . 'bhg_ads';
-       $placement    = sanitize_text_field( $placement );
-       $rows         = $wpdb->get_results(
-               $wpdb->prepare(
-                       'SELECT content, link_url, visible_to FROM %i WHERE active=1 AND placement=%s ORDER BY id DESC',
-                       $tbl,
-                       $placement
-               )
-       );
-	$hunt_site_id = 0;
+		$tbl       = $wpdb->prefix . 'bhg_ads';
+		$placement = sanitize_text_field( $placement );
+		$rows      = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT content, link_url, visible_to FROM %i WHERE active=1 AND placement=%s ORDER BY id DESC',
+				$tbl,
+				$placement
+			)
+		);
+	$hunt_site_id  = 0;
 
 	if ( $hunt_id ) {
-               $hunt_site_id = (int) $wpdb->get_var(
-                       $wpdb->prepare(
-                               'SELECT affiliate_site_id FROM %i WHERE id=%d',
-                               "{$wpdb->prefix}bhg_bonus_hunts",
-                               (int) $hunt_id
-                       )
-               );
-       }
+				$hunt_site_id = (int) $wpdb->get_var(
+					$wpdb->prepare(
+						'SELECT affiliate_site_id FROM %i WHERE id=%d',
+						"{$wpdb->prefix}bhg_bonus_hunts",
+						(int) $hunt_id
+					)
+				);
+	}
 
 	if ( ! $rows ) {
 		return '';
@@ -843,11 +842,11 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 			if ( $exists !== $tbl ) {
 				continue;
 			}
-                       if ( false !== strpos( $tbl, 'bhg_translations' ) || false !== strpos( $tbl, 'bhg_affiliate_websites' ) ) {
-                               continue; // keep; upsert below.
-                       }
-                       $wpdb->delete( $tbl, '1=1' );
-               }
+			if ( false !== strpos( $tbl, 'bhg_translations' ) || false !== strpos( $tbl, 'bhg_affiliate_websites' ) ) {
+					continue; // keep; upsert below.
+			}
+						$wpdb->delete( $tbl, '1=1' );
+		}
 
 		// Seed affiliate websites (idempotent upsert by slug).
 		$aff_tbl = "{$p}bhg_affiliate_websites";
@@ -864,16 +863,16 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 					'url'  => home_url( '/casino' ),
 				),
 			);
-                       foreach ( $affs as $a ) {
-                               $id = $wpdb->get_var(
-                                       $wpdb->prepare( 'SELECT id FROM %i WHERE slug=%s', $aff_tbl, $a['slug'] )
-                               );
-                               if ( $id ) {
-                                       $wpdb->update( $aff_tbl, $a, array( 'id' => (int) $id ), array( '%s', '%s', '%s' ), array( '%d' ) );
-                               } else {
-                                       $wpdb->insert( $aff_tbl, $a, array( '%s', '%s', '%s' ) );
-                               }
-                       }
+			foreach ( $affs as $a ) {
+					$id = $wpdb->get_var(
+						$wpdb->prepare( 'SELECT id FROM %i WHERE slug=%s', $aff_tbl, $a['slug'] )
+					);
+				if ( $id ) {
+					$wpdb->update( $aff_tbl, $a, array( 'id' => (int) $id ), array( '%s', '%s', '%s' ), array( '%d' ) );
+				} else {
+								$wpdb->insert( $aff_tbl, $a, array( '%s', '%s', '%s' ) );
+				}
+			}
 		}
 
 		// Seed hunts.
@@ -890,12 +889,12 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 					'num_bonuses'       => 10,
 					'prizes'            => __( 'Gift card + swag', 'bonus-hunt-guesser' ),
 					'status'            => 'open',
-                                       'affiliate_site_id' => (int) $wpdb->get_var(
-                                               $wpdb->prepare(
-                                                       'SELECT id FROM %i ORDER BY id ASC LIMIT 1',
-                                                       "{$p}bhg_affiliate_websites"
-                                               )
-                                       ),
+					'affiliate_site_id' => (int) $wpdb->get_var(
+						$wpdb->prepare(
+							'SELECT id FROM %i ORDER BY id ASC LIMIT 1',
+							"{$p}bhg_affiliate_websites"
+						)
+					),
 					'created_at'        => $now,
 					'updated_at'        => $now,
 				),
@@ -923,10 +922,10 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 			);
 
 			// Seed guesses for open hunt.
-                       $g_tbl = "{$p}bhg_guesses";
-                       $users = $wpdb->get_col(
-                               $wpdb->prepare( 'SELECT ID FROM %i ORDER BY ID ASC LIMIT 5', $wpdb->users )
-                       );
+						$g_tbl = "{$p}bhg_guesses";
+						$users = $wpdb->get_col(
+							$wpdb->prepare( 'SELECT ID FROM %i ORDER BY ID ASC LIMIT 5', $wpdb->users )
+						);
 			if ( empty( $users ) ) {
 				$users = array( 1 );
 			}
@@ -950,20 +949,20 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 		// Tournaments + results based on closed hunts.
 		$t_tbl = "{$p}bhg_tournaments";
 		$r_tbl = "{$p}bhg_tournament_results";
-               if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $t_tbl ) ) === $t_tbl ) {
-                       // Wipe results only.
-                       if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $r_tbl ) ) === $r_tbl ) {
-                               $wpdb->delete( $r_tbl, '1=1' );
-                       }
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $t_tbl ) ) === $t_tbl ) {
+				// Wipe results only.
+			if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $r_tbl ) ) === $r_tbl ) {
+						$wpdb->delete( $r_tbl, '1=1' );
+			}
 
-                       $closed = $wpdb->get_results(
-                               $wpdb->prepare(
-                                       'SELECT winner_user_id, closed_at FROM %i WHERE status=%s AND winner_user_id IS NOT NULL',
-                                       $hunts_tbl,
-                                       'closed'
-                               )
-                       );
-                       foreach ( $closed as $row ) {
+				$closed = $wpdb->get_results(
+					$wpdb->prepare(
+						'SELECT winner_user_id, closed_at FROM %i WHERE status=%s AND winner_user_id IS NOT NULL',
+						$hunts_tbl,
+						'closed'
+					)
+				);
+			foreach ( $closed as $row ) {
 				$ts        = $row->closed_at ? strtotime( $row->closed_at ) : time();
 				$iso_year  = gmdate( 'o', $ts );
 				$week      = str_pad( gmdate( 'W', $ts ), 2, '0', STR_PAD_LEFT );
@@ -972,9 +971,9 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 				$year_key  = gmdate( 'Y', $ts );
 
 				$ensure = function ( $type, $period ) use ( $wpdb, $t_tbl ) {
-					$now   = current_time( 'mysql', 1 );
-					$start = $now;
-					$end   = $now;
+						$now   = current_time( 'mysql', 1 );
+						$start = $now;
+						$end   = $now;
 
 					if ( 'weekly' === $type ) {
 						$start = gmdate( 'Y-m-d', strtotime( $period . '-1' ) );
@@ -987,106 +986,106 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 						$end   = $period . '-12-31';
 					}
 
-                                       $id = $wpdb->get_var(
-                                               $wpdb->prepare(
-                                                       'SELECT id FROM %i WHERE type=%s AND start_date=%s AND end_date=%s',
-                                                       $t_tbl,
-                                                       $type,
-                                                       $start,
-                                                       $end
-                                               )
-                                       );
+										$id = $wpdb->get_var(
+											$wpdb->prepare(
+												'SELECT id FROM %i WHERE type=%s AND start_date=%s AND end_date=%s',
+												$t_tbl,
+												$type,
+												$start,
+												$end
+											)
+										);
 					if ( $id ) {
 						return (int) $id;
 					}
-					$wpdb->insert(
-						$t_tbl,
-						array(
-							'type'       => $type,
-							'start_date' => $start,
-							'end_date'   => $end,
-							'status'     => 'active',
-							'created_at' => $now,
-							'updated_at' => $now,
-						),
-						array( '%s', '%s', '%s', '%s', '%s', '%s' )
-					);
-					return (int) $wpdb->insert_id;
+						$wpdb->insert(
+							$t_tbl,
+							array(
+								'type'       => $type,
+								'start_date' => $start,
+								'end_date'   => $end,
+								'status'     => 'active',
+								'created_at' => $now,
+								'updated_at' => $now,
+							),
+							array( '%s', '%s', '%s', '%s', '%s', '%s' )
+						);
+						return (int) $wpdb->insert_id;
 				};
 
-				$uid = (int) $row->winner_user_id;
+						$uid = (int) $row->winner_user_id;
 				foreach ( array(
 					$ensure( 'weekly', $week_key ),
 					$ensure( 'monthly', $month_key ),
 					$ensure( 'yearly', $year_key ),
 				) as $tid ) {
-                                       if ( $tid && $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $r_tbl ) ) === $r_tbl ) {
-                                               $wpdb->query(
-                                                       $wpdb->prepare(
-                                                               'INSERT INTO %i (tournament_id, user_id, wins) VALUES (%d, %d, 1) ON DUPLICATE KEY UPDATE wins = wins + 1',
-                                                               $r_tbl,
-                                                               $tid,
-                                                               $uid
-                                                       )
-                                               );
-                                       }
+					if ( $tid && $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $r_tbl ) ) === $r_tbl ) {
+							$wpdb->query(
+								$wpdb->prepare(
+									'INSERT INTO %i (tournament_id, user_id, wins) VALUES (%d, %d, 1) ON DUPLICATE KEY UPDATE wins = wins + 1',
+									$r_tbl,
+									$tid,
+									$uid
+								)
+							);
 					}
 				}
 			}
 		}
+	}
 
-                // Seed translations (upsert).
-                global $wpdb;
-                $p      = $wpdb->prefix;
-                $tr_tbl = "{$p}bhg_translations";
-                if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $tr_tbl ) ) === $tr_tbl ) {
-			$pairs = array(
-				'email_results_title'    => 'The Bonus Hunt has been closed!',
-				'email_final_balance'    => 'Final Balance',
-				'email_winner'           => 'Winner',
-				'email_congrats_subject' => 'Congratulations! You won the Bonus Hunt',
-				'email_congrats_body'    => 'You had the closest guess. Great job!',
-				'email_hunt'             => 'Hunt',
-			);
-                       foreach ( $pairs as $k => $v ) {
-                               $exists = $wpdb->get_var(
-                                       $wpdb->prepare( 'SELECT id FROM %i WHERE tkey=%s', $tr_tbl, $k )
-                               );
-                               if ( $exists ) {
-                                       $wpdb->update( $tr_tbl, array( 'tvalue' => $v ), array( 'id' => (int) $exists ), array( '%s' ), array( '%d' ) );
-                               } else {
-                                       $wpdb->insert(
-                                               $tr_tbl,
-                                               array(
-							'tkey'   => $k,
-							'tvalue' => $v,
-						),
-						array( '%s', '%s' )
-					);
-				}
+				// Seed translations (upsert).
+				global $wpdb;
+				$p      = $wpdb->prefix;
+				$tr_tbl = "{$p}bhg_translations";
+	if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $tr_tbl ) ) === $tr_tbl ) {
+		$pairs = array(
+			'email_results_title'    => 'The Bonus Hunt has been closed!',
+			'email_final_balance'    => 'Final Balance',
+			'email_winner'           => 'Winner',
+			'email_congrats_subject' => 'Congratulations! You won the Bonus Hunt',
+			'email_congrats_body'    => 'You had the closest guess. Great job!',
+			'email_hunt'             => 'Hunt',
+		);
+		foreach ( $pairs as $k => $v ) {
+							$exists = $wpdb->get_var(
+								$wpdb->prepare( 'SELECT id FROM %i WHERE tkey=%s', $tr_tbl, $k )
+							);
+			if ( $exists ) {
+				$wpdb->update( $tr_tbl, array( 'tvalue' => $v ), array( 'id' => (int) $exists ), array( '%s' ), array( '%d' ) );
+			} else {
+				$wpdb->insert(
+					$tr_tbl,
+					array(
+						'tkey'   => $k,
+						'tvalue' => $v,
+					),
+					array( '%s', '%s' )
+				);
 			}
 		}
+	}
 
 		// Seed ads.
 		$ads_tbl = "{$p}bhg_ads";
-		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $ads_tbl ) ) === $ads_tbl ) {
-			$now = current_time( 'mysql', 1 );
-			$wpdb->insert(
-				$ads_tbl,
-				array(
-					'title'        => '',
-					'content'      => '<strong>Play responsibly.</strong> <a href="' . esc_url( home_url( '/promo' ) ) . '">See promo</a>',
-					'link_url'     => '',
-					'placement'    => 'footer',
-					'visible_to'   => 'all',
-					'target_pages' => '',
-					'active'       => 1,
-					'created_at'   => $now,
-					'updated_at'   => $now,
-				),
-				array( '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s' )
-			);
-		}
+	if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $ads_tbl ) ) === $ads_tbl ) {
+		$now = current_time( 'mysql', 1 );
+		$wpdb->insert(
+			$ads_tbl,
+			array(
+				'title'        => '',
+				'content'      => '<strong>Play responsibly.</strong> <a href="' . esc_url( home_url( '/promo' ) ) . '">See promo</a>',
+				'link_url'     => '',
+				'placement'    => 'footer',
+				'visible_to'   => 'all',
+				'target_pages' => '',
+				'active'       => 1,
+				'created_at'   => $now,
+				'updated_at'   => $now,
+			),
+			array( '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s' )
+		);
+	}
 
 		return true;
-	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -25,7 +25,7 @@ $tables = array(
 	'bhg_tournament_results',
 	'bhg_ads',
 	'bhg_translations',
-	'bhg_affiliates',
+	'bhg_affiliate_websites',
 );
 
 foreach ( $tables as $table ) {


### PR DESCRIPTION
## Summary
- add dedicated `bhg_affiliate_websites` table and retrieval helper
- update admin interfaces and helpers to use `bhg_affiliate_websites`
- adjust bonus hunt forms and controllers for affiliate website integration

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml admin/class-bhg-admin.php admin/class-bhg-bonus-hunts-controller.php admin/views/affiliate-websites.php admin/views/bonus-hunts-edit.php admin/views/bonus-hunts.php admin/views/header.php includes/class-bhg-db.php includes/class-bhg-shortcodes.php includes/helpers.php uninstall.php`

------
https://chatgpt.com/codex/tasks/task_e_68bd8049bc648333ad0cb7ddbdff3def