### PR TITLE
Refine dashboard styling with WP widgets

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -33,208 +33,128 @@ $users_count = isset( $user_counts['total_users'] ) ? (int) $user_counts['total_
 
 $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect: id, title, starting_balance, final_balance, winners_count, closed_at.
 ?>
-
 <div class="wrap bhg-wrap bhg-dashboard">
-<h1>
-<?php
-echo esc_html( bhg_t( 'menu_dashboard', 'Dashboard' ) );
-?>
-</h1>
+	<h1><?php echo esc_html( bhg_t( 'menu_dashboard', 'Dashboard' ) ); ?></h1>
 
-<div class="bhg-dashboard-cards">
-<div class="bhg-dashboard-card">
-<h2 class="bhg-dashboard-card-title">
-<?php
-echo esc_html( bhg_t( 'summary', 'Summary' ) );
-?>
-</h2>
-<div class="bhg-dashboard-card-content">
-<ul class="bhg-dashboard-meta">
-<li><span class="dashicons dashicons-book-alt"></span> <strong>
-<?php
-echo esc_html( bhg_t( 'hunts', 'Hunts:' ) );
-?>
-</strong> <?php echo esc_html( number_format_i18n( $hunts_count ) ); ?></li>
-<li><span class="dashicons dashicons-groups"></span> <strong>
-<?php
-echo esc_html( bhg_t( 'users', 'Users:' ) );
-?>
-</strong> <?php echo esc_html( number_format_i18n( $users_count ) ); ?></li>
-<li><span class="dashicons dashicons-awards"></span> <strong>
-<?php
-echo esc_html( bhg_t( 'tournaments', 'Tournaments:' ) );
-?>
-</strong> <?php echo esc_html( number_format_i18n( $tournaments_count ) ); ?></li>
-</ul>
-</div>
-</div>
+	<div class="dashboard-widgets-wrap bhg-dashboard-cards">
+		<div class="postbox bhg-dashboard-card">
+			<h2 class="hndle"><span><?php echo esc_html( bhg_t( 'summary', 'Summary' ) ); ?></span></h2>
+			<div class="inside">
+				<ul class="bhg-dashboard-meta">
+					<li><span class="dashicons dashicons-book-alt"></span> <strong><?php echo esc_html( bhg_t( 'hunts', 'Hunts:' ) ); ?></strong> <?php echo esc_html( number_format_i18n( $hunts_count ) ); ?></li>
+					<li><span class="dashicons dashicons-groups"></span> <strong><?php echo esc_html( bhg_t( 'users', 'Users:' ) ); ?></strong> <?php echo esc_html( number_format_i18n( $users_count ) ); ?></li>
+					<li><span class="dashicons dashicons-awards"></span> <strong><?php echo esc_html( bhg_t( 'tournaments', 'Tournaments:' ) ); ?></strong> <?php echo esc_html( number_format_i18n( $tournaments_count ) ); ?></li>
+				</ul>
+			</div>
+		</div>
 
-<div class="bhg-dashboard-card">
-<h2 class="bhg-dashboard-card-title">
-<?php
-echo esc_html( bhg_t( 'label_latest_hunts', 'Latest Hunts' ) );
-?>
-</h2>
-<div class="bhg-dashboard-card-content">
-<div class="bhg-dashboard-table-wrapper">
-<table class="wp-list-table widefat striped bhg-dashboard-table">
-												<thead>
-														<tr>
-																<th>
-																<?php
-																echo esc_html( bhg_t( 'label_bonushunt', 'Bonushunt' ) );
-																?>
-</th>
-																<th>
-																<?php
-																echo esc_html( bhg_t( 'label_all_winners', 'All Winners' ) );
-																?>
-</th>
-																<th>
-																<?php
-																echo esc_html( bhg_t( 'sc_start_balance', 'Start Balance' ) );
-																?>
-</th>
-																<th>
-																<?php
-																echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) );
-																?>
-</th>
-																<th>
-																<?php
-																echo esc_html( bhg_t( 'label_closed_at', 'Closed At' ) );
-																?>
-</th>
-														</tr>
-												</thead>
-												<tbody>
-												<?php if ( ! empty( $hunts ) && is_array( $hunts ) ) : ?>
-														<?php foreach ( $hunts as $h ) : ?>
-															<?php
-															$hunt_id       = isset( $h->id ) ? (int) $h->id : 0;
-															$winners_count = isset( $h->winners_count ) ? (int) $h->winners_count : 0;
-															$winners       = array();
+		<div class="postbox bhg-dashboard-card">
+			<h2 class="hndle"><span><?php echo esc_html( bhg_t( 'label_latest_hunts', 'Latest Hunts' ) ); ?></span></h2>
+			<div class="inside">
+				<div class="bhg-dashboard-table-wrapper">
+					<table class="wp-list-table widefat striped bhg-dashboard-table">
+						<thead>
+							<tr>
+								<th><?php echo esc_html( bhg_t( 'label_bonushunt', 'Bonushunt' ) ); ?></th>
+								<th><?php echo esc_html( bhg_t( 'label_all_winners', 'All Winners' ) ); ?></th>
+								<th><?php echo esc_html( bhg_t( 'sc_start_balance', 'Start Balance' ) ); ?></th>
+								<th><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></th>
+								<th><?php echo esc_html( bhg_t( 'label_closed_at', 'Closed At' ) ); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+						<?php if ( ! empty( $hunts ) && is_array( $hunts ) ) : ?>
+							<?php foreach ( $hunts as $h ) : ?>
+								<?php
+								$hunt_id       = isset( $h->id ) ? (int) $h->id : 0;
+								$winners_count = isset( $h->winners_count ) ? (int) $h->winners_count : 0;
+								$winners       = array();
 
-															if ( $hunt_id && function_exists( 'bhg_get_top_winners_for_hunt' ) ) {
-																$winners = bhg_get_top_winners_for_hunt( $hunt_id, $winners_count );
-																if ( ! is_array( $winners ) ) {
-																	$winners = array();
-																}
-															}
+								if ( $hunt_id && function_exists( 'bhg_get_top_winners_for_hunt' ) ) {
+									$winners = bhg_get_top_winners_for_hunt( $hunt_id, $winners_count );
+									if ( ! is_array( $winners ) ) {
+										$winners = array();
+									}
+								}
 
-															$hunt_title = isset( $h->title ) ? (string) $h->title : '';
-															$start      = isset( $h->starting_balance ) ? (float) $h->starting_balance : 0.0;
-															?>
+								$hunt_title = isset( $h->title ) ? (string) $h->title : '';
+								$start      = isset( $h->starting_balance ) ? (float) $h->starting_balance : 0.0;
+								?>
 								<tr>
-									<td data-label="
-															<?php
-															echo esc_attr( bhg_t( 'label_bonushunt', 'Bonushunt' ) );
-															?>
-">
-															<?php echo '' !== $hunt_title ? esc_html( $hunt_title ) : esc_html( bhg_t( 'label_untitled', '(untitled)' ) ); ?>
+									<td data-label="<?php echo esc_attr( bhg_t( 'label_bonushunt', 'Bonushunt' ) ); ?>">
+										<?php echo '' !== $hunt_title ? esc_html( $hunt_title ) : esc_html( bhg_t( 'label_untitled', '(untitled)' ) ); ?>
 									</td>
-									<td data-label="
-															<?php
-															echo esc_attr( bhg_t( 'label_all_winners', 'All Winners' ) );
-															?>
-">
-															<?php
-															if ( ! empty( $winners ) ) {
-																$out = array();
-																foreach ( $winners as $w ) {
-																	$user_id = isset( $w->user_id ) ? (int) $w->user_id : 0;
-																	$guess   = isset( $w->guess ) ? (float) $w->guess : 0.0;
-																	$diff    = isset( $w->diff ) ? (float) $w->diff : 0.0;
+									<td data-label="<?php echo esc_attr( bhg_t( 'label_all_winners', 'All Winners' ) ); ?>">
+										<?php
+										if ( ! empty( $winners ) ) {
+											$out = array();
+											foreach ( $winners as $w ) {
+												$user_id = isset( $w->user_id ) ? (int) $w->user_id : 0;
+												$guess   = isset( $w->guess ) ? (float) $w->guess : 0.0;
+												$diff    = isset( $w->diff ) ? (float) $w->diff : 0.0;
 
-																	$u  = $user_id ? get_userdata( $user_id ) : false;
-																	$nm = $u ? $u->user_login : sprintf(
-																		/* translators: %d: user ID. */
-																		esc_html( bhg_t( 'label_user_number', 'User #%d' ) ),
-																		$user_id
-																	);
+												$u  = $user_id ? get_userdata( $user_id ) : false;
+												$nm = $u ? $u->user_login : sprintf(
+													/* translators: %d: user ID. */
+													esc_html( bhg_t( 'label_user_number', 'User #%d' ) ),
+													$user_id
+												);
 
-																	// Compose: "name — 1,234.00 (diff 12.34)".
-																	$out[] = sprintf(
-																		'%1$s %2$s %3$s (%4$s %5$s)',
-																		esc_html( $nm ),
-																		esc_html_x( '—', 'name/guess separator', 'bonus-hunt-guesser' ),
-																		esc_html( number_format_i18n( $guess, 2 ) ),
-																		esc_html( bhg_t( 'label_diff', 'diff' ) ),
-																		esc_html( number_format_i18n( $diff, 2 ) )
-																	);
-																}
-																// Implode to a single, safely-escaped string separated by dots.
-																echo esc_html( implode( ' • ', $out ) );
-															} else {
-																echo esc_html( bhg_t( 'no_winners_yet', 'No winners yet' ) );
-
-															}
-															?>
+												// Compose: "name — 1,234.00 (diff 12.34)".
+												$out[] = sprintf(
+													'%1$s %2$s %3$s (%4$s %5$s)',
+													esc_html( $nm ),
+													esc_html_x( '—', 'name/guess separator', 'bonus-hunt-guesser' ),
+													esc_html( number_format_i18n( $guess, 2 ) ),
+													esc_html( bhg_t( 'label_diff', 'diff' ) ),
+													esc_html( number_format_i18n( $diff, 2 ) )
+												);
+											}
+											// Implode to a single, safely-escaped string separated by dots.
+											echo esc_html( implode( ' • ', $out ) );
+										} else {
+											echo esc_html( bhg_t( 'no_winners_yet', 'No winners yet' ) );
+										}
+										?>
 									</td>
-									<td data-label="
-															<?php
-															echo esc_attr( bhg_t( 'sc_start_balance', 'Start Balance' ) );
-															?>
-">
-															<?php echo esc_html( number_format_i18n( $start, 2 ) ); ?>
+									<td data-label="<?php echo esc_attr( bhg_t( 'sc_start_balance', 'Start Balance' ) ); ?>">
+										<?php echo esc_html( number_format_i18n( $start, 2 ) ); ?>
 									</td>
-									<td data-label="
-															<?php
-															echo esc_attr( bhg_t( 'sc_final_balance', 'Final Balance' ) );
-															?>
-">
-															<?php
-															if ( isset( $h->final_balance ) && null !== $h->final_balance ) {
-																echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
-															} else {
-																echo esc_html( bhg_t( 'label_emdash', '—' ) );
-
-															}
-															?>
+									<td data-label="<?php echo esc_attr( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?>">
+										<?php
+										if ( isset( $h->final_balance ) && null !== $h->final_balance ) {
+											echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
+										} else {
+											echo esc_html( bhg_t( 'label_emdash', '—' ) );
+										}
+										?>
 									</td>
-									<td data-label="
-															<?php
-															echo esc_attr( bhg_t( 'label_closed_at', 'Closed At' ) );
-															?>
-">
-															<?php
-															if ( ! empty( $h->closed_at ) ) {
-																$ts = strtotime( (string) $h->closed_at );
-																echo esc_html(
-																	false !== $ts
-																		? date_i18n(
-																			get_option( 'date_format' ) . ' ' . get_option( 'time_format' ),
-																			$ts
-																		)
-																		: (string) $h->closed_at
-																);
-															} else {
-																echo esc_html( bhg_t( 'label_emdash', '—' ) );
-
-															}
-															?>
+									<td data-label="<?php echo esc_attr( bhg_t( 'label_closed_at', 'Closed At' ) ); ?>">
+										<?php
+										if ( ! empty( $h->closed_at ) ) {
+											$ts = strtotime( (string) $h->closed_at );
+											echo esc_html(
+												false !== $ts
+													? date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $ts )
+													: (string) $h->closed_at
+											);
+										} else {
+											echo esc_html( bhg_t( 'label_emdash', '—' ) );
+										}
+										?>
 									</td>
 								</tr>
 							<?php endforeach; ?>
 						<?php else : ?>
 							<tr>
-								<td colspan="5">
-								<?php
-								echo esc_html( bhg_t( 'notice_no_closed_hunts', 'No closed hunts yet.' ) );
-								?>
-</td>
+								<td colspan="5"><?php echo esc_html( bhg_t( 'notice_no_closed_hunts', 'No closed hunts yet.' ) ); ?></td>
 							</tr>
-	<?php endif; ?>
-	</tbody>
-	</table>
-	</div>
-	<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts' ) ); ?>" class="button button-primary">
-	<?php
-	echo esc_html( bhg_t( 'view_all_hunts', 'View All Hunts' ) );
-	?>
-</a></p>
+						<?php endif; ?>
+						</tbody>
+					</table>
+				</div>
+				<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts' ) ); ?>" class="button button-primary"><?php echo esc_html( bhg_t( 'view_all_hunts', 'View All Hunts' ) ); ?></a></p>
+			</div>
+		</div>
 	</div>
 </div>
-</div><!-- .bhg-dashboard-cards -->
-</div>
-

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -146,7 +146,7 @@ flex: 1;
     border-radius: 4px;
 }
 
-.bhg-dashboard-card {
+.postbox.bhg-dashboard-card {
     font-family: var(--bhg-font-family);
     background: var(--bhg-card-bg);
     border: 1px solid var(--bhg-border-color);
@@ -157,7 +157,7 @@ flex: 1;
     width: 100%;
 }
 
-.bhg-dashboard-card-title {
+.postbox.bhg-dashboard-card .hndle {
     background-color: var(--bhg-accent-color);
     border: 1px solid var(--bhg-accent-color);
     color: #fff;
@@ -165,7 +165,7 @@ flex: 1;
     margin: 0;
 }
 
-.bhg-dashboard-card-content {
+.postbox.bhg-dashboard-card .inside {
     padding: var(--bhg-spacing);
 }
 
@@ -251,6 +251,14 @@ flex: 1;
 .bhg-dashboard-table-wrapper th,
 .bhg-dashboard-table-wrapper td {
     padding: 8px 10px;
+}
+
+.bhg-dashboard-table-wrapper th {
+    text-align: left;
+}
+
+.bhg-dashboard-table-wrapper td {
+    vertical-align: top;
 }
 
 /* Table visual accents */


### PR DESCRIPTION
## Summary
- Restyle dashboard to use WordPress `postbox` widgets
- Apply consistent `#2271b1` accent to headings and buttons
- Improve dashboard table alignment and responsiveness

## Testing
- `vendor/bin/phpcs admin/views/dashboard.php assets/css/admin.css`


------
https://chatgpt.com/codex/tasks/task_e_68bd90ecc7c08333a20b2daf80e4a805