### PR TITLE
Refactor dashboard latest hunts into cards

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -54,111 +54,90 @@ $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect: id, title, starting_balanc
 						<header class="bhg-card-header">
 								<h2 id="bhg-dashboard-latest-title" class="bhg-card-title"><?php echo esc_html( bhg_t( 'label_latest_hunts', 'Latest Hunts' ) ); ?></h2>
 						</header>
-						<div class="bhg-card-content">
-								<div class="bhg-dashboard-table-wrapper">
-										<table class="wp-list-table widefat striped bhg-dashboard-table">
-						<thead>
-							<tr>
-								<th><?php echo esc_html( bhg_t( 'label_bonushunt', 'Bonushunt' ) ); ?></th>
-								<th><?php echo esc_html( bhg_t( 'label_all_winners', 'All Winners' ) ); ?></th>
-								<th><?php echo esc_html( bhg_t( 'sc_start_balance', 'Start Balance' ) ); ?></th>
-								<th><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></th>
-								<th><?php echo esc_html( bhg_t( 'label_closed_at', 'Closed At' ) ); ?></th>
-							</tr>
-						</thead>
-						<tbody>
-						<?php if ( ! empty( $hunts ) && is_array( $hunts ) ) : ?>
-							<?php foreach ( $hunts as $h ) : ?>
-								<?php
-								$hunt_id       = isset( $h->id ) ? (int) $h->id : 0;
-								$winners_count = isset( $h->winners_count ) ? (int) $h->winners_count : 0;
-								$winners       = array();
+                                               <div class="bhg-card-content">
+                                                               <?php if ( ! empty( $hunts ) && is_array( $hunts ) ) : ?>
+                                                               <div class="bhg-dashboard-list">
+                                                               <?php foreach ( $hunts as $h ) : ?>
+                                                               <?php
+                                                               $hunt_id       = isset( $h->id ) ? (int) $h->id : 0;
+                                                               $winners_count = isset( $h->winners_count ) ? (int) $h->winners_count : 0;
+                                                               $winners       = array();
 
-								if ( $hunt_id && function_exists( 'bhg_get_top_winners_for_hunt' ) ) {
-									$winners = bhg_get_top_winners_for_hunt( $hunt_id, $winners_count );
-									if ( ! is_array( $winners ) ) {
-										$winners = array();
-									}
-								}
+                                                               if ( $hunt_id && function_exists( 'bhg_get_top_winners_for_hunt' ) ) {
+                                                                       $winners = bhg_get_top_winners_for_hunt( $hunt_id, $winners_count );
+                                                                       if ( ! is_array( $winners ) ) {
+                                                                               $winners = array();
+                                                                       }
+                                                               }
 
-								$hunt_title = isset( $h->title ) ? (string) $h->title : '';
-								$start      = isset( $h->starting_balance ) ? (float) $h->starting_balance : 0.0;
-								?>
-								<tr>
-									<td data-label="<?php echo esc_attr( bhg_t( 'label_bonushunt', 'Bonushunt' ) ); ?>">
-										<?php echo '' !== $hunt_title ? esc_html( $hunt_title ) : esc_html( bhg_t( 'label_untitled', '(untitled)' ) ); ?>
-									</td>
-									<td data-label="<?php echo esc_attr( bhg_t( 'label_all_winners', 'All Winners' ) ); ?>">
-										<?php
-										if ( ! empty( $winners ) ) {
-											$out = array();
-											foreach ( $winners as $w ) {
-												$user_id = isset( $w->user_id ) ? (int) $w->user_id : 0;
-												$guess   = isset( $w->guess ) ? (float) $w->guess : 0.0;
-												$diff    = isset( $w->diff ) ? (float) $w->diff : 0.0;
+                                                               $hunt_title = isset( $h->title ) ? (string) $h->title : '';
+                                                               $start      = isset( $h->starting_balance ) ? (float) $h->starting_balance : 0.0;
+                                                               ?>
+                                                               <article class="bhg-dashboard-hunt">
+                                                                       <h3 class="bhg-dashboard-subtitle">
+                                                                               <?php echo '' !== $hunt_title ? esc_html( $hunt_title ) : esc_html( bhg_t( 'label_untitled', '(untitled)' ) ); ?>
+                                                                       </h3>
+                                                                       <ul class="bhg-dashboard-hunt-meta">
+                                                                               <li><strong><?php echo esc_html( bhg_t( 'label_all_winners', 'All Winners' ) ); ?></strong> <?php
+                                                                               if ( ! empty( $winners ) ) {
+                                                                                       $out = array();
+                                                                                       foreach ( $winners as $w ) {
+                                                                                               $user_id = isset( $w->user_id ) ? (int) $w->user_id : 0;
+                                                                                               $guess   = isset( $w->guess ) ? (float) $w->guess : 0.0;
+                                                                                               $diff    = isset( $w->diff ) ? (float) $w->diff : 0.0;
 
-												$u  = $user_id ? get_userdata( $user_id ) : false;
-												$nm = $u ? $u->user_login : sprintf(
-													/* translators: %d: user ID. */
-													esc_html( bhg_t( 'label_user_number', 'User #%d' ) ),
-													$user_id
-												);
+                                                                                               $u  = $user_id ? get_userdata( $user_id ) : false;
+                                                                                               $nm = $u ? $u->user_login : sprintf(
+                                                                                                       /* translators: %d: user ID. */
+                                                                                                       esc_html( bhg_t( 'label_user_number', 'User #%d' ) ),
+                                                                                                       $user_id
+                                                                                               );
 
-												// Compose: "name — 1,234.00 (diff 12.34)".
-												$out[] = sprintf(
-													'%1$s %2$s %3$s (%4$s %5$s)',
-													esc_html( $nm ),
-													esc_html_x( '—', 'name/guess separator', 'bonus-hunt-guesser' ),
-													esc_html( number_format_i18n( $guess, 2 ) ),
-													esc_html( bhg_t( 'label_diff', 'diff' ) ),
-													esc_html( number_format_i18n( $diff, 2 ) )
-												);
-											}
-											// Implode to a single, safely-escaped string separated by dots.
-											echo esc_html( implode( ' • ', $out ) );
-										} else {
-											echo esc_html( bhg_t( 'no_winners_yet', 'No winners yet' ) );
-										}
-										?>
-									</td>
-									<td data-label="<?php echo esc_attr( bhg_t( 'sc_start_balance', 'Start Balance' ) ); ?>">
-										<?php echo esc_html( number_format_i18n( $start, 2 ) ); ?>
-									</td>
-									<td data-label="<?php echo esc_attr( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?>">
-										<?php
-										if ( isset( $h->final_balance ) && null !== $h->final_balance ) {
-											echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
-										} else {
-											echo esc_html( bhg_t( 'label_emdash', '—' ) );
-										}
-										?>
-									</td>
-									<td data-label="<?php echo esc_attr( bhg_t( 'label_closed_at', 'Closed At' ) ); ?>">
-										<?php
-										if ( ! empty( $h->closed_at ) ) {
-											$ts = strtotime( (string) $h->closed_at );
-											echo esc_html(
-												false !== $ts
-													? date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $ts )
-													: (string) $h->closed_at
-											);
-										} else {
-											echo esc_html( bhg_t( 'label_emdash', '—' ) );
-										}
-										?>
-									</td>
-								</tr>
-							<?php endforeach; ?>
-						<?php else : ?>
-							<tr>
-								<td colspan="5"><?php echo esc_html( bhg_t( 'notice_no_closed_hunts', 'No closed hunts yet.' ) ); ?></td>
-							</tr>
-						<?php endif; ?>
-						</tbody>
-					</table>
-				</div>
-								<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts' ) ); ?>" class="button button-primary"><?php echo esc_html( bhg_t( 'view_all_hunts', 'View All Hunts' ) ); ?></a></p>
-						</div>
-				</section>
-		</div>
+                                                                                               // Compose: "name — 1,234.00 (diff 12.34)".
+                                                                                               $out[] = sprintf(
+                                                                                                       '%1$s %2$s %3$s (%4$s %5$s)',
+                                                                                                       esc_html( $nm ),
+                                                                                                       esc_html_x( '—', 'name/guess separator', 'bonus-hunt-guesser' ),
+                                                                                                       esc_html( number_format_i18n( $guess, 2 ) ),
+                                                                                                       esc_html( bhg_t( 'label_diff', 'diff' ) ),
+                                                                                                       esc_html( number_format_i18n( $diff, 2 ) )
+                                                                                               );
+                                                                                       }
+                                                                                       // Implode to a single, safely-escaped string separated by dots.
+                                                                                       echo esc_html( implode( ' • ', $out ) );
+                                                                               } else {
+                                                                                       echo esc_html( bhg_t( 'no_winners_yet', 'No winners yet' ) );
+                                                                               }
+                                                                               ?></li>
+                                                                               <li><strong><?php echo esc_html( bhg_t( 'sc_start_balance', 'Start Balance' ) ); ?></strong> <?php echo esc_html( number_format_i18n( $start, 2 ) ); ?></li>
+                                                                               <li><strong><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></strong> <?php
+                                                                               if ( isset( $h->final_balance ) && null !== $h->final_balance ) {
+                                                                                       echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
+                                                                               } else {
+                                                                                       echo esc_html( bhg_t( 'label_emdash', '—' ) );
+                                                                               }
+                                                                               ?></li>
+                                                                               <li><strong><?php echo esc_html( bhg_t( 'label_closed_at', 'Closed At' ) ); ?></strong> <?php
+                                                                               if ( ! empty( $h->closed_at ) ) {
+                                                                                       $ts = strtotime( (string) $h->closed_at );
+                                                                                       echo esc_html(
+                                                                                               false !== $ts
+                                                                                                       ? date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $ts )
+                                                                                                       : (string) $h->closed_at
+                                                                                       );
+                                                                               } else {
+                                                                                       echo esc_html( bhg_t( 'label_emdash', '—' ) );
+                                                                               }
+                                                                               ?></li>
+                                                                       </ul>
+                                                               </article>
+                                                               <?php endforeach; ?>
+                                                               </div>
+                                                               <?php else : ?>
+                                                               <p><?php echo esc_html( bhg_t( 'notice_no_closed_hunts', 'No closed hunts yet.' ) ); ?></p>
+                                                               <?php endif; ?>
+                                                               <p><a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts' ) ); ?>" class="button button-primary"><?php echo esc_html( bhg_t( 'view_all_hunts', 'View All Hunts' ) ); ?></a></p>
+                                               </div>
+                               </section>
+               </div>
 </div>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -240,94 +240,30 @@ flex: 1;
     color: var(--bhg-accent-color);
 }
 
-.bhg-dashboard-table-wrapper {
-    overflow-x: auto;
+/* Latest hunts list */
+.bhg-dashboard-list {
+    display: grid;
+    gap: var(--bhg-spacing);
 }
 
-.bhg-dashboard-table-wrapper table {
-    width: 100%;
-    border-collapse: collapse;
-}
-
-.bhg-dashboard-table thead th {
-    background-color: var(--bhg-accent-color);
-    border: 1px solid var(--bhg-accent-color);
-    color: #fff;
-}
-
-.bhg-dashboard-table-wrapper th,
-.bhg-dashboard-table-wrapper td {
-    padding: 8px 10px;
-}
-
-.bhg-dashboard-table-wrapper th {
-    text-align: left;
-}
-
-.bhg-dashboard-table-wrapper td {
-    vertical-align: top;
-}
-
-/* Table visual accents */
-.bhg-dashboard-table-wrapper table {
+.bhg-dashboard-hunt {
+    background: var(--bhg-card-bg);
     border: 1px solid var(--bhg-border-color);
     border-radius: 6px;
+    padding: var(--bhg-spacing);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
 }
 
-.bhg-dashboard-table-wrapper tr:nth-child(even) {
-    background-color: #f9fafb;
+.bhg-dashboard-hunt-meta {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 4px;
 }
 
-.bhg-dashboard-table-wrapper tr:hover {
-    background-color: #fdf2f8;
-}
-
-/* Responsive tables */
-@media screen and (max-width: 782px) {
-    .bhg-dashboard-table-wrapper table,
-    .bhg-dashboard-table-wrapper thead,
-    .bhg-dashboard-table-wrapper tbody,
-    .bhg-dashboard-table-wrapper th,
-    .bhg-dashboard-table-wrapper td,
-    .bhg-dashboard-table-wrapper tr {
-        display: block;
-    }
-
-    .bhg-dashboard-table-wrapper thead tr {
-        position: absolute;
-        top: -9999px;
-        left: -9999px;
-    }
-
-    .bhg-dashboard-table-wrapper tr {
-        border: 1px solid var(--bhg-border-color);
-        margin-bottom: 6px;
-        border-radius: 6px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
-    }
-
-    .bhg-dashboard-table-wrapper td {
-        border: none;
-        border-bottom: 1px solid var(--bhg-border-color);
-        position: relative;
-        padding-left: 50%;
-        white-space: pre-wrap;
-    }
-
-    .bhg-dashboard-table-wrapper td::before {
-        position: absolute;
-        top: 8px;
-        left: 10px;
-        width: calc(50% - 20px);
-        white-space: nowrap;
-        font-weight: 600;
-        color: var(--bhg-accent-color);
-        content: attr(data-label);
-    }
-
-    .bhg-dashboard-table-wrapper td:last-child {
-        border-bottom: 0;
-    }
+.bhg-dashboard-hunt-meta strong {
+    color: var(--bhg-accent-color);
 }
 
 


### PR DESCRIPTION
## Summary
- Display latest bonus hunts as full-width card list instead of table
- Add admin dashboard CSS for card spacing, typography, and responsive layout

## Testing
- `composer phpcs` *(fails: coding standard violations in dashboard.php)*


------
https://chatgpt.com/codex/tasks/task_e_68be2cfd0b0883339b70acf9d931ce4d