### PR TITLE
Use prepared statements in uninstall cleanup

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,4 +1,4 @@
-<?php
+			<?php
 /**
  * Uninstall script for Bonus Hunt Guesser.
  *
@@ -29,7 +29,7 @@ $tables = array(
 );
 
 foreach ( $tables as $table ) {
-	$table_name = $wpdb->prefix . $table;
-	// db call ok; no-cache ok.
-		$wpdb->query( "DROP TABLE IF EXISTS {$table_name}" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$table_name   = $wpdb->prefix . $table;
+	$prepared_sql = $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table_name ); // db call ok; no-cache ok.
+	$wpdb->query( $prepared_sql );
 }


### PR DESCRIPTION
## Summary
- use `$wpdb->prepare()` when dropping tables on uninstall
- execute prepared SQL with `$wpdb->query()` and remove phpcs ignores

## Testing
- `composer install`
- `./vendor/bin/phpcs uninstall.php` *(fails: FOUND 26 ERRORS AND 2 WARNINGS AFFECTING 25 LINES)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0c67ab348333804592fadc18b888