### PR TITLE
Add settings form with nonce validation

### DIFF
--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -1,13 +1,92 @@
 <?php
+/**
+ * Settings view.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-		exit;
+	exit;
 }
 
 if ( ! current_user_can( 'manage_options' ) ) {
-		wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
+	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
 }
+
+// Fetch existing settings.
+$settings = get_option( 'bhg_plugin_settings', array() );
+
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$message = isset( $_GET['message'] ) ? sanitize_key( wp_unslash( $_GET['message'] ) ) : '';
+
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$error_code = isset( $_GET['error'] ) ? sanitize_key( wp_unslash( $_GET['error'] ) ) : '';
 ?>
 <div class="wrap">
-		<h1><?php echo esc_html( bhg_t( 'bonus_hunt_guesser_settings', 'Bonus Hunt Guesser Settings' ) ); ?></h1>
-		<p><?php echo esc_html( bhg_t( 'settings_currently_unavailable', 'Settings management is currently unavailable.' ) ); ?></p>
+<h1><?php echo esc_html( bhg_t( 'bonus_hunt_guesser_settings', 'Bonus Hunt Guesser Settings' ) ); ?></h1>
+
+<?php if ( 'saved' === $message ) : ?>
+<div class="notice notice-success"><p><?php echo esc_html( bhg_t( 'settings_saved', 'Settings saved.' ) ); ?></p></div>
+<?php elseif ( 'invalid_data' === $error_code ) : ?>
+<div class="notice notice-error"><p><?php echo esc_html( bhg_t( 'invalid_settings', 'Invalid data submitted.' ) ); ?></p></div>
+<?php elseif ( 'nonce_failed' === $error_code ) : ?>
+<div class="notice notice-error"><p><?php echo esc_html( bhg_t( 'security_check_failed', 'Security check failed. Please try again.' ) ); ?></p></div>
+<?php endif; ?>
+
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+<?php wp_nonce_field( 'bhg_save_settings', 'bhg_save_settings_nonce' ); ?>
+<input type="hidden" name="action" value="bhg_save_settings">
+
+<table class="form-table" role="presentation">
+<tbody>
+<tr>
+<th scope="row"><label for="bhg_default_tournament_period"><?php echo esc_html( bhg_t( 'default_tournament_period', 'Default Tournament Period' ) ); ?></label></th>
+<td>
+<select name="bhg_default_tournament_period" id="bhg_default_tournament_period">
+<?php
+$periods        = array(
+'weekly'    => bhg_t( 'weekly', 'Weekly' ),
+'monthly'   => bhg_t( 'monthly', 'Monthly' ),
+'quarterly' => bhg_t( 'quarterly', 'Quarterly' ),
+'yearly'    => bhg_t( 'yearly', 'Yearly' ),
+'alltime'   => bhg_t( 'alltime', 'All-time' ),
+);
+$current_period = isset( $settings['default_tournament_period'] ) ? $settings['default_tournament_period'] : '';
+foreach ( $periods as $key => $label ) :
+?>
+<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $current_period, $key ); ?>><?php echo esc_html( $label ); ?></option>
+<?php endforeach; ?>
+</select>
+</td>
+</tr>
+<tr>
+<th scope="row"><label for="bhg_min_guess_amount"><?php echo esc_html( bhg_t( 'min_guess_amount', 'Minimum Guess Amount' ) ); ?></label></th>
+<td><input type="number" class="small-text" id="bhg_min_guess_amount" name="bhg_min_guess_amount" value="<?php echo isset( $settings['min_guess_amount'] ) ? esc_attr( $settings['min_guess_amount'] ) : '0'; ?>" min="0"></td>
+</tr>
+<tr>
+<th scope="row"><label for="bhg_max_guess_amount"><?php echo esc_html( bhg_t( 'max_guess_amount', 'Maximum Guess Amount' ) ); ?></label></th>
+<td><input type="number" class="small-text" id="bhg_max_guess_amount" name="bhg_max_guess_amount" value="<?php echo isset( $settings['max_guess_amount'] ) ? esc_attr( $settings['max_guess_amount'] ) : '100000'; ?>" min="0"></td>
+</tr>
+<tr>
+<th scope="row"><label for="bhg_allow_guess_changes"><?php echo esc_html( bhg_t( 'allow_guess_changes', 'Allow Guess Changes' ) ); ?></label></th>
+<td>
+<select name="bhg_allow_guess_changes" id="bhg_allow_guess_changes">
+<option value="yes" <?php selected( isset( $settings['allow_guess_changes'] ) ? $settings['allow_guess_changes'] : '', 'yes' ); ?>><?php echo esc_html( bhg_t( 'yes', 'Yes' ) ); ?></option>
+<option value="no" <?php selected( isset( $settings['allow_guess_changes'] ) ? $settings['allow_guess_changes'] : '', 'no' ); ?>><?php echo esc_html( bhg_t( 'no', 'No' ) ); ?></option>
+</select>
+</td>
+</tr>
+<tr>
+<th scope="row"><label for="bhg_ads_enabled"><?php echo esc_html( bhg_t( 'ads_enabled', 'Enable Ads' ) ); ?></label></th>
+<td><input type="checkbox" id="bhg_ads_enabled" name="bhg_ads_enabled" value="1" <?php checked( isset( $settings['ads_enabled'] ) ? (int) $settings['ads_enabled'] : 0, 1 ); ?>></td>
+</tr>
+<tr>
+<th scope="row"><label for="bhg_email_from"><?php echo esc_html( bhg_t( 'email_from', 'Email From Address' ) ); ?></label></th>
+<td><input type="email" class="regular-text" id="bhg_email_from" name="bhg_email_from" value="<?php echo isset( $settings['email_from'] ) ? esc_attr( $settings['email_from'] ) : esc_attr( get_bloginfo( 'admin_email' ) ); ?>"></td>
+</tr>
+</tbody>
+</table>
+
+<?php submit_button( bhg_t( 'save_settings', 'Save Settings' ) ); ?>
+</form>
 </div>


### PR DESCRIPTION
## Summary
- replace placeholder settings page with functional form
- save plugin options with nonce check

## Testing
- `composer install`
- `composer phpcs` *(fails: direct database call and coding standard errors in unrelated files)*
- `vendor/bin/phpcs --standard=phpcs.xml admin/views/settings.php -p`

------
https://chatgpt.com/codex/tasks/task_e_68bdace474d483338509702e333231ea