### PR TITLE
Ensure translations use composite slug-locale key

### DIFF
--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -236,7 +236,14 @@ class BHG_DB {
                                                                $wpdb->query( $alter );
                                                        }
                                                }
-                                               // Ensure unique index
+                                               // Ensure composite unique index on (slug, locale).
+                                               // Drop legacy single-column indexes if present first.
+                                               if ( $this->index_exists( $trans_table, 'slug' ) ) {
+                                                       $wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX slug" );
+                                               }
+                                               if ( $this->index_exists( $trans_table, 'slug_unique' ) ) {
+                                                       $wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX slug_unique" );
+                                               }
                                                if ( ! $this->index_exists( $trans_table, 'slug_locale' ) ) {
                                                        $wpdb->query( "ALTER TABLE `{$trans_table}` ADD UNIQUE KEY slug_locale (slug, locale)" );
                                                }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -616,16 +616,16 @@ if ( ! function_exists( 'bhg_seed_default_translations' ) ) {
                                continue; // Skip invalid keys.
                        }
 
-                       $exists = (int) $wpdb->get_var(
+                       $exists = $wpdb->get_var(
                                $wpdb->prepare(
-                                       'SELECT COUNT(*) FROM %i WHERE slug = %s AND locale = %s',
+                                       'SELECT id FROM %i WHERE slug = %s AND locale = %s LIMIT 1',
                                        $table,
                                        $slug,
                                        $locale
                                )
                        );
 
-                       if ( 0 === $exists ) {
+                       if ( null === $exists ) {
                                $wpdb->insert(
                                        $table,
                                        array(


### PR DESCRIPTION
## Summary
- use composite slug-locale key for translations table
- guard schema migrations by dropping old indexes
- avoid duplicate translation seeds for same slug and locale

## Testing
- `composer run phpcs` *(fails: Tabs must be used to indent lines; spaces are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68bee192108483338cdf85d4841bfdd8