### PR TITLE
Use accent color variable for buttons and headings

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,3 +1,12 @@
+/* Global color variables */
+:root {
+    --bhg-accent-color: #2271b1;
+    --bhg-border-color: #e5e7eb;
+    --bhg-card-bg: #ffffff;
+    --bhg-spacing: 16px;
+    --bhg-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Inter, Arial, 'Noto Sans', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+}
+
 .bhg-wrap .bhg-cards {
     display: flex;
     gap: 16px;
@@ -128,13 +137,6 @@ flex: 1;
 }
 
 /* Dashboard styles */
-:root {
-    --bhg-accent-color: #2271b1;
-    --bhg-border-color: #e5e7eb;
-    --bhg-card-bg: #ffffff;
-    --bhg-spacing: 16px;
-    --bhg-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Inter, Arial, 'Noto Sans', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
-}
 
 .bhg-dashboard h1 {
     background-color: var(--bhg-accent-color);

--- a/assets/css/bhg-shortcodes.css
+++ b/assets/css/bhg-shortcodes.css
@@ -36,19 +36,20 @@
     display: block;
     padding: 8px 12px;
     text-decoration: none;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--bhg-accent-color);
     border-bottom: none;
     margin-right: 4px;
-    background: #f7fafc;
+    background-color: var(--bhg-accent-color);
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
-    color: var(--bhg-accent-color);
+    color: #fff;
 }
 
 .bhg-tabs a:hover {
     background-color: var(--bhg-accent-color);
     border-color: var(--bhg-accent-color);
     color: #fff;
+    filter: brightness(0.9);
 }
 
 .bhg-tabs li.active a {


### PR DESCRIPTION
## Summary
- define global `--bhg-accent-color` and apply to admin buttons and headings
- adjust shortcode tab buttons to use accent color variable

## Testing
- `composer install`
- `composer phpcs` *(fails: Use of a direct database call is discouraged)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9a9184bc8333a0dd52a475acd661