### PR TITLE
Add slug label to translation defaults

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -169,6 +169,7 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'label_id'                                     => 'ID',
 			'label_key'                                    => 'Key',
 			'label_name'                                   => 'Name',
+			'slug'                                         => 'Slug',
 			'label_winners'                                => 'Winners',
 			'label_title_content'                          => 'Title/Content',
 			'label_placement'                              => 'Placement',


### PR DESCRIPTION
## Summary
- include slug label in default translations so admin strings appear on the Translations page

## Testing
- `composer install`
- `composer phpcs` *(fails: script returned error code 2)*
- `vendor/bin/phpcs includes/helpers.php` *(fails: contains warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bda75a907083338a199a262ecbdb38