### PR TITLE
Fix SQL query syntax in bonus-hunt view

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -328,15 +328,14 @@ if ( $view === 'edit' ) :
 	if ( ! in_array( $users_table_local, $allowed_tables, true ) ) {
 			wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
 	}
+	$users_table_local = esc_sql( $users_table_local );
 				// db call ok; no-cache ok.
-								$guesses = $wpdb->get_results(
-									$wpdb->prepare(
-										'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
-										$guesses_table,
-										$users_table_local,
+							$guesses = $wpdb->get_results(
+								$wpdb->prepare(
+									"SELECT g.*, u.display_name FROM {$guesses_table} g LEFT JOIN {$users_table_local} u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC",
 										$id
-									)
-								);
+										)
+							);
 	?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html( bhg_t( 'edit_bonus_hunt', 'Edit Bonus Hunt' ) ); ?> <?php echo esc_html( bhg_t( 'label_emdash', '—' ) ); ?> <?php echo esc_html( $hunt->title ); ?></h1>


### PR DESCRIPTION
## Summary
- sanitize `users_table_local` before use
- fix SQL prepare call when loading guesses for an edited hunt

## Testing
- `php -l admin/views/bonus-hunts.php`
- `vendor/bin/phpcs --standard=phpcs.xml admin/views/bonus-hunts.php` *(fails: Tabs must be used to indent lines; spaces are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68bef71346fc8333a24959eef4a112cf