### PR TITLE
Allow hunt winners table in shortcode sanitizer

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -42,6 +42,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				$wpdb->prefix . 'bhg_tournaments',
 				$wpdb->prefix . 'bhg_tournament_results',
 				$wpdb->prefix . 'bhg_affiliate_websites',
+				$wpdb->prefix . 'bhg_hunt_winners',
 				$wpdb->users,
 			);
 			return in_array( $table, $allowed, true ) ? esc_sql( $table ) : '';


### PR DESCRIPTION
## Summary
- allow the `bhg_hunt_winners` table to be used by shortcodes

## Testing
- `vendor/bin/phpcs includes/class-bhg-shortcodes.php | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68be6c32b85483339a129899e2bbbeff