### PR TITLE
Replace admin_url() calls for settings redirects

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -381,11 +381,11 @@ function bhg_handle_settings_save() {
 			wp_die( esc_html__( 'You do not have sufficient permissions to perform this action.', 'bonus-hunt-guesser' ) );
 	}
 
-		// Verify nonce.
-	if ( ! check_admin_referer( 'bhg_save_settings', 'bhg_save_settings_nonce' ) ) {
-			wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg-settings&error=nonce_failed' ) ) );
-			exit;
-	}
+                // Verify nonce.
+        if ( ! check_admin_referer( 'bhg_save_settings', 'bhg_save_settings_nonce' ) ) {
+                        wp_safe_redirect( esc_url_raw( 'admin.php?page=bhg-settings&error=nonce_failed' ) );
+                        exit;
+        }
 
 		// Sanitize and validate data.
 		$settings = array();
@@ -411,12 +411,12 @@ function bhg_handle_settings_save() {
 		}
 	}
 
-		// Validate that min is not greater than max.
-	if ( isset( $settings['min_guess_amount'] ) && isset( $settings['max_guess_amount'] ) &&
-				$settings['min_guess_amount'] > $settings['max_guess_amount'] ) {
-			wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg-settings&error=invalid_data' ) ) );
-			exit;
-	}
+                // Validate that min is not greater than max.
+        if ( isset( $settings['min_guess_amount'] ) && isset( $settings['max_guess_amount'] ) &&
+                                $settings['min_guess_amount'] > $settings['max_guess_amount'] ) {
+                        wp_safe_redirect( esc_url_raw( 'admin.php?page=bhg-settings&error=invalid_data' ) );
+                        exit;
+        }
 
 	if ( isset( $_POST['bhg_allow_guess_changes'] ) ) {
 			$allow = sanitize_text_field( wp_unslash( $_POST['bhg_allow_guess_changes'] ) );
@@ -441,9 +441,9 @@ function bhg_handle_settings_save() {
 		$existing = get_option( 'bhg_plugin_settings', array() );
 		update_option( 'bhg_plugin_settings', array_merge( $existing, $settings ) );
 
-		// Redirect back to settings page.
-		wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg-settings&message=saved' ) ) );
-		exit;
+                // Redirect back to settings page.
+                wp_safe_redirect( esc_url_raw( 'admin.php?page=bhg-settings&message=saved' ) );
+                exit;
 }
 
 // Canonical guess submit handler.


### PR DESCRIPTION
## Summary
- simplify settings redirect targets by removing `admin_url()` and using relative `admin.php?page=bhg-settings` paths
- reindent affected settings save blocks for consistency

## Testing
- `composer run phpcs` *(fails: Missing doc comments and other coding standard issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68be2033310c8333ac0a6417cc1abef0