### PR TITLE
Validate leaderboard orderby and remove PHPCS ignore

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -270,7 +270,7 @@ $total = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM ' . $g . ' 
 												if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
 														$orderby = 'g.guess';
 												}
-$sql = 'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id' // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+$sql = 'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id' 
 														. ' FROM ' . $g . ' g'
 														. ' LEFT JOIN ' . $u . ' u ON u.ID = g.user_id'
 														. ' LEFT JOIN ' . $hunts_table . ' h ON h.id = g.hunt_id'


### PR DESCRIPTION
## Summary
- remove redundant PHPCS ignore and rely on whitelist validation for leaderboard `ORDER BY`

## Testing
- `php vendor/bin/phpcs --standard=phpcs.xml includes/class-bhg-shortcodes.php`
- `composer -n run phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bda1ff6c7c833394b6cd6004507ef9