### PR TITLE
Apply default tournament period and email sender

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -320,14 +320,16 @@ class BHG_Admin {
 											)
 										);
 
+										$headers = array( 'From: ' . BHG_Utils::get_email_from() );
 										wp_mail(
-											$u->user_email,
-											sprintf(
-														/* translators: %s: bonus hunt title. */
-												bhg_t( 'results_for_s', 'Results for %s' ),
-												$hunt_title ? $hunt_title : bhg_t( 'bonus_hunt', 'Bonus Hunt' )
-											),
-											$body
+										$u->user_email,
+										sprintf(
+										/* translators: %s: bonus hunt title. */
+										bhg_t( 'results_for_s', 'Results for %s' ),
+										$hunt_title ? $hunt_title : bhg_t( 'bonus_hunt', 'Bonus Hunt' )
+										),
+										$body,
+										$headers
 										);
 				}
 			}

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -150,15 +150,16 @@ spl_autoload_register(
 		}
 
 		$class_map = array(
-			'BHG_Admin'          => 'admin/class-bhg-admin.php',
-			'BHG_Shortcodes'     => 'includes/class-bhg-shortcodes.php',
-			'BHG_Logger'         => 'includes/class-bhg-logger.php',
-			'BHG_Utils'          => 'includes/class-bhg-utils.php',
-			'BHG_Models'         => 'includes/class-bhg-models.php',
-			'BHG_Front_Menus'    => 'includes/class-bhg-front-menus.php',
-			'BHG_Ads'            => 'includes/class-bhg-ads.php',
-			'BHG_Login_Redirect' => 'includes/class-bhg-login-redirect.php',
-			'BHG_Demo'           => 'admin/class-bhg-demo.php',
+			'BHG_Admin'                  => 'admin/class-bhg-admin.php',
+			'BHG_Shortcodes'             => 'includes/class-bhg-shortcodes.php',
+			'BHG_Logger'                 => 'includes/class-bhg-logger.php',
+			'BHG_Utils'                  => 'includes/class-bhg-utils.php',
+			'BHG_Models'                 => 'includes/class-bhg-models.php',
+			'BHG_Front_Menus'            => 'includes/class-bhg-front-menus.php',
+			'BHG_Ads'                    => 'includes/class-bhg-ads.php',
+			'BHG_Login_Redirect'         => 'includes/class-bhg-login-redirect.php',
+			'BHG_Tournaments_Controller' => 'includes/class-bhg-tournaments-controller.php',
+			'BHG_Demo'                   => 'admin/class-bhg-demo.php',
 		);
 
 		if ( isset( $class_map[ $class_name ] ) ) {
@@ -344,6 +345,10 @@ function bhg_init_plugin() {
 
 	if ( class_exists( 'BHG_Utils' ) ) {
 		BHG_Utils::init_hooks();
+	}
+
+	if ( class_exists( 'BHG_Tournaments_Controller' ) ) {
+		BHG_Tournaments_Controller::init();
 	}
 
 		// Register form handlers.

--- a/includes/class-bhg-tournaments-controller.php
+++ b/includes/class-bhg-tournaments-controller.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Tournaments controller for Bonus Hunt Guesser.
+ *
+ * Applies default tournament settings during creation.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+}
+
+/**
+ * Handles tournament-related hooks and logic.
+ */
+class BHG_Tournaments_Controller {
+		/**
+		 * Initialize hooks.
+		 *
+		 * @return void
+		 */
+	public static function init() {
+			add_action( 'admin_post_bhg_tournament_save', array( __CLASS__, 'apply_default_period' ), 5 );
+	}
+
+		/**
+		 * Apply default tournament period if none supplied.
+		 *
+		 * @return void
+		 */
+	public static function apply_default_period() {
+		if ( isset( $_POST['type'] ) && '' !== $_POST['type'] ) {
+				return;
+		}
+
+			$settings = get_option( 'bhg_plugin_settings', array() );
+			$period   = isset( $settings['default_tournament_period'] ) ? $settings['default_tournament_period'] : 'monthly';
+			$period   = sanitize_text_field( $period );
+
+			$allowed = array( 'weekly', 'monthly', 'quarterly', 'yearly', 'alltime' );
+		if ( ! in_array( $period, $allowed, true ) ) {
+				$period = 'monthly';
+		}
+
+			$_POST['type'] = $period;
+	}
+}

--- a/includes/class-bhg-utils.php
+++ b/includes/class-bhg-utils.php
@@ -63,6 +63,23 @@ class BHG_Utils {
 		update_option( 'bhg_settings', $new );
 		return $new;
 	}
+	
+	/**
+	 * Retrieve the "From" email address for notifications.
+	 *
+	 * @return string Email address.
+	 */
+	public static function get_email_from() {
+		$settings = get_option( 'bhg_plugin_settings', array() );
+		$email    = isset( $settings['email_from'] ) ? $settings['email_from'] : get_bloginfo( 'admin_email' );
+		$email    = sanitize_email( $email );
+		
+		if ( ! is_email( $email ) ) {
+			$email = sanitize_email( get_bloginfo( 'admin_email' ) );
+		}
+		
+		return $email;
+	}
 
 	/**
 	 * Require manage options capability or abort.


### PR DESCRIPTION
## Summary
- ensure tournaments default to the configured period when none provided
- centralize notification sender address in utils and apply when emailing results

## Testing
- `composer phpcs` *(fails: Use of a direct database call is discouraged)*

------
https://chatgpt.com/codex/tasks/task_e_68bdba4ca37c8333b677293323f43b33