### PR TITLE
Add file-level docblocks

### DIFF
--- a/admin/views/demo-data.php
+++ b/admin/views/demo-data.php
@@ -1,3 +1,8 @@
 <?php
-// Demo data installer for Bonus Hunt Guesser
-// Seeds sample hunts, guesses, tournaments, ads, translations
+/**
+ * Demo data installer for Bonus Hunt Guesser.
+ *
+ * Seeds sample hunts, guesses, tournaments, ads, translations.
+ *
+ * @package Bonus_Hunt_Guesser
+ */

--- a/admin/views/page-template.php
+++ b/admin/views/page-template.php
@@ -1,3 +1,8 @@
 <?php
-// Pre-made WordPress page template for demo
-// Usage: [bhg_bonus_hunt] [bhg_leaderboard] [bhg_tournament_leaderboard]
+/**
+ * Pre-made WordPress page template for demo.
+ *
+ * Usage: [bhg_bonus_hunt] [bhg_leaderboard] [bhg_tournament_leaderboard].
+ *
+ * @package Bonus_Hunt_Guesser
+ */


### PR DESCRIPTION
## Summary
- add plugin package docblocks for demo page template and demo data installer views

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml` *(fails: numerous coding standard warnings/errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68bee8fe19fc8333ab49bfe60a828436