### PR TITLE
Use prepared statements for SQL queries

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -170,7 +170,8 @@ if ( 'close' === $view ) :
                // db call ok; no-cache ok.
                $hunt = $wpdb->get_row(
                        $wpdb->prepare(
-                               "SELECT * FROM {$hunts_table} WHERE id = %d",
+                               'SELECT * FROM %i WHERE id = %d',
+                               $hunts_table,
                                $id
                        )
                );
@@ -316,7 +317,8 @@ if ( $view === 'edit' ) :
 		// db call ok; no-cache ok.
                $hunt = $wpdb->get_row(
                        $wpdb->prepare(
-                               "SELECT * FROM {$hunts_table} WHERE id = %d",
+                               'SELECT * FROM %i WHERE id = %d',
+                               $hunts_table,
                                $id
                        )
                );
@@ -328,14 +330,16 @@ if ( $view === 'edit' ) :
 	if ( ! in_array( $users_table_local, $allowed_tables, true ) ) {
 			wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
 	}
-	$users_table_local = esc_sql( $users_table_local );
-				// db call ok; no-cache ok.
-							$guesses = $wpdb->get_results(
-								$wpdb->prepare(
-									"SELECT g.*, u.display_name FROM {$guesses_table} g LEFT JOIN {$users_table_local} u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC",
-										$id
-										)
-							);
+       $users_table_local = esc_sql( $users_table_local );
+                                // db call ok; no-cache ok.
+                                                        $guesses = $wpdb->get_results(
+                                                                $wpdb->prepare(
+                                                                        'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
+                                                                        $guesses_table,
+                                                                        $users_table_local,
+                                                                        $id
+                                                                                )
+                                                        );
 	?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html( bhg_t( 'edit_bonus_hunt', 'Edit Bonus Hunt' ) ); ?> <?php echo esc_html( bhg_t( 'label_emdash', '—' ) ); ?> <?php echo esc_html( $hunt->title ); ?></h1>

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -453,11 +453,14 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
                         if ( ! isset( $orderby_map[ $orderby_key ] ) ) {
                                 $orderby_key = 'hunt';
                         }
-                        $orderby = $orderby_map[ $orderby_key ];
+$orderby = $orderby_map[ $orderby_key ];
 
-						$query  = 'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id FROM ' . $g . ' g INNER JOIN ' . $h . ' h ON h.id = g.hunt_id WHERE ' . implode( ' AND ', $where );
-						$query  = $wpdb->prepare( $query, ...$params );
-						$query .= ' ORDER BY ' . $orderby . ' ' . $order;
+$params = array_merge( array( $g, $h ), $params );
+$query  = $wpdb->prepare(
+'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id FROM %i g INNER JOIN %i h ON h.id = g.hunt_id WHERE ' . implode( ' AND ', $where ),
+...$params
+);
+$query .= ' ORDER BY ' . $orderby . ' ' . $order;
 						if ( 'recent' === strtolower( $a['timeline'] ) ) {
 								$query .= ' LIMIT 10';
 						}


### PR DESCRIPTION
## Summary
- Secure hunt retrieval and participant queries with `$wpdb->prepare`
- Use placeholders for table names in shortcode user-guesses query

## Testing
- `php -l admin/views/bonus-hunts.php`
- `php -l includes/class-bhg-shortcodes.php`
- `composer phpcs` *(fails: numerous existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bef8eb0b308333be7eb47a5cc9a373