### PR TITLE
Sanitize tools diagnostics queries

### DIFF
--- a/admin/views/tools.php
+++ b/admin/views/tools.php
@@ -13,8 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<h1><?php echo esc_html( bhg_t( 'bhg_tools', 'BHG Tools' ) ); ?></h1>
 
 		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-                               <input type="hidden" name="action" value="bhg_tools_action">
-                               <?php wp_nonce_field( 'bhg_tools_action', 'bhg_tools_nonce' ); ?>
+								<input type="hidden" name="action" value="bhg_tools_action">
+								<?php wp_nonce_field( 'bhg_tools_action', 'bhg_tools_nonce' ); ?>
 				<p>
 				<?php
 				echo esc_html( bhg_t( 'this_will_delete_all_demo_data_and_pages_then_recreate_fresh_demo_content', 'This will delete all demo data and pages, then recreate fresh demo content.' ) );
@@ -27,24 +27,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 " /></p>
 	</form>
 
-	<?php
-	global $wpdb;
-	$hunts       = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_bonus_hunts" );
-	$guesses     = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_guesses" );
-	$users       = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->users}" );
-	$ads         = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_ads" );
-	$tournaments = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_tournaments" );
-	?>
+		<?php
+		global $wpdb;
+
+		$hunts_table       = esc_sql( "{$wpdb->prefix}bhg_bonus_hunts" );
+		$guesses_table     = esc_sql( "{$wpdb->prefix}bhg_guesses" );
+		$users_table       = esc_sql( $wpdb->users );
+		$ads_table         = esc_sql( "{$wpdb->prefix}bhg_ads" );
+		$tournaments_table = esc_sql( "{$wpdb->prefix}bhg_tournaments" );
+
+		$hunts               = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM ' . $hunts_table ) );
+				$guesses     = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM ' . $guesses_table ) );
+				$users       = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM ' . $users_table ) );
+				$ads         = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM ' . $ads_table ) );
+				$tournaments = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM ' . $tournaments_table ) );
+		?>
 
 	<div class="card" style="max-width:900px;padding:16px;margin-top:12px;">
 		<h2><?php echo esc_html( bhg_t( 'diagnostics', 'Diagnostics' ) ); ?></h2>
 		<?php if ( ( $hunts + $guesses + $users + $ads + $tournaments ) > 0 ) : ?>
 			<ul>
-				<li><?php echo esc_html( bhg_t( 'hunts', 'Hunts:' ) ); ?> <?php echo number_format_i18n( $hunts ); ?></li>
-				<li><?php echo esc_html( bhg_t( 'guesses_2', 'Guesses:' ) ); ?> <?php echo number_format_i18n( $guesses ); ?></li>
-				<li><?php echo esc_html( bhg_t( 'users', 'Users:' ) ); ?> <?php echo number_format_i18n( $users ); ?></li>
-				<li><?php echo esc_html( bhg_t( 'ads', 'Ads:' ) ); ?> <?php echo number_format_i18n( $ads ); ?></li>
-				<li><?php echo esc_html( bhg_t( 'tournaments', 'Tournaments:' ) ); ?> <?php echo number_format_i18n( $tournaments ); ?></li>
+								<li><?php echo esc_html( bhg_t( 'hunts', 'Hunts:' ) ); ?> <?php echo esc_html( number_format_i18n( $hunts ) ); ?></li>
+								<li><?php echo esc_html( bhg_t( 'guesses_2', 'Guesses:' ) ); ?> <?php echo esc_html( number_format_i18n( $guesses ) ); ?></li>
+								<li><?php echo esc_html( bhg_t( 'users', 'Users:' ) ); ?> <?php echo esc_html( number_format_i18n( $users ) ); ?></li>
+								<li><?php echo esc_html( bhg_t( 'ads', 'Ads:' ) ); ?> <?php echo esc_html( number_format_i18n( $ads ) ); ?></li>
+								<li><?php echo esc_html( bhg_t( 'tournaments', 'Tournaments:' ) ); ?> <?php echo esc_html( number_format_i18n( $tournaments ) ); ?></li>
 			</ul>
 		<?php else : ?>
 			<p><?php echo esc_html( bhg_t( 'nothing_to_show_yet_start_by_creating_a_hunt_or_a_test_user', 'Nothing to show yet. Start by creating a hunt or a test user.' ) ); ?></p>


### PR DESCRIPTION
## Summary
- sanitize table names with `esc_sql`
- use `$wpdb->prepare` for diagnostics counts
- escape numerical output in tools view

## Testing
- `composer run phpcs admin/views/tools.php` *(fails: Use placeholders for dynamic table names; direct DB call warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb35ba4e483338362579cfe39dad4