### PR TITLE
Add standalone labels to default translations

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -145,12 +145,21 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'menu_translations'                            => 'Translations',
 			'menu_tools'                                   => 'Tools',
 			'menu_ads'                                     => 'Ads',
-			'bhg_menu_admin'                               => 'BHG Menu — Admin/Moderators',
-			'bhg_menu_loggedin'                            => 'BHG Menu — Logged-in Users',
-			'bhg_menu_guests'                              => 'BHG Menu — Guests',
+                        'bhg_menu_admin'                               => 'BHG Menu — Admin/Moderators',
+                        'bhg_menu_loggedin'                            => 'BHG Menu — Logged-in Users',
+                        'bhg_menu_guests'                              => 'BHG Menu — Guests',
 
-			// Form/field labels.
-			'label_start_balance'                          => 'Starting Balance',
+                        // Standalone labels.
+                        'dashboard'                                    => 'Dashboard',
+                        'bonus_hunts'                                  => 'Bonus Hunts',
+                        'results'                                      => 'Results',
+                        'affiliate_websites'                           => 'Affiliate Websites',
+                        'advertising'                                  => 'Advertising',
+                        'translations'                                 => 'Translations',
+                        'tools'                                        => 'Tools',
+
+                        // Form/field labels.
+                        'label_start_balance'                          => 'Starting Balance',
 			'label_number_bonuses'                         => 'Number of Bonuses',
 			'label_prizes'                                 => 'Prizes',
 			'label_submit_guess'                           => 'Submit Guess',


### PR DESCRIPTION
## Summary
- include standalone menu labels in the default translations so they can be customized

## Testing
- `composer run phpcs includes/helpers.php` *(fails: Use of a direct database call is discouraged)*
- `php -d display_errors=1 -r "define('ABSPATH',true); require 'includes/helpers.php'; bhg_seed_default_translations();"` *(fails: Call to undefined function add_filter()*


------
https://chatgpt.com/codex/tasks/task_e_68be3cabedf88333994ffb25d6b28cb2