### PR TITLE
Use tab-based indentation in main plugin file

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -184,11 +184,11 @@ add_action( 'plugins_loaded', 'bhg_maybe_seed_translations', 1 );
  * @return void
  */
 function bhg_maybe_seed_translations() {
-        bhg_seed_default_translations_if_empty();
-        $stored_version = get_option( 'bhg_version' );
-        if ( BHG_VERSION !== $stored_version ) {
-                update_option( 'bhg_version', BHG_VERSION );
-        }
+		bhg_seed_default_translations_if_empty();
+		$stored_version = get_option( 'bhg_version' );
+	if ( BHG_VERSION !== $stored_version ) {
+			update_option( 'bhg_version', BHG_VERSION );
+	}
 }
 
 // Activation hook: create tables and set default options.
@@ -271,12 +271,12 @@ function bhg_enqueue_public_assets() {
 			true
 		);
 
-                $guess_range = sprintf(
-                                                /* translators: 1: minimum guess, 2: maximum guess. */
-                                        bhg_t( 'guess_must_be_between', 'Guess must be between %1$s and %2$s.' ),
-                                        bhg_format_currency( $min_guess ),
-                                        bhg_format_currency( $max_guess )
-                                );
+				$guess_range = sprintf(
+												/* translators: 1: minimum guess, 2: maximum guess. */
+					bhg_t( 'guess_must_be_between', 'Guess must be between %1$s and %2$s.' ),
+					bhg_format_currency( $min_guess ),
+					bhg_format_currency( $max_guess )
+				);
 
 		wp_localize_script(
 			'bhg-public',
@@ -287,18 +287,18 @@ function bhg_enqueue_public_assets() {
 				'is_logged_in'     => is_user_logged_in(),
 				'min_guess_amount' => $min_guess,
 				'max_guess_amount' => $max_guess,
-                                'i18n'             => array(
-                                        'guess_required'          => bhg_t( 'guess_required', 'Please enter a guess.' ),
-                                        'guess_numeric'           => bhg_t( 'guess_numeric', 'Please enter a valid number.' ),
-                                        'guess_range'             => $guess_range,
-                                        'guess_submitted'         => bhg_t( 'guess_submitted', 'Your guess has been submitted!' ),
-                                        'ajax_error'              => bhg_t( 'ajax_error', 'An error occurred. Please try again.' ),
-                                        'affiliate_user'          => bhg_t( 'affiliate_user', 'Affiliate' ),
-                                        'non_affiliate_user'      => bhg_t( 'non_affiliate_user', 'Non-affiliate' ),
-                                        'error_loading_leaderboard' => bhg_t( 'error_loading_leaderboard', 'Error loading leaderboard.' ),
-                                ),
-                        )
-                );
+				'i18n'             => array(
+					'guess_required'            => bhg_t( 'guess_required', 'Please enter a guess.' ),
+					'guess_numeric'             => bhg_t( 'guess_numeric', 'Please enter a valid number.' ),
+					'guess_range'               => $guess_range,
+					'guess_submitted'           => bhg_t( 'guess_submitted', 'Your guess has been submitted!' ),
+					'ajax_error'                => bhg_t( 'ajax_error', 'An error occurred. Please try again.' ),
+					'affiliate_user'            => bhg_t( 'affiliate_user', 'Affiliate' ),
+					'non_affiliate_user'        => bhg_t( 'non_affiliate_user', 'Non-affiliate' ),
+					'error_loading_leaderboard' => bhg_t( 'error_loading_leaderboard', 'Error loading leaderboard.' ),
+				),
+			)
+		);
 
 	wp_enqueue_style( 'bhg-public' );
 	wp_enqueue_script( 'bhg-public' );
@@ -378,9 +378,9 @@ add_action( 'init', 'bhg_check_tables', 0 );
  */
 function bhg_handle_settings_save() {
 		// Check user capabilities.
-        if ( ! current_user_can( 'manage_options' ) ) {
-                        wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_perform_this_action', 'You do not have sufficient permissions to perform this action.' ) ) );
-        }
+	if ( ! current_user_can( 'manage_options' ) ) {
+					wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_perform_this_action', 'You do not have sufficient permissions to perform this action.' ) ) );
+	}
 
 				// Verify nonce.
 	if ( ! check_admin_referer( 'bhg_save_settings', 'bhg_save_settings_nonce' ) ) {
@@ -426,7 +426,7 @@ function bhg_handle_settings_save() {
 		}
 	}
 
-        $settings['ads_enabled'] = isset( $_POST['bhg_ads_enabled'] ) ? 1 : 0;
+		$settings['ads_enabled'] = isset( $_POST['bhg_ads_enabled'] ) ? 1 : 0;
 
 	if ( isset( $_POST['bhg_email_from'] ) ) {
 			$email_from = sanitize_email( wp_unslash( $_POST['bhg_email_from'] ) );
@@ -454,26 +454,26 @@ function bhg_handle_submit_guess() {
 	if ( wp_doing_ajax() ) {
 			check_ajax_referer( 'bhg_public_nonce', 'nonce' );
 	} else {
-                if ( ! isset( $_POST['_wpnonce'] ) ) {
-                                wp_die( esc_html( bhg_t( 'notice_security_check_failed', 'Security check failed.' ) ) );
-                }
+		if ( ! isset( $_POST['_wpnonce'] ) ) {
+						wp_die( esc_html( bhg_t( 'notice_security_check_failed', 'Security check failed.' ) ) );
+		}
 						check_admin_referer( 'bhg_submit_guess', 'bhg_submit_guess_nonce' );
 	}
 
 	$user_id = get_current_user_id();
 	if ( ! $user_id ) {
-                if ( wp_doing_ajax() ) {
-                        wp_send_json_error( bhg_t( 'you_must_be_logged_in_to_submit_a_guess', 'You must be logged in to submit a guess.' ) );
-                }
-                wp_die( esc_html( bhg_t( 'you_must_be_logged_in_to_submit_a_guess', 'You must be logged in to submit a guess.' ) ) );
+		if ( wp_doing_ajax() ) {
+				wp_send_json_error( bhg_t( 'you_must_be_logged_in_to_submit_a_guess', 'You must be logged in to submit a guess.' ) );
+		}
+				wp_die( esc_html( bhg_t( 'you_must_be_logged_in_to_submit_a_guess', 'You must be logged in to submit a guess.' ) ) );
 	}
 
 		$hunt_id = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
 	if ( 0 >= $hunt_id ) {
-                if ( wp_doing_ajax() ) {
-                        wp_send_json_error( bhg_t( 'notice_invalid_hunt', 'Invalid hunt.' ) );
-                }
-                wp_die( esc_html( bhg_t( 'notice_invalid_hunt', 'Invalid hunt.' ) ) );
+		if ( wp_doing_ajax() ) {
+				wp_send_json_error( bhg_t( 'notice_invalid_hunt', 'Invalid hunt.' ) );
+		}
+				wp_die( esc_html( bhg_t( 'notice_invalid_hunt', 'Invalid hunt.' ) ) );
 	}
 
 		// Parse guess robustly.
@@ -496,10 +496,10 @@ function bhg_handle_submit_guess() {
 		$allow_edit = isset( $settings['allow_guess_changes'] ) && 'yes' === $settings['allow_guess_changes'];
 
 	if ( $guess < $min_guess || $guess > $max_guess ) {
-                if ( wp_doing_ajax() ) {
-                        wp_send_json_error( bhg_t( 'notice_invalid_guess_amount', 'Invalid guess amount.' ) );
-                }
-                wp_die( esc_html( bhg_t( 'notice_invalid_guess_amount', 'Invalid guess amount.' ) ) );
+		if ( wp_doing_ajax() ) {
+				wp_send_json_error( bhg_t( 'notice_invalid_guess_amount', 'Invalid guess amount.' ) );
+		}
+				wp_die( esc_html( bhg_t( 'notice_invalid_guess_amount', 'Invalid guess amount.' ) ) );
 	}
 
 	global $wpdb;
@@ -508,18 +508,18 @@ function bhg_handle_submit_guess() {
 
 		// db call ok; no-cache ok.
 				$hunt = $wpdb->get_row( $wpdb->prepare( 'SELECT id, status FROM %i WHERE id = %d', $hunts, $hunt_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-        if ( ! $hunt ) {
-                if ( wp_doing_ajax() ) {
-                        wp_send_json_error( bhg_t( 'notice_hunt_not_found', 'Hunt not found.' ) );
-                }
-                wp_die( esc_html( bhg_t( 'notice_hunt_not_found', 'Hunt not found.' ) ) );
-        }
-        if ( 'open' !== $hunt->status ) {
-                if ( wp_doing_ajax() ) {
-                        wp_send_json_error( bhg_t( 'this_hunt_is_closed_you_cannot_submit_or_change_a_guess', 'This hunt is closed. You cannot submit or change a guess.' ) );
-                }
-                wp_die( esc_html( bhg_t( 'this_hunt_is_closed_you_cannot_submit_or_change_a_guess', 'This hunt is closed. You cannot submit or change a guess.' ) ) );
-        }
+	if ( ! $hunt ) {
+		if ( wp_doing_ajax() ) {
+				wp_send_json_error( bhg_t( 'notice_hunt_not_found', 'Hunt not found.' ) );
+		}
+			wp_die( esc_html( bhg_t( 'notice_hunt_not_found', 'Hunt not found.' ) ) );
+	}
+	if ( 'open' !== $hunt->status ) {
+		if ( wp_doing_ajax() ) {
+				wp_send_json_error( bhg_t( 'this_hunt_is_closed_you_cannot_submit_or_change_a_guess', 'This hunt is closed. You cannot submit or change a guess.' ) );
+		}
+			wp_die( esc_html( bhg_t( 'this_hunt_is_closed_you_cannot_submit_or_change_a_guess', 'This hunt is closed. You cannot submit or change a guess.' ) ) );
+	}
 
 		// Insert or update last guess per settings.
 
@@ -547,10 +547,10 @@ function bhg_handle_submit_guess() {
 				exit;
 			}
 		}
-                if ( wp_doing_ajax() ) {
-                        wp_send_json_error( bhg_t( 'you_have_reached_the_maximum_number_of_guesses', 'You have reached the maximum number of guesses.' ) );
-                }
-                wp_die( esc_html( bhg_t( 'you_have_reached_the_maximum_number_of_guesses', 'You have reached the maximum number of guesses.' ) ) );
+		if ( wp_doing_ajax() ) {
+				wp_send_json_error( bhg_t( 'you_have_reached_the_maximum_number_of_guesses', 'You have reached the maximum number of guesses.' ) );
+		}
+				wp_die( esc_html( bhg_t( 'you_have_reached_the_maximum_number_of_guesses', 'You have reached the maximum number of guesses.' ) ) );
 	}
 
 		// Insert.
@@ -657,15 +657,15 @@ add_action( 'wp_ajax_nopriv_bhg_load_leaderboard', 'bhg_load_leaderboard_ajax' )
 function bhg_load_leaderboard_ajax() {
 		check_ajax_referer( 'bhg_public_nonce', 'nonce' );
 
-        if ( ! isset( $_POST['timeframe'] ) ) {
-                wp_send_json_error( bhg_t( 'invalid_timeframe', 'Invalid timeframe' ) );
-        }
+	if ( ! isset( $_POST['timeframe'] ) ) {
+			wp_send_json_error( bhg_t( 'invalid_timeframe', 'Invalid timeframe' ) );
+	}
 
 		$timeframe          = sanitize_text_field( wp_unslash( $_POST['timeframe'] ) );
 		$allowed_timeframes = array( 'overall', 'monthly', 'yearly', 'alltime' );
-        if ( ! in_array( $timeframe, $allowed_timeframes, true ) ) {
-                        wp_send_json_error( bhg_t( 'invalid_timeframe', 'Invalid timeframe' ) );
-        }
+	if ( ! in_array( $timeframe, $allowed_timeframes, true ) ) {
+					wp_send_json_error( bhg_t( 'invalid_timeframe', 'Invalid timeframe' ) );
+	}
 
 		$paged = isset( $_POST['paged'] ) ? max( 1, absint( $_POST['paged'] ) ) : 1;
 
@@ -751,22 +751,22 @@ function bhg_generate_leaderboard_html( $timeframe, $paged ) {
 	LIMIT %d OFFSET %d
 	";
 		$rows = $wpdb->get_results( $wpdb->prepare( $sql, $per_page, $offset ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-        if ( ! $rows ) {
-                return '<p>' . esc_html( bhg_t( 'notice_no_data_available', 'No data available.' ) ) . '</p>';
-        }
+	if ( ! $rows ) {
+			return '<p>' . esc_html( bhg_t( 'notice_no_data_available', 'No data available.' ) ) . '</p>';
+	}
 
 	ob_start();
 	echo '<table class="bhg-leaderboard bhg-table" data-timeframe="' . esc_attr( $timeframe ) . '">';
-        echo '<thead><tr>';
-        echo '<th class="sortable" data-sort="position">' . esc_html( bhg_t( 'sc_position', 'Position' ) ) . '</th>';
-        echo '<th class="sortable" data-sort="username">' . esc_html( bhg_t( 'sc_user', 'User' ) ) . '</th>';
-        echo '<th class="sortable" data-sort="wins">' . esc_html( bhg_t( 'sc_wins', 'Wins' ) ) . '</th>';
-        echo '</tr></thead><tbody>';
+		echo '<thead><tr>';
+		echo '<th class="sortable" data-sort="position">' . esc_html( bhg_t( 'sc_position', 'Position' ) ) . '</th>';
+		echo '<th class="sortable" data-sort="username">' . esc_html( bhg_t( 'sc_user', 'User' ) ) . '</th>';
+		echo '<th class="sortable" data-sort="wins">' . esc_html( bhg_t( 'sc_wins', 'Wins' ) ) . '</th>';
+		echo '</tr></thead><tbody>';
 
 	$pos = $offset + 1;
 	foreach ( $rows as $row ) {
-                                /* translators: %d: user ID. */
-                                $user_label = $row->user_login ? $row->user_login : sprintf( bhg_t( 'label_user_hash', 'user#%d' ), (int) $row->user_id );
+								/* translators: %d: user ID. */
+								$user_label = $row->user_login ? $row->user_login : sprintf( bhg_t( 'label_user_hash', 'user#%d' ), (int) $row->user_id );
 				echo '<tr>';
 				echo '<td>' . (int) $pos . '</td>';
 				echo '<td>' . esc_html( $user_label ) . '</td>';


### PR DESCRIPTION
## Summary
- reformat bonus-hunt-guesser.php to use tab indentation and align arrays per WordPress standards

## Testing
- `vendor/bin/phpcs -p --standard=phpcs.xml bonus-hunt-guesser.php`
- `vendor/bin/phpcs -p --standard=phpcs.xml uninstall.php`


------
https://chatgpt.com/codex/tasks/task_e_68be66817d4c833396da499a5fc0d3af