### PR TITLE
Use prepared table names and winners_count in hunts list

### DIFF
--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -1,27 +1,36 @@
 <?php
+/**
+ * Admin view: Hunts list.
+ *
+ * @package BonusHuntGuesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+        exit;
+}
+
 if ( ! current_user_can( 'manage_options' ) ) {
-	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) ); }
+        wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
+}
 
 global $wpdb;
-$t = $wpdb->prefix . 'bhg_hunts';
+$t = $wpdb->prefix . 'bhg_bonus_hunts';
 
 $paged    = max( 1, isset( $_GET['paged'] ) ? (int) $_GET['paged'] : 1 );
 $per_page = 20;
 $offset   = ( $paged - 1 ) * $per_page;
 
 $rows  = $wpdb->get_results(
-	$wpdb->prepare(
-		"SELECT id, title, start_balance, final_balance, status, winners_limit, closed_at
-		FROM $t
-		ORDER BY id DESC
-		LIMIT %d OFFSET %d",
-		$per_page,
-		$offset
-	)
+        $wpdb->prepare(
+                'SELECT id, title, start_balance, final_balance, status, winners_count, closed_at FROM %i ORDER BY id DESC LIMIT %d OFFSET %d',
+                $t,
+                $per_page,
+                $offset
+        )
 );
-$total = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $t" );
+$total = (int) $wpdb->get_var(
+        $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $t )
+);
 $pages = max( 1, (int) ceil( $total / $per_page ) );
 
 ?>
@@ -87,7 +96,7 @@ $pages = max( 1, (int) ceil( $total / $per_page ) );
 			<td><?php echo esc_html( number_format_i18n( (float) $r->start_balance, 2 ) ); ?></td>
 					<td><?php echo ( $r->final_balance !== null ) ? esc_html( number_format_i18n( (float) $r->final_balance, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
                        <td><?php echo esc_html( bhg_t( $r->status, ucfirst( $r->status ) ) ); ?></td>
-			<td><?php echo (int) $r->winners_limit; ?></td>
+                        <td><?php echo (int) $r->winners_count; ?></td>
 					<td><?php echo $r->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->closed_at ) ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
 			<td>
 							<?php


### PR DESCRIPTION
## Summary
- harden hunt listing queries with `$wpdb->prepare` and identifier placeholders
- switch to `bhg_bonus_hunts` table and `winners_count` column
- add file-level documentation and expanded `ABSPATH` guard

## Testing
- `composer run phpcs` *(fails: Processing form data without nonce verification, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bea70f08a08333b195d7f6788e1c4e