### PR TITLE
Fix ads enabled setting checkbox handling

### DIFF
--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -78,7 +78,8 @@ foreach ( $periods as $key => $label ) :
 </tr>
 <tr>
 <th scope="row"><label for="bhg_ads_enabled"><?php echo esc_html( bhg_t( 'ads_enabled', 'Enable Ads' ) ); ?></label></th>
-<td><input type="checkbox" id="bhg_ads_enabled" name="bhg_ads_enabled" value="1" <?php checked( isset( $settings['ads_enabled'] ) ? (int) $settings['ads_enabled'] : 0, 1 ); ?>></td>
+<td><input type="hidden" name="bhg_ads_enabled" value="0">
+<input type="checkbox" id="bhg_ads_enabled" name="bhg_ads_enabled" value="1" <?php checked( ! empty( $settings['ads_enabled'] ) ); ?>></td>
 </tr>
 <tr>
 <th scope="row"><label for="bhg_email_from"><?php echo esc_html( bhg_t( 'email_from', 'Email From Address' ) ); ?></label></th>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -426,10 +426,7 @@ function bhg_handle_settings_save() {
 		}
 	}
 
-	if ( isset( $_POST['bhg_ads_enabled'] ) ) {
-			$ads_enabled             = sanitize_text_field( wp_unslash( $_POST['bhg_ads_enabled'] ) );
-			$settings['ads_enabled'] = '1' === $ads_enabled ? 1 : 0;
-	}
+        $settings['ads_enabled'] = isset( $_POST['bhg_ads_enabled'] ) ? 1 : 0;
 
 	if ( isset( $_POST['bhg_email_from'] ) ) {
 			$email_from = sanitize_email( wp_unslash( $_POST['bhg_email_from'] ) );


### PR DESCRIPTION
## Summary
- simplify `ads_enabled` saving logic to default to 0 when not posted
- ensure settings form posts explicit `ads_enabled` value when checkbox unchecked

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68be52b2f2a883339aac9614e41271e3