### PR TITLE
Add ads enabled check to shortcode

### DIFF
--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -225,6 +225,10 @@ class BHG_Ads {
 	 * @return string
 	 */
 	public static function shortcode( $atts = array(), $content = '', $tag = '' ) {
+		if ( ! self::ads_enabled() ) {
+			return '';
+		}
+
 		$a = shortcode_atts(
 			array(
 				'id'     => 0,


### PR DESCRIPTION
## Summary
- ensure ads shortcode respects global advertising enable setting

## Testing
- `composer phpcs` *(fails: existing coding standard violations in repository)*
- `./vendor/bin/phpcs --standard=phpcs.xml includes/class-bhg-ads.php`


------
https://chatgpt.com/codex/tasks/task_e_68be69df420c833381c8c8edb3849d21