### PR TITLE
Sanitize ad queries with $wpdb->prepare()

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -15,9 +15,8 @@ global $wpdb;
 $ads_table      = $wpdb->prefix . 'bhg_ads';
 $allowed_tables = array( $wpdb->prefix . 'bhg_ads' );
 if ( ! in_array( $ads_table, $allowed_tables, true ) ) {
-				wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
+	wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
 }
-$ads_table = esc_sql( $ads_table );
 
 $edit_id = isset( $_GET['edit'] ) ? absint( wp_unslash( $_GET['edit'] ) ) : 0;
 


### PR DESCRIPTION
## Summary
- use `$wpdb->prepare()` for selecting ads in the admin advertising view
- use prepared SQL for ad deletion and email notifications in admin handler

## Testing
- `vendor/bin/phpcs admin/views/advertising.php` – warnings about direct DB calls
- `vendor/bin/phpcs admin/class-bhg-admin.php` – numerous pre-existing coding standard issues


------
https://chatgpt.com/codex/tasks/task_e_68be4ae5d3ec8333840cd634c4d2542d