### PR TITLE
Refine dashboard tables and styling

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -34,110 +34,132 @@ $users_count = isset( $user_counts['total_users'] ) ? (int) $user_counts['total_
 $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect: id, title, starting_balance, final_balance, winners_count, closed_at.
 ?>
 <div class="wrap bhg-admin bhg-wrap bhg-dashboard">
-                <h1 class="bhg-dashboard-heading"><?php echo esc_html( bhg_t( 'menu_dashboard', 'Dashboard' ) ); ?></h1>
+				<h1 class="bhg-dashboard-heading"><?php echo esc_html( bhg_t( 'menu_dashboard', 'Dashboard' ) ); ?></h1>
 
-               <main class="bhg-dashboard-cards">
-                               <section class="bhg-dashboard-card" aria-labelledby="bhg-dashboard-summary-title" role="region">
-						<header class="bhg-card-header">
-								<h2 id="bhg-dashboard-summary-title" class="bhg-card-title"><?php echo esc_html( bhg_t( 'summary', 'Summary' ) ); ?></h2>
-						</header>
-						<div class="bhg-card-content">
-								<ul class="bhg-dashboard-meta">
-										<li><span class="dashicons dashicons-book-alt"></span> <strong><?php echo esc_html( bhg_t( 'hunts', 'Hunts:' ) ); ?></strong> <?php echo esc_html( number_format_i18n( $hunts_count ) ); ?></li>
-										<li><span class="dashicons dashicons-groups"></span> <strong><?php echo esc_html( bhg_t( 'users', 'Users:' ) ); ?></strong> <?php echo esc_html( number_format_i18n( $users_count ) ); ?></li>
-										<li><span class="dashicons dashicons-awards"></span> <strong><?php echo esc_html( bhg_t( 'tournaments', 'Tournaments:' ) ); ?></strong> <?php echo esc_html( number_format_i18n( $tournaments_count ) ); ?></li>
-								</ul>
-						</div>
-				</section>
+				<main class="bhg-dashboard-cards">
+								<section class="bhg-dashboard-card" aria-labelledby="bhg-dashboard-summary-title" role="region">
+												<header class="bhg-card-header">
+																<h2 id="bhg-dashboard-summary-title" class="bhg-card-title"><?php echo esc_html( bhg_t( 'summary', 'Summary' ) ); ?></h2>
+												</header>
+												<div class="bhg-card-content">
+																<table class="bhg-dashboard-table bhg-summary-table">
+																				<thead>
+																								<tr>
+																												<th><span class="dashicons dashicons-book-alt"></span> <?php echo esc_html( bhg_t( 'hunts', 'Hunts' ) ); ?></th>
+																												<th><span class="dashicons dashicons-groups"></span> <?php echo esc_html( bhg_t( 'users', 'Users' ) ); ?></th>
+																												<th><span class="dashicons dashicons-awards"></span> <?php echo esc_html( bhg_t( 'tournaments', 'Tournaments' ) ); ?></th>
+																								</tr>
+																				</thead>
+																				<tbody>
+																								<tr>
+																												<td><?php echo esc_html( number_format_i18n( $hunts_count ) ); ?></td>
+																												<td><?php echo esc_html( number_format_i18n( $users_count ) ); ?></td>
+																												<td><?php echo esc_html( number_format_i18n( $tournaments_count ) ); ?></td>
+																								</tr>
+																				</tbody>
+																</table>
+												</div>
+								</section>
 
-                               <section class="bhg-dashboard-card" aria-labelledby="bhg-dashboard-latest-title" role="region">
-						<header class="bhg-card-header">
-								<h2 id="bhg-dashboard-latest-title" class="bhg-card-title"><?php echo esc_html( bhg_t( 'label_latest_hunts', 'Latest Hunts' ) ); ?></h2>
-						</header>
-                                               <div class="bhg-card-content">
-                                                               <?php if ( ! empty( $hunts ) && is_array( $hunts ) ) : ?>
-                                                               <div class="bhg-dashboard-list">
-                                                               <?php foreach ( $hunts as $h ) : ?>
-                                                               <?php
-                                                               $hunt_id       = isset( $h->id ) ? (int) $h->id : 0;
-                                                               $winners_count = isset( $h->winners_count ) ? (int) $h->winners_count : 0;
-                                                               $winners       = array();
+								<section class="bhg-dashboard-card" aria-labelledby="bhg-dashboard-latest-title" role="region">
+												<header class="bhg-card-header">
+																<h2 id="bhg-dashboard-latest-title" class="bhg-card-title"><?php echo esc_html( bhg_t( 'label_latest_hunts', 'Latest Hunts' ) ); ?></h2>
+												</header>
+												<div class="bhg-card-content">
+																<?php if ( ! empty( $hunts ) && is_array( $hunts ) ) : ?>
+																<table class="bhg-dashboard-table bhg-latest-hunts-table">
+																		<thead>
+																				<tr>
+																						<th><?php echo esc_html( bhg_t( 'label_bonushunt', 'Bonushunt' ) ); ?></th>
+																						<th><?php echo esc_html( bhg_t( 'label_all_winners', 'All Winners' ) ); ?></th>
+																						<th><?php echo esc_html( bhg_t( 'sc_start_balance', 'Start Balance' ) ); ?></th>
+																						<th><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></th>
+																						<th><?php echo esc_html( bhg_t( 'label_closed_at', 'Closed At' ) ); ?></th>
+																				</tr>
+																		</thead>
+																		<tbody>
+																		<?php foreach ( $hunts as $h ) : ?>
+																			<?php
+																			$hunt_id       = isset( $h->id ) ? (int) $h->id : 0;
+																			$winners_count = isset( $h->winners_count ) ? (int) $h->winners_count : 0;
+																			$winners       = array();
 
-                                                               if ( $hunt_id && function_exists( 'bhg_get_top_winners_for_hunt' ) ) {
-                                                                       $winners = bhg_get_top_winners_for_hunt( $hunt_id, $winners_count );
-                                                                       if ( ! is_array( $winners ) ) {
-                                                                               $winners = array();
-                                                                       }
-                                                               }
+																			if ( $hunt_id && function_exists( 'bhg_get_top_winners_for_hunt' ) ) {
+																					$winners = bhg_get_top_winners_for_hunt( $hunt_id, $winners_count );
+																				if ( ! is_array( $winners ) ) {
+																					$winners = array();
+																				}
+																			}
 
-                                                               $hunt_title = isset( $h->title ) ? (string) $h->title : '';
-                                                               $start      = isset( $h->starting_balance ) ? (float) $h->starting_balance : 0.0;
-                                                               ?>
-                                                               <article class="bhg-dashboard-hunt">
-                                                                       <h3 class="bhg-dashboard-subtitle">
-                                                                               <?php echo '' !== $hunt_title ? esc_html( $hunt_title ) : esc_html( bhg_t( 'label_untitled', '(untitled)' ) ); ?>
-                                                                       </h3>
-                                                                       <ul class="bhg-dashboard-hunt-meta">
-                                                                               <li><strong><?php echo esc_html( bhg_t( 'label_all_winners', 'All Winners' ) ); ?></strong> <?php
-                                                                               if ( ! empty( $winners ) ) {
-                                                                                       $out = array();
-                                                                                       foreach ( $winners as $w ) {
-                                                                                               $user_id = isset( $w->user_id ) ? (int) $w->user_id : 0;
-                                                                                               $guess   = isset( $w->guess ) ? (float) $w->guess : 0.0;
-                                                                                               $diff    = isset( $w->diff ) ? (float) $w->diff : 0.0;
+																			$hunt_title  = isset( $h->title ) ? (string) $h->title : '';
+																			$start       = isset( $h->starting_balance ) ? (float) $h->starting_balance : 0.0;
+																			$winners_out = '';
 
-                                                                                               $u  = $user_id ? get_userdata( $user_id ) : false;
-                                                                                               $nm = $u ? $u->user_login : sprintf(
-                                                                                                       /* translators: %d: user ID. */
-                                                                                                       esc_html( bhg_t( 'label_user_number', 'User #%d' ) ),
-                                                                                                       $user_id
-                                                                                               );
+																			if ( ! empty( $winners ) ) {
+																					$out = array();
+																				foreach ( $winners as $w ) {
+																					$user_id = isset( $w->user_id ) ? (int) $w->user_id : 0;
+																					$guess   = isset( $w->guess ) ? (float) $w->guess : 0.0;
+																					$diff    = isset( $w->diff ) ? (float) $w->diff : 0.0;
 
-                                                                                               // Compose: "name — 1,234.00 (diff 12.34)".
-                                                                                               $out[] = sprintf(
-                                                                                                       '%1$s %2$s %3$s (%4$s %5$s)',
-                                                                                                       esc_html( $nm ),
-                                                                                                       esc_html_x( '—', 'name/guess separator', 'bonus-hunt-guesser' ),
-                                                                                                       esc_html( number_format_i18n( $guess, 2 ) ),
-                                                                                                       esc_html( bhg_t( 'label_diff', 'diff' ) ),
-                                                                                                       esc_html( number_format_i18n( $diff, 2 ) )
-                                                                                               );
-                                                                                       }
-                                                                                       // Implode to a single, safely-escaped string separated by dots.
-                                                                                       echo esc_html( implode( ' • ', $out ) );
-                                                                               } else {
-                                                                                       echo esc_html( bhg_t( 'no_winners_yet', 'No winners yet' ) );
-                                                                               }
-                                                                               ?></li>
-                                                                               <li><strong><?php echo esc_html( bhg_t( 'sc_start_balance', 'Start Balance' ) ); ?></strong> <?php echo esc_html( number_format_i18n( $start, 2 ) ); ?></li>
-                                                                               <li><strong><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></strong> <?php
-                                                                               if ( isset( $h->final_balance ) && null !== $h->final_balance ) {
-                                                                                       echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
-                                                                               } else {
-                                                                                       echo esc_html( bhg_t( 'label_emdash', '—' ) );
-                                                                               }
-                                                                               ?></li>
-                                                                               <li><strong><?php echo esc_html( bhg_t( 'label_closed_at', 'Closed At' ) ); ?></strong> <?php
-                                                                               if ( ! empty( $h->closed_at ) ) {
-                                                                                       $ts = strtotime( (string) $h->closed_at );
-                                                                                       echo esc_html(
-                                                                                               false !== $ts
-                                                                                                       ? date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $ts )
-                                                                                                       : (string) $h->closed_at
-                                                                                       );
-                                                                               } else {
-                                                                                       echo esc_html( bhg_t( 'label_emdash', '—' ) );
-                                                                               }
-                                                                               ?></li>
-                                                                       </ul>
-                                                               </article>
-                                                               <?php endforeach; ?>
-                                                               </div>
-                                                               <?php else : ?>
-                                                               <p><?php echo esc_html( bhg_t( 'notice_no_closed_hunts', 'No closed hunts yet.' ) ); ?></p>
-                                                               <?php endif; ?>
-                                                               <p><a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts' ) ); ?>" class="button button-primary bhg-dashboard-button"><?php echo esc_html( bhg_t( 'view_all_hunts', 'View All Hunts' ) ); ?></a></p>
-                                               </div>
-                               </section>
-               </main>
+																					$u  = $user_id ? get_userdata( $user_id ) : false;
+																					$nm = $u ? $u->user_login : sprintf(
+																						/* translators: %d: user ID. */
+																						esc_html( bhg_t( 'label_user_number', 'User #%d' ) ),
+																						$user_id
+																					);
+
+																					$out[] = sprintf(
+																						'%1$s %2$s %3$s (%4$s %5$s)',
+																						esc_html( $nm ),
+																						esc_html_x( '—', 'name/guess separator', 'bonus-hunt-guesser' ),
+																						esc_html( number_format_i18n( $guess, 2 ) ),
+																						esc_html( bhg_t( 'label_diff', 'diff' ) ),
+																						esc_html( number_format_i18n( $diff, 2 ) )
+																					);
+																				}
+																				$winners_out = implode( ' • ', $out );
+																			} else {
+																					$winners_out = bhg_t( 'no_winners_yet', 'No winners yet' );
+																			}
+
+																			?>
+																				<tr>
+																						<td><?php echo '' !== $hunt_title ? esc_html( $hunt_title ) : esc_html( bhg_t( 'label_untitled', '(untitled)' ) ); ?></td>
+																						<td><?php echo esc_html( $winners_out ); ?></td>
+																						<td><?php echo esc_html( number_format_i18n( $start, 2 ) ); ?></td>
+																						<td>
+																						<?php
+																						if ( isset( $h->final_balance ) && null !== $h->final_balance ) {
+																								echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
+																						} else {
+																								echo esc_html( bhg_t( 'label_emdash', '—' ) );
+																						}
+																						?>
+																						</td>
+																						<td>
+																						<?php
+																						if ( ! empty( $h->closed_at ) ) {
+																								$ts = strtotime( (string) $h->closed_at );
+																								echo esc_html(
+																									false !== $ts
+																												? date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $ts )
+																												: (string) $h->closed_at
+																								);
+																						} else {
+																								echo esc_html( bhg_t( 'label_emdash', '—' ) );
+																						}
+																						?>
+																						</td>
+																				</tr>
+																		<?php endforeach; ?>
+																		</tbody>
+																</table>
+																<?php else : ?>
+																<p><?php echo esc_html( bhg_t( 'notice_no_closed_hunts', 'No closed hunts yet.' ) ); ?></p>
+																<?php endif; ?>
+																<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts' ) ); ?>" class="button button-primary bhg-dashboard-button"><?php echo esc_html( bhg_t( 'view_all_hunts', 'View All Hunts' ) ); ?></a></p>
+												</div>
+								</section>
+				</main>
 </div>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -165,7 +165,46 @@ flex: 1;
 }
 
 .bhg-dashboard-card .bhg-card-content {
-    padding: var(--bhg-spacing);
+    padding: calc(var(--bhg-spacing) * 1.5);
+}
+
+/* Dashboard tables */
+.bhg-dashboard-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.bhg-dashboard-table th,
+.bhg-dashboard-table td {
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--bhg-border-color);
+    vertical-align: top;
+}
+
+.bhg-dashboard-table th {
+    background-color: #f9fafb;
+    color: var(--bhg-accent-color);
+    font-weight: 600;
+    text-align: left;
+}
+
+.bhg-summary-table td,
+.bhg-summary-table th {
+    text-align: center;
+}
+
+.bhg-summary-table td {
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.bhg-latest-hunts-table td:nth-child(3),
+.bhg-latest-hunts-table td:nth-child(4) {
+    text-align: right;
+}
+
+.bhg-card-content > p {
+    margin-top: var(--bhg-spacing);
 }
 
 /* Buttons */
@@ -191,83 +230,11 @@ flex: 1;
     filter: brightness(0.9);
 }
 
-.bhg-dashboard-meta {
-    list-style: none;
-    margin: 0 0 12px;
-    padding: 0;
-}
-
-.bhg-dashboard-subtitle {
-    margin: 0 0 8px;
-    color: var(--bhg-accent-color);
-    font-size: 14px;
-}
-
-.bhg-dashboard-winners {
-    margin: 0;
-    padding-left: 20px;
-}
-
-.bhg-dashboard-winners li {
-    margin-bottom: 4px;
-}
-
 /* Enhanced dashboard layout */
 .bhg-dashboard-cards {
     display: grid;
     grid-template-columns: 1fr;
     gap: var(--bhg-spacing);
-}
-
-.bhg-dashboard-meta li + li {
-    margin-top: 4px;
-}
-
-.bhg-dashboard-meta strong {
-    color: var(--bhg-accent-color);
-}
-
-.bhg-dashboard-meta li {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-}
-
-.bhg-dashboard-meta .dashicons {
-    color: var(--bhg-accent-color);
-}
-
-/* Latest hunts list */
-.bhg-dashboard-list {
-    display: grid;
-    gap: var(--bhg-spacing);
-}
-
-.bhg-dashboard-hunt {
-    background: var(--bhg-card-bg);
-    border: 1px solid var(--bhg-border-color);
-    border-radius: 6px;
-    padding: var(--bhg-spacing);
-    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
-}
-
-.bhg-dashboard-hunt-meta {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 4px;
-    grid-template-columns: 1fr;
-}
-
-.bhg-dashboard-hunt-meta strong {
-    color: var(--bhg-accent-color);
-}
-
-@media (min-width: 600px) {
-    .bhg-dashboard-hunt-meta {
-        grid-template-columns: repeat(2, 1fr);
-    }
 }
 
 


### PR DESCRIPTION
## Summary
- Present dashboard summary counts in a centered full-width table for clearer overview
- Replace latest hunts list with a wide, detailed table and updated CSS for polished spacing and typography

## Testing
- `composer install`
- `vendor/bin/phpcs --standard=phpcs.xml admin/views/dashboard.php assets/css/admin.css`


------
https://chatgpt.com/codex/tasks/task_e_68bea4c0c9308333a01bb3e8446a2453