### PR TITLE
Fix default bonus hunt schema key

### DIFF
--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -103,11 +103,11 @@ function bhg_insert_demo_data() {
 	$wpdb->insert(
 		$wpdb->prefix . 'bhg_bonus_hunts',
 		array(
-			'title'             => 'Demo Bonus Hunt',
-			'starting_balance'  => 2000,
-			'number_of_bonuses' => 10,
-			'status'            => 'active',
-			'created_at'        => current_time( 'mysql' ),
+                       'title'             => 'Demo Bonus Hunt',
+                       'starting_balance'  => 2000,
+                       'num_bonuses'       => 10,
+                       'status'            => 'active',
+                       'created_at'        => current_time( 'mysql' ),
 		),
 		array( '%s', '%d', '%d', '%s', '%s' )
 	);


### PR DESCRIPTION
## Summary
- use `num_bonuses` field when inserting demo bonus hunt

## Testing
- `composer phpcs` *(fails: Use of direct database calls and placeholder issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bec4f3f9ec83339a1fbbdbf4899b9a