### PR TITLE
Add headers and normalize ABSPATH checks in admin views

### DIFF
--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Admin view template for editing an existing bonus hunt.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -1,6 +1,13 @@
 <?php
+/**
+ * Admin view template for displaying results of a bonus hunt.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html( bhg_t( 'insufficient_permissions', 'Insufficient permissions' ) ) );
 }
@@ -11,7 +18,8 @@ $guesses = $wpdb->prefix . 'bhg_guesses';
 $hunt    = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `$hunts` WHERE id=%d", $hunt_id ) );
 if ( ! $hunt ) {
 	echo '<div class="wrap"><h1>' . esc_html( bhg_t( 'hunt_not_found', 'Hunt not found' ) ) . '</h1></div>';
-	return; }
+	return;
+}
 $rows = $wpdb->get_results(
 	$wpdb->prepare(
 		"SELECT g.*, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
@@ -21,7 +29,7 @@ $rows = $wpdb->get_results(
 );
 ?>
 <div class="wrap">
-        <h1><?php echo esc_html( sprintf( bhg_t( 'title_results_s', 'Results — %s' ), $hunt->title ) ); ?></h1>
+	<h1><?php echo esc_html( sprintf( bhg_t( 'title_results_s', 'Results — %s' ), $hunt->title ) ); ?></h1>
 	<table class="widefat striped">
 	<thead><tr>
 		<th>

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -1,6 +1,13 @@
 <?php
+/**
+ * Admin view template for database tools and maintenance.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );

--- a/admin/views/demo-data.php
+++ b/admin/views/demo-data.php
@@ -1,3 +1,12 @@
 <?php
-// Demo data installer for Bonus Hunt Guesser
-// Seeds sample hunts, guesses, tournaments, ads, translations
+/**
+ * Demo data installer for Bonus Hunt Guesser.
+ *
+ * Seeds sample hunts, guesses, tournaments, ads, translations.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}

--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Admin view template for the plugin's main dashboard header.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/admin/views/hunts-edit.php
+++ b/admin/views/hunts-edit.php
@@ -1,12 +1,21 @@
 <?php
+/**
+ * Admin view template for editing hunt details.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 if ( ! current_user_can( 'manage_options' ) ) {
-	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) ); }
+	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
+}
 
 $hunt_id = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
 if ( ! $hunt_id ) {
-	wp_die( esc_html( bhg_t( 'missing_hunt_id', 'Missing hunt id' ) ) ); }
+	wp_die( esc_html( bhg_t( 'missing_hunt_id', 'Missing hunt id' ) ) );
+}
 
 check_admin_referer( 'bhg_edit_hunt_' . $hunt_id, 'bhg_nonce' );
 
@@ -26,7 +35,8 @@ if ( ! function_exists( 'bhg_get_hunt' ) || ! function_exists( 'bhg_get_hunt_par
 
 $hunt = bhg_get_hunt( $hunt_id );
 if ( ! $hunt ) {
-	wp_die( esc_html( bhg_t( 'hunt_not_found', 'Hunt not found' ) ) ); }
+	wp_die( esc_html( bhg_t( 'hunt_not_found', 'Hunt not found' ) ) );
+}
 
 $paged    = max( 1, isset( $_GET['ppaged'] ) ? (int) $_GET['ppaged'] : 1 );
 $per_page = 30;

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -1,8 +1,16 @@
 <?php
+/**
+ * Admin view template for listing hunts.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 if ( ! current_user_can( 'manage_options' ) ) {
-	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) ); }
+	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
+}
 
 global $wpdb;
 $t = $wpdb->prefix . 'bhg_hunts';

--- a/admin/views/page-template.php
+++ b/admin/views/page-template.php
@@ -1,3 +1,12 @@
 <?php
-// Pre-made WordPress page template for demo
-// Usage: [bhg_bonus_hunt] [bhg_leaderboard] [bhg_tournament_leaderboard]
+/**
+ * Pre-made WordPress page template for demo usage.
+ *
+ * Usage: [bhg_bonus_hunt] [bhg_leaderboard] [bhg_tournament_leaderboard]
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -1,6 +1,13 @@
 <?php
+/**
+ * Admin view template for managing tournaments.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
 }

--- a/admin/views/users.php
+++ b/admin/views/users.php
@@ -1,6 +1,13 @@
 <?php
+/**
+ * Admin view template for managing users.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
 }


### PR DESCRIPTION
## Summary
- add file-level PHPDoc blocks to admin view templates
- standardize ABSPATH guards to multiline form

## Testing
- `composer phpcs` *(fails: repository contains existing coding standard violations)*
- `./vendor/bin/phpcs admin/views/bonus-hunts-results.php` *(fails: warnings for direct database calls and missing nonce checks)*

------
https://chatgpt.com/codex/tasks/task_e_68bea86086d4833397e7fb5918958202