### PR TITLE
Use table placeholders in bonus hunt queries

### DIFF
--- a/includes/class-bhg-bonus-hunts.php
+++ b/includes/class-bhg-bonus-hunts.php
@@ -19,36 +19,39 @@ class BHG_Bonus_Hunts {
 		$guesses_table = $wpdb->prefix . 'bhg_guesses';
 		$limit         = max( 1, (int) $limit );
 
-		$hunts = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT id, title, starting_balance, final_balance, winners_count, closed_at
-					FROM `$hunts_table`
-					WHERE status = %s AND final_balance IS NOT NULL AND closed_at IS NOT NULL
-					ORDER BY closed_at DESC
-					LIMIT %d",
-				'closed',
-				$limit
-			)
-		);
+                $hunts = $wpdb->get_results(
+                        $wpdb->prepare(
+                                "SELECT id, title, starting_balance, final_balance, winners_count, closed_at
+                                        FROM %i
+                                        WHERE status = %s AND final_balance IS NOT NULL AND closed_at IS NOT NULL
+                                        ORDER BY closed_at DESC
+                                        LIMIT %d",
+                                $hunts_table,
+                                'closed',
+                                $limit
+                        )
+                );
 
 		$out = array();
 
 		foreach ( (array) $hunts as $h ) {
 			$winners_count = max( 1, (int) $h->winners_count );
-			$winners       = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT g.user_id, u.display_name, g.guess,
-							ABS(g.guess - %f) AS diff
-						FROM `$guesses_table` g
-						LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
-						WHERE g.hunt_id = %d
-						ORDER BY diff ASC, g.id ASC
-						LIMIT %d",
-					$h->final_balance,
-					$h->id,
-					$winners_count
-				)
-			);
+                        $winners       = $wpdb->get_results(
+                                $wpdb->prepare(
+                                        "SELECT g.user_id, u.display_name, g.guess,
+                                                        ABS(g.guess - %f) AS diff
+                                                FROM %i g
+                                                LEFT JOIN %i u ON u.ID = g.user_id
+                                                WHERE g.hunt_id = %d
+                                                ORDER BY diff ASC, g.id ASC
+                                                LIMIT %d",
+                                        $h->final_balance,
+                                        $guesses_table,
+                                        $wpdb->users,
+                                        $h->id,
+                                        $winners_count
+                                )
+                        );
 
 			$out[] = array(
 				'hunt'    => $h,
@@ -69,7 +72,13 @@ class BHG_Bonus_Hunts {
 		global $wpdb;
 		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
 
-		return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `$hunts_table` WHERE id=%d", (int) $hunt_id ) );
+                return $wpdb->get_row(
+                        $wpdb->prepare(
+                                'SELECT * FROM %i WHERE id=%d',
+                                $hunts_table,
+                                (int) $hunt_id
+                        )
+                );
 	}
 
 	/**
@@ -88,28 +97,32 @@ class BHG_Bonus_Hunts {
 			return array(); }
 
 		if ( null !== $hunt->final_balance ) {
-			return $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT g.*, u.display_name, ABS(g.guess - %f) AS diff
-						FROM `$guesses_table` g
-						LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
-						WHERE g.hunt_id = %d
-						ORDER BY diff ASC, g.id ASC",
-					$hunt->final_balance,
-					$hunt_id
-				)
-			);
+                        return $wpdb->get_results(
+                                $wpdb->prepare(
+                                        "SELECT g.*, u.display_name, ABS(g.guess - %f) AS diff
+                                                FROM %i g
+                                                LEFT JOIN %i u ON u.ID = g.user_id
+                                                WHERE g.hunt_id = %d
+                                                ORDER BY diff ASC, g.id ASC",
+                                        $hunt->final_balance,
+                                        $guesses_table,
+                                        $wpdb->users,
+                                        $hunt_id
+                                )
+                        );
 		}
 
-		return $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT g.*, u.display_name, NULL AS diff
-					FROM `$guesses_table` g
-					LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
-					WHERE g.hunt_id = %d
-					ORDER BY g.id ASC",
-				$hunt_id
-			)
-		);
+                return $wpdb->get_results(
+                        $wpdb->prepare(
+                                "SELECT g.*, u.display_name, NULL AS diff
+                                        FROM %i g
+                                        LEFT JOIN %i u ON u.ID = g.user_id
+                                        WHERE g.hunt_id = %d
+                                        ORDER BY g.id ASC",
+                                $guesses_table,
+                                $wpdb->users,
+                                $hunt_id
+                        )
+                );
 	}
 }


### PR DESCRIPTION
## Summary
- replace backtick-wrapped table variables with `%i` identifiers in bonus hunt queries
- pass `$hunts_table`, `$guesses_table`, and `$wpdb->users` as identifier arguments to `$wpdb->prepare()`

## Testing
- `composer phpcs` *(fails: Direct database call warnings and coding standard errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68bea710a18c8333ae520bca3ca53759