### PR TITLE
Clear translation cache after edits

### DIFF
--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -47,16 +47,17 @@ if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'
 	if ( '' === $tkey ) {
 			$form_error = bhg_t( 'key_field_is_required', 'Key field is required.' );
 	} else {
-			$wpdb->replace(
-				$table,
-				array(
-					'tkey'   => $tkey,
-					'tvalue' => $tvalue,
-				),
-				array( '%s', '%s' )
-			);
-			$notice = bhg_t( 'translation_saved', 'Translation saved.' );
-	}
+                        $wpdb->replace(
+                                $table,
+                                array(
+                                        'tkey'   => $tkey,
+                                        'tvalue' => $tvalue,
+                                ),
+                                array( '%s', '%s' )
+                        );
+                       wp_cache_delete( 'bhg_translation_' . $tkey );
+                        $notice = bhg_t( 'translation_saved', 'Translation saved.' );
+        }
 }
 
 // Fetch rows with pagination.

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -97,28 +97,31 @@ if ( ! function_exists( 'bhg_t' ) ) {
 	 * @param string $default Default text if not found.
 	 * @return string
 	 */
-	function bhg_t( $key, $default = '' ) {
-		global $wpdb;
-		static $cache = array();
+       function bhg_t( $key, $default = '' ) {
+               global $wpdb;
 
-		$key = (string) $key;
+               $key       = (string) $key;
+               $cache_key = 'bhg_translation_' . $key;
+               $cached    = wp_cache_get( $cache_key );
 
-		if ( isset( $cache[ $key ] ) ) {
-			return $cache[ $key ];
-		}
+               if ( false !== $cached ) {
+                       return (string) $cached;
+               }
 
-				$table = $wpdb->prefix . 'bhg_translations';
-				$row   = $wpdb->get_row(
-					$wpdb->prepare( 'SELECT tvalue FROM %i WHERE tkey = %s', $table, $key )
-				);
+               $table = $wpdb->prefix . 'bhg_translations';
+               $row   = $wpdb->get_row(
+                       $wpdb->prepare( 'SELECT tvalue FROM %i WHERE tkey = %s', $table, $key )
+               );
 
-		if ( $row && isset( $row->tvalue ) ) {
-			$cache[ $key ] = (string) $row->tvalue;
-			return (string) $row->tvalue;
-		}
+               if ( $row && isset( $row->tvalue ) ) {
+                       $value = (string) $row->tvalue;
+                       wp_cache_set( $cache_key, $value );
+                       return $value;
+               }
 
-		return (string) $default;
-	}
+               wp_cache_set( $cache_key, (string) $default );
+               return (string) $default;
+       }
 }
 
 if ( ! function_exists( 'bhg_get_default_translations' ) ) {


### PR DESCRIPTION
## Summary
- clear translation cache when a translation row is saved
- use WordPress object caching in `bhg_t()` for translation lookups

## Testing
- `composer run phpcs` *(fails: script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8587d57083338eb8b3a1cd93196e