### PR TITLE
Add tournament selection to bonus hunts

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -232,25 +232,27 @@ class BHG_Admin {
 		$title                 = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
 		$starting              = isset( $_POST['starting_balance'] ) ? floatval( wp_unslash( $_POST['starting_balance'] ) ) : 0;
 		$num_bonuses           = isset( $_POST['num_bonuses'] ) ? absint( wp_unslash( $_POST['num_bonuses'] ) ) : 0;
-		$prizes                = isset( $_POST['prizes'] ) ? wp_kses_post( wp_unslash( $_POST['prizes'] ) ) : '';
-		$winners_count         = isset( $_POST['winners_count'] ) ? max( 1, absint( wp_unslash( $_POST['winners_count'] ) ) ) : 3;
-		$affiliate_site        = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
-				$final_balance = ( isset( $_POST['final_balance'] ) && '' !== $_POST['final_balance'] ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
-		$status                = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'open';
+                $prizes                = isset( $_POST['prizes'] ) ? wp_kses_post( wp_unslash( $_POST['prizes'] ) ) : '';
+                $affiliate_site        = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
+                $tournament_id         = isset( $_POST['tournament_id'] ) ? bhg_sanitize_tournament_id( wp_unslash( $_POST['tournament_id'] ) ) : 0;
+                $winners_count         = isset( $_POST['winners_count'] ) ? max( 1, absint( wp_unslash( $_POST['winners_count'] ) ) ) : 3;
+                                $final_balance = ( isset( $_POST['final_balance'] ) && '' !== $_POST['final_balance'] ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
+                $status                = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'open';
 
 		$data = array(
 			'title'             => $title,
 			'starting_balance'  => $starting,
 			'num_bonuses'       => $num_bonuses,
 			'prizes'            => $prizes,
-			'winners_count'     => $winners_count,
-			'affiliate_site_id' => $affiliate_site,
-			'final_balance'     => $final_balance,
-			'status'            => $status,
-			'updated_at'        => current_time( 'mysql' ),
-		);
+                        'affiliate_site_id' => $affiliate_site,
+                        'tournament_id'     => $tournament_id,
+                        'winners_count'     => $winners_count,
+                        'final_balance'     => $final_balance,
+                        'status'            => $status,
+                        'updated_at'        => current_time( 'mysql' ),
+                );
 
-		$format = array( '%s', '%f', '%d', '%s', '%d', '%d', '%f', '%s', '%s' );
+                $format = array( '%s', '%f', '%d', '%s', '%d', '%d', '%d', '%f', '%s', '%s' );
 		if ( $id ) {
 			$wpdb->update( $hunts_table, $data, array( 'id' => $id ), $format, array( '%d' ) );
 		} else {

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -13,26 +13,30 @@ if ( ! current_user_can( 'manage_options' ) ) {
 }
 
 global $wpdb;
-$hunts_table    = $wpdb->prefix . 'bhg_bonus_hunts';
-$guesses_table  = $wpdb->prefix . 'bhg_guesses';
-$users_table    = $wpdb->users;
+$hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
+$guesses_table = $wpdb->prefix . 'bhg_guesses';
+$tours_table   = $wpdb->prefix . 'bhg_tournaments';
+$users_table   = $wpdb->users;
 $allowed_tables = array(
-	$wpdb->prefix . 'bhg_bonus_hunts',
-	$wpdb->prefix . 'bhg_guesses',
-	$wpdb->prefix . 'bhg_affiliate_websites',
-	$wpdb->users,
+        $wpdb->prefix . 'bhg_bonus_hunts',
+        $wpdb->prefix . 'bhg_guesses',
+        $wpdb->prefix . 'bhg_affiliate_websites',
+        $wpdb->prefix . 'bhg_tournaments',
+        $wpdb->users,
 );
 if (
-		! in_array( $hunts_table, $allowed_tables, true ) ||
-		! in_array( $guesses_table, $allowed_tables, true ) ||
-		! in_array( $users_table, $allowed_tables, true )
+                ! in_array( $hunts_table, $allowed_tables, true ) ||
+                ! in_array( $guesses_table, $allowed_tables, true ) ||
+                ! in_array( $users_table, $allowed_tables, true ) ||
+                ! in_array( $tours_table, $allowed_tables, true )
 ) {
-		wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
+                wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
 }
 
 $hunts_table   = esc_sql( $hunts_table );
 $guesses_table = esc_sql( $guesses_table );
 $users_table   = esc_sql( $users_table );
+$tours_table   = esc_sql( $tours_table );
 
 $view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'list';
 
@@ -248,12 +252,41 @@ if ( $view === 'add' ) :
 				<?php endforeach; ?>
 			</select>
 			</td>
-		</tr>
-		<tr>
-			<th scope="row"><label for="bhg_winners"><?php echo esc_html( bhg_t( 'number_of_winners', 'Number of Winners' ) ); ?></label></th>
-			<td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="3"></td>
-		</tr>
-		<tr>
+                </tr>
+                <tr>
+                        <th scope="row"><label for="bhg_tournament"><?php echo esc_html( bhg_t( 'tournament', 'Tournament' ) ); ?></label></th>
+                        <td>
+                                                <?php
+                                                $t_table = $wpdb->prefix . 'bhg_tournaments';
+                                                if ( ! in_array( $t_table, $allowed_tables, true ) ) {
+                                                                wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
+                                                }
+                                                $t_table = esc_sql( $t_table );
+                                                // db call ok; no-cache ok.
+                                                $tours = $wpdb->get_results(
+                                                        $wpdb->prepare( 'SELECT id, title FROM %i ORDER BY title ASC', $t_table )
+                                                );
+                                                $tsel = isset( $hunt->tournament_id ) ? (int) $hunt->tournament_id : 0;
+                                                ?>
+                        <select id="bhg_tournament" name="tournament_id">
+                                <option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
+                                <?php foreach ( $tours as $t ) : ?>
+                                <option value="<?php echo (int) $t->id; ?>"
+                                        <?php
+                                        if ( $tsel === (int) $t->id ) {
+                                                echo 'selected';
+                                        }
+                                        ?>
+                                ><?php echo esc_html( $t->title ); ?></option>
+                                <?php endforeach; ?>
+                        </select>
+                        </td>
+                </tr>
+                <tr>
+                        <th scope="row"><label for="bhg_winners"><?php echo esc_html( bhg_t( 'number_of_winners', 'Number of Winners' ) ); ?></label></th>
+                        <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="3"></td>
+                </tr>
+                <tr>
 			<th scope="row"><label for="bhg_status"><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) ); ?></label></th>
 			<td>
 			<select id="bhg_status" name="status">
@@ -355,13 +388,42 @@ if ( $view === 'edit' ) :
 				><?php echo esc_html( $a->name ); ?></option>
 				<?php endforeach; ?>
 			</select>
-			</td>
-		</tr>
-		<tr>
-			<th scope="row"><label for="bhg_winners"><?php echo esc_html( bhg_t( 'number_of_winners', 'Number of Winners' ) ); ?></label></th>
-			<td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ?: 3 ); ?>"></td>
-		</tr>
-		<tr>
+                        </td>
+                </tr>
+                <tr>
+                        <th scope="row"><label for="bhg_tournament"><?php echo esc_html( bhg_t( 'tournament', 'Tournament' ) ); ?></label></th>
+                        <td>
+                                                <?php
+                                                $t_table = $wpdb->prefix . 'bhg_tournaments';
+                                                if ( ! in_array( $t_table, $allowed_tables, true ) ) {
+                                                                wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
+                                                }
+                                                $t_table = esc_sql( $t_table );
+                                                // db call ok; no-cache ok.
+                                                $tours = $wpdb->get_results(
+                                                        $wpdb->prepare( 'SELECT id, title FROM %i ORDER BY title ASC', $t_table )
+                                                );
+                                                $tsel = isset( $hunt->tournament_id ) ? (int) $hunt->tournament_id : 0;
+                                                ?>
+                        <select id="bhg_tournament" name="tournament_id">
+                                <option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
+                                <?php foreach ( $tours as $t ) : ?>
+                                <option value="<?php echo (int) $t->id; ?>"
+                                        <?php
+                                        if ( $tsel === (int) $t->id ) {
+                                                echo 'selected';
+                                        }
+                                        ?>
+                                ><?php echo esc_html( $t->title ); ?></option>
+                                <?php endforeach; ?>
+                        </select>
+                        </td>
+                </tr>
+                <tr>
+                        <th scope="row"><label for="bhg_winners"><?php echo esc_html( bhg_t( 'number_of_winners', 'Number of Winners' ) ); ?></label></th>
+                        <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ?: 3 ); ?>"></td>
+                </tr>
+                <tr>
 			<th scope="row"><label for="bhg_final"><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></label></th>
 					<td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html( bhg_t( 'label_emdash', '—' ) ) ); ?>"></td>
 		</tr>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -103,6 +103,19 @@ if ( ! function_exists( 'bhg_parse_amount' ) ) {
 	}
 }
 
+if ( ! function_exists( 'bhg_sanitize_tournament_id' ) ) {
+
+	/**
+	 * Sanitize a tournament ID value.
+	 *
+	 * @param mixed $tid Raw tournament ID.
+	 * @return int Sanitized ID.
+	 */
+	function bhg_sanitize_tournament_id( $tid ) {
+		return max( 0, absint( $tid ) );
+	}
+}
+
 // Ensure canonical DB class is loaded.
 require_once __DIR__ . '/includes/class-bhg-db.php';
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -157,6 +157,7 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
                         'advertising'                                  => 'Advertising',
                         'translations'                                 => 'Translations',
                         'tools'                                        => 'Tools',
+                        'tournament'                                   => 'Tournament',
 
                         // Form/field labels.
                         'label_start_balance'                          => 'Starting Balance',


### PR DESCRIPTION
## Summary
- support associating bonus hunts with tournaments in the database
- allow admins to pick a tournament when adding or editing a hunt
- persist tournament choice when saving hunts and expose translation key

## Testing
- `composer install`
- `vendor/bin/phpcs --standard=phpcs.xml bonus-hunt-guesser.php admin/class-bhg-admin.php includes/class-bhg-db.php admin/views/bonus-hunts.php includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68be8523d1c48333a2158c7b6172db9a