### PR TITLE
Use tabs for indentation

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -232,27 +232,27 @@ class BHG_Admin {
 		$title                 = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
 		$starting              = isset( $_POST['starting_balance'] ) ? floatval( wp_unslash( $_POST['starting_balance'] ) ) : 0;
 		$num_bonuses           = isset( $_POST['num_bonuses'] ) ? absint( wp_unslash( $_POST['num_bonuses'] ) ) : 0;
-                $prizes                = isset( $_POST['prizes'] ) ? wp_kses_post( wp_unslash( $_POST['prizes'] ) ) : '';
-                $affiliate_site        = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
-                $tournament_id         = isset( $_POST['tournament_id'] ) ? bhg_sanitize_tournament_id( wp_unslash( $_POST['tournament_id'] ) ) : 0;
-                $winners_count         = isset( $_POST['winners_count'] ) ? max( 1, absint( wp_unslash( $_POST['winners_count'] ) ) ) : 3;
-                                $final_balance = ( isset( $_POST['final_balance'] ) && '' !== $_POST['final_balance'] ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
-                $status                = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'open';
+				$prizes                = isset( $_POST['prizes'] ) ? wp_kses_post( wp_unslash( $_POST['prizes'] ) ) : '';
+				$affiliate_site        = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
+				$tournament_id         = isset( $_POST['tournament_id'] ) ? bhg_sanitize_tournament_id( wp_unslash( $_POST['tournament_id'] ) ) : 0;
+				$winners_count         = isset( $_POST['winners_count'] ) ? max( 1, absint( wp_unslash( $_POST['winners_count'] ) ) ) : 3;
+								$final_balance = ( isset( $_POST['final_balance'] ) && '' !== $_POST['final_balance'] ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
+				$status                = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'open';
 
 		$data = array(
 			'title'             => $title,
 			'starting_balance'  => $starting,
 			'num_bonuses'       => $num_bonuses,
 			'prizes'            => $prizes,
-                        'affiliate_site_id' => $affiliate_site,
-                        'tournament_id'     => $tournament_id,
-                        'winners_count'     => $winners_count,
-                        'final_balance'     => $final_balance,
-                        'status'            => $status,
-                        'updated_at'        => current_time( 'mysql' ),
-                );
+						'affiliate_site_id' => $affiliate_site,
+						'tournament_id'     => $tournament_id,
+						'winners_count'     => $winners_count,
+						'final_balance'     => $final_balance,
+						'status'            => $status,
+						'updated_at'        => current_time( 'mysql' ),
+				);
 
-                $format = array( '%s', '%f', '%d', '%s', '%d', '%d', '%d', '%f', '%s', '%s' );
+				$format = array( '%s', '%f', '%d', '%s', '%d', '%d', '%d', '%f', '%s', '%s' );
 		if ( $id ) {
 			$wpdb->update( $hunts_table, $data, array( 'id' => $id ), $format, array( '%d' ) );
 		} else {
@@ -390,12 +390,12 @@ class BHG_Admin {
 		} elseif ( 'delete' === $bulk_action && ! empty( $bulk_ad_ids ) ) {
 				$placeholders          = implode( ', ', array_fill( 0, count( $bulk_ad_ids ), '%d' ) );
 								$query = $wpdb->prepare(
-                                       // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+									   // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 									"DELETE FROM %i WHERE id IN ($placeholders)",
 									array_merge( array( $ads_table ), $bulk_ad_ids )
 								);
 
-                               // phpcs:ignore WordPress.DB.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+							   // phpcs:ignore WordPress.DB.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
 								$wpdb->query( $query );
 		}
 

--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -146,7 +146,7 @@ $ads = $wpdb->get_results(
 					'all'            => bhg_t( 'label_all', 'All' ),
 					'guests'         => bhg_t( 'label_guests', 'Guests' ),
 					'logged_in'      => bhg_t( 'label_logged_in', 'Logged In' ),
-                                    'affiliates'     => bhg_t( 'label_affiliates', 'Affiliates' ),
+									'affiliates'     => bhg_t( 'label_affiliates', 'Affiliates' ),
 					'non_affiliates' => bhg_t( 'label_non_affiliates', 'Non Affiliates' ),
 				);
 				$sel            = $ad ? ( $ad->visible_to ?? 'all' ) : 'all';

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -85,7 +85,7 @@ $rows = $wpdb->get_results(
 						<td><?php echo esc_html( $r->name ); ?></td>
 						<td><?php echo esc_html( $r->slug ); ?></td>
 						<td><?php echo esc_html( $r->url ); ?></td>
-                                                <td><?php echo esc_html( bhg_t( $r->status, ucfirst( $r->status ) ) ); ?></td>
+												<td><?php echo esc_html( bhg_t( $r->status, ucfirst( $r->status ) ) ); ?></td>
 			<td>
 			<a class="button" href="<?php echo esc_url( add_query_arg( array( 'edit' => (int) $r->id ) ) ); ?>">
 				<?php

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -21,7 +21,7 @@ $rows = $wpdb->get_results(
 );
 ?>
 <div class="wrap">
-        <h1><?php echo esc_html( sprintf( bhg_t( 'title_results_s', 'Results — %s' ), $hunt->title ) ); ?></h1>
+		<h1><?php echo esc_html( sprintf( bhg_t( 'title_results_s', 'Results — %s' ), $hunt->title ) ); ?></h1>
 	<table class="widefat striped">
 	<thead><tr>
 		<th>

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -18,19 +18,19 @@ $guesses_table = $wpdb->prefix . 'bhg_guesses';
 $tours_table   = $wpdb->prefix . 'bhg_tournaments';
 $users_table   = $wpdb->users;
 $allowed_tables = array(
-        $wpdb->prefix . 'bhg_bonus_hunts',
-        $wpdb->prefix . 'bhg_guesses',
-        $wpdb->prefix . 'bhg_affiliate_websites',
-        $wpdb->prefix . 'bhg_tournaments',
-        $wpdb->users,
+		$wpdb->prefix . 'bhg_bonus_hunts',
+		$wpdb->prefix . 'bhg_guesses',
+		$wpdb->prefix . 'bhg_affiliate_websites',
+		$wpdb->prefix . 'bhg_tournaments',
+		$wpdb->users,
 );
 if (
-                ! in_array( $hunts_table, $allowed_tables, true ) ||
-                ! in_array( $guesses_table, $allowed_tables, true ) ||
-                ! in_array( $users_table, $allowed_tables, true ) ||
-                ! in_array( $tours_table, $allowed_tables, true )
+				! in_array( $hunts_table, $allowed_tables, true ) ||
+				! in_array( $guesses_table, $allowed_tables, true ) ||
+				! in_array( $users_table, $allowed_tables, true ) ||
+				! in_array( $tours_table, $allowed_tables, true )
 ) {
-                wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
+				wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
 }
 
 $hunts_table   = esc_sql( $hunts_table );
@@ -104,7 +104,7 @@ if ( 'list' === $view ) :
 			<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
 					<td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
 			<td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
-                       <td><?php echo esc_html( bhg_t( $h->status, ucfirst( $h->status ) ) ); ?></td>
+					   <td><?php echo esc_html( bhg_t( $h->status, ucfirst( $h->status ) ) ); ?></td>
 			<td>
 			<a class="button" href="
 				<?php
@@ -166,16 +166,16 @@ endif;
 <?php
 /** CLOSE VIEW */
 if ( 'close' === $view ) :
-               $id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
-               // db call ok; no-cache ok.
-               $hunt = $wpdb->get_row(
-                       $wpdb->prepare(
-                               'SELECT * FROM %i WHERE id = %d',
-                               $hunts_table,
-                               $id
-                       )
-               );
-        if ( ! $hunt || 'open' !== $hunt->status ) :
+			   $id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
+			   // db call ok; no-cache ok.
+			   $hunt = $wpdb->get_row(
+					   $wpdb->prepare(
+							   'SELECT * FROM %i WHERE id = %d',
+							   $hunts_table,
+							   $id
+					   )
+			   );
+		if ( ! $hunt || 'open' !== $hunt->status ) :
 		echo '<div class="notice notice-error"><p>' . esc_html( bhg_t( 'invalid_hunt_2', 'Invalid hunt.' ) ) . '</p></div>';
 	else :
 		?>
@@ -256,41 +256,41 @@ if ( $view === 'add' ) :
 				<?php endforeach; ?>
 			</select>
 			</td>
-                </tr>
-                <tr>
-                        <th scope="row"><label for="bhg_tournament"><?php echo esc_html( bhg_t( 'tournament', 'Tournament' ) ); ?></label></th>
-                        <td>
-                                                <?php
-                                                $t_table = $wpdb->prefix . 'bhg_tournaments';
-                                                if ( ! in_array( $t_table, $allowed_tables, true ) ) {
-                                                                wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
-                                                }
-                                                $t_table = esc_sql( $t_table );
-                                                // db call ok; no-cache ok.
-                                                $tours = $wpdb->get_results(
-                                                        $wpdb->prepare( 'SELECT id, title FROM %i ORDER BY title ASC', $t_table )
-                                                );
-                                                $tsel = isset( $hunt->tournament_id ) ? (int) $hunt->tournament_id : 0;
-                                                ?>
-                        <select id="bhg_tournament" name="tournament_id">
-                                <option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
-                                <?php foreach ( $tours as $t ) : ?>
-                                <option value="<?php echo (int) $t->id; ?>"
-                                        <?php
-                                        if ( $tsel === (int) $t->id ) {
-                                                echo 'selected';
-                                        }
-                                        ?>
-                                ><?php echo esc_html( $t->title ); ?></option>
-                                <?php endforeach; ?>
-                        </select>
-                        </td>
-                </tr>
-                <tr>
-                        <th scope="row"><label for="bhg_winners"><?php echo esc_html( bhg_t( 'number_of_winners', 'Number of Winners' ) ); ?></label></th>
-                        <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="3"></td>
-                </tr>
-                <tr>
+				</tr>
+				<tr>
+						<th scope="row"><label for="bhg_tournament"><?php echo esc_html( bhg_t( 'tournament', 'Tournament' ) ); ?></label></th>
+						<td>
+												<?php
+												$t_table = $wpdb->prefix . 'bhg_tournaments';
+												if ( ! in_array( $t_table, $allowed_tables, true ) ) {
+																wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
+												}
+												$t_table = esc_sql( $t_table );
+												// db call ok; no-cache ok.
+												$tours = $wpdb->get_results(
+														$wpdb->prepare( 'SELECT id, title FROM %i ORDER BY title ASC', $t_table )
+												);
+												$tsel = isset( $hunt->tournament_id ) ? (int) $hunt->tournament_id : 0;
+												?>
+						<select id="bhg_tournament" name="tournament_id">
+								<option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
+								<?php foreach ( $tours as $t ) : ?>
+								<option value="<?php echo (int) $t->id; ?>"
+										<?php
+										if ( $tsel === (int) $t->id ) {
+												echo 'selected';
+										}
+										?>
+								><?php echo esc_html( $t->title ); ?></option>
+								<?php endforeach; ?>
+						</select>
+						</td>
+				</tr>
+				<tr>
+						<th scope="row"><label for="bhg_winners"><?php echo esc_html( bhg_t( 'number_of_winners', 'Number of Winners' ) ); ?></label></th>
+						<td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="3"></td>
+				</tr>
+				<tr>
 			<th scope="row"><label for="bhg_status"><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) ); ?></label></th>
 			<td>
 			<select id="bhg_status" name="status">
@@ -315,14 +315,14 @@ if ( $view === 'add' ) :
 if ( $view === 'edit' ) :
 		$id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
 		// db call ok; no-cache ok.
-               $hunt = $wpdb->get_row(
-                       $wpdb->prepare(
-                               'SELECT * FROM %i WHERE id = %d',
-                               $hunts_table,
-                               $id
-                       )
-               );
-        if ( ! $hunt ) {
+			   $hunt = $wpdb->get_row(
+					   $wpdb->prepare(
+							   'SELECT * FROM %i WHERE id = %d',
+							   $hunts_table,
+							   $id
+					   )
+			   );
+		if ( ! $hunt ) {
 		echo '<div class="notice notice-error"><p>' . esc_html( bhg_t( 'invalid_hunt', 'Invalid hunt' ) ) . '</p></div>';
 		return;
 	}
@@ -330,16 +330,16 @@ if ( $view === 'edit' ) :
 	if ( ! in_array( $users_table_local, $allowed_tables, true ) ) {
 			wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
 	}
-       $users_table_local = esc_sql( $users_table_local );
-                                // db call ok; no-cache ok.
-                                                        $guesses = $wpdb->get_results(
-                                                                $wpdb->prepare(
-                                                                        'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
-                                                                        $guesses_table,
-                                                                        $users_table_local,
-                                                                        $id
-                                                                                )
-                                                        );
+	   $users_table_local = esc_sql( $users_table_local );
+								// db call ok; no-cache ok.
+														$guesses = $wpdb->get_results(
+																$wpdb->prepare(
+																		'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
+																		$guesses_table,
+																		$users_table_local,
+																		$id
+																				)
+														);
 	?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html( bhg_t( 'edit_bonus_hunt', 'Edit Bonus Hunt' ) ); ?> <?php echo esc_html( bhg_t( 'label_emdash', '—' ) ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
@@ -393,42 +393,42 @@ if ( $view === 'edit' ) :
 				><?php echo esc_html( $a->name ); ?></option>
 				<?php endforeach; ?>
 			</select>
-                        </td>
-                </tr>
-                <tr>
-                        <th scope="row"><label for="bhg_tournament"><?php echo esc_html( bhg_t( 'tournament', 'Tournament' ) ); ?></label></th>
-                        <td>
-                                                <?php
-                                                $t_table = $wpdb->prefix . 'bhg_tournaments';
-                                                if ( ! in_array( $t_table, $allowed_tables, true ) ) {
-                                                                wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
-                                                }
-                                                $t_table = esc_sql( $t_table );
-                                                // db call ok; no-cache ok.
-                                                $tours = $wpdb->get_results(
-                                                        $wpdb->prepare( 'SELECT id, title FROM %i ORDER BY title ASC', $t_table )
-                                                );
-                                                $tsel = isset( $hunt->tournament_id ) ? (int) $hunt->tournament_id : 0;
-                                                ?>
-                        <select id="bhg_tournament" name="tournament_id">
-                                <option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
-                                <?php foreach ( $tours as $t ) : ?>
-                                <option value="<?php echo (int) $t->id; ?>"
-                                        <?php
-                                        if ( $tsel === (int) $t->id ) {
-                                                echo 'selected';
-                                        }
-                                        ?>
-                                ><?php echo esc_html( $t->title ); ?></option>
-                                <?php endforeach; ?>
-                        </select>
-                        </td>
-                </tr>
-                <tr>
-                        <th scope="row"><label for="bhg_winners"><?php echo esc_html( bhg_t( 'number_of_winners', 'Number of Winners' ) ); ?></label></th>
-                        <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ?: 3 ); ?>"></td>
-                </tr>
-                <tr>
+						</td>
+				</tr>
+				<tr>
+						<th scope="row"><label for="bhg_tournament"><?php echo esc_html( bhg_t( 'tournament', 'Tournament' ) ); ?></label></th>
+						<td>
+												<?php
+												$t_table = $wpdb->prefix . 'bhg_tournaments';
+												if ( ! in_array( $t_table, $allowed_tables, true ) ) {
+																wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
+												}
+												$t_table = esc_sql( $t_table );
+												// db call ok; no-cache ok.
+												$tours = $wpdb->get_results(
+														$wpdb->prepare( 'SELECT id, title FROM %i ORDER BY title ASC', $t_table )
+												);
+												$tsel = isset( $hunt->tournament_id ) ? (int) $hunt->tournament_id : 0;
+												?>
+						<select id="bhg_tournament" name="tournament_id">
+								<option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
+								<?php foreach ( $tours as $t ) : ?>
+								<option value="<?php echo (int) $t->id; ?>"
+										<?php
+										if ( $tsel === (int) $t->id ) {
+												echo 'selected';
+										}
+										?>
+								><?php echo esc_html( $t->title ); ?></option>
+								<?php endforeach; ?>
+						</select>
+						</td>
+				</tr>
+				<tr>
+						<th scope="row"><label for="bhg_winners"><?php echo esc_html( bhg_t( 'number_of_winners', 'Number of Winners' ) ); ?></label></th>
+						<td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ?: 3 ); ?>"></td>
+				</tr>
+				<tr>
 			<th scope="row"><label for="bhg_final"><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></label></th>
 					<td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html( bhg_t( 'label_emdash', '—' ) ) ); ?>"></td>
 		</tr>

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -103,11 +103,11 @@ function bhg_insert_demo_data() {
 	$wpdb->insert(
 		$wpdb->prefix . 'bhg_bonus_hunts',
 		array(
-                       'title'             => 'Demo Bonus Hunt',
-                       'starting_balance'  => 2000,
-                       'num_bonuses'       => 10,
-                       'status'            => 'active',
-                       'created_at'        => current_time( 'mysql' ),
+					   'title'             => 'Demo Bonus Hunt',
+					   'starting_balance'  => 2000,
+					   'num_bonuses'       => 10,
+					   'status'            => 'active',
+					   'created_at'        => current_time( 'mysql' ),
 		),
 		array( '%s', '%d', '%d', '%s', '%s' )
 	);

--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -327,9 +327,9 @@ if ( isset( $_GET['message'] ) ) {
 							</td>
 							<td><?php echo esc_html( $hunt->num_bonuses ); ?></td>
 							<td>
-                                                            <span class="bhg-status bhg-status-<?php echo esc_attr( $hunt->status ); ?>">
-                                                                    <?php echo esc_html( bhg_t( strtolower( (string) $hunt->status ), ucfirst( $hunt->status ) ) ); ?>
-                                                            </span>
+															<span class="bhg-status bhg-status-<?php echo esc_attr( $hunt->status ); ?>">
+																	<?php echo esc_html( bhg_t( strtolower( (string) $hunt->status ), ucfirst( $hunt->status ) ) ); ?>
+															</span>
 							</td>
 							<td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $hunt->created_at ) ) ); ?></td>
 							<td>

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -6,11 +6,11 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-        exit;
+		exit;
 }
 
 if ( ! current_user_can( 'manage_options' ) ) {
-        wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
+		wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
 }
 
 global $wpdb;
@@ -21,15 +21,15 @@ $per_page = 20;
 $offset   = ( $paged - 1 ) * $per_page;
 
 $rows  = $wpdb->get_results(
-        $wpdb->prepare(
-                'SELECT id, title, start_balance, final_balance, status, winners_count, closed_at FROM %i ORDER BY id DESC LIMIT %d OFFSET %d',
-                $t,
-                $per_page,
-                $offset
-        )
+		$wpdb->prepare(
+				'SELECT id, title, start_balance, final_balance, status, winners_count, closed_at FROM %i ORDER BY id DESC LIMIT %d OFFSET %d',
+				$t,
+				$per_page,
+				$offset
+		)
 );
 $total = (int) $wpdb->get_var(
-        $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $t )
+		$wpdb->prepare( 'SELECT COUNT(*) FROM %i', $t )
 );
 $pages = max( 1, (int) ceil( $total / $per_page ) );
 
@@ -95,8 +95,8 @@ $pages = max( 1, (int) ceil( $total / $per_page ) );
 			<td><strong><a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-hunts-edit&id=' . (int) $r->id ) ); ?>"><?php echo esc_html( $r->title ); ?></a></strong></td>
 			<td><?php echo esc_html( number_format_i18n( (float) $r->start_balance, 2 ) ); ?></td>
 					<td><?php echo ( $r->final_balance !== null ) ? esc_html( number_format_i18n( (float) $r->final_balance, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
-                       <td><?php echo esc_html( bhg_t( $r->status, ucfirst( $r->status ) ) ); ?></td>
-                        <td><?php echo (int) $r->winners_count; ?></td>
+					   <td><?php echo esc_html( bhg_t( $r->status, ucfirst( $r->status ) ) ); ?></td>
+						<td><?php echo (int) $r->winners_count; ?></td>
 					<td><?php echo $r->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->closed_at ) ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
 			<td>
 							<?php

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -96,7 +96,7 @@ $labels = array(
 			<td><?php echo esc_html( $labels[ $r->type ] ?? $r->type ); ?></td>
 			<td><?php echo esc_html( $r->start_date ); ?></td>
 			<td><?php echo esc_html( $r->end_date ); ?></td>
-                       <td><?php echo esc_html( bhg_t( $r->status, ucfirst( $r->status ) ) ); ?></td>
+					   <td><?php echo esc_html( bhg_t( $r->status, ucfirst( $r->status ) ) ); ?></td>
 			<td>
 			<a class="button" href="<?php echo esc_url( add_query_arg( array( 'edit' => (int) $r->id ) ) ); ?>">
 				<?php

--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -37,89 +37,89 @@ $search_term = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s']
 
 // Handle form submission.
 if ( isset( $_POST['bhg_save_translation'] ) && check_admin_referer( 'bhg_save_translation_action', 'bhg_nonce' ) ) {
-       $slug   = isset( $_POST['slug'] ) ? sanitize_text_field( wp_unslash( $_POST['slug'] ) ) : '';
-       $locale = isset( $_POST['locale'] ) ? sanitize_text_field( wp_unslash( $_POST['locale'] ) ) : get_locale();
-       $text   = isset( $_POST['text'] ) ? sanitize_textarea_field( wp_unslash( $_POST['text'] ) ) : '';
+	   $slug   = isset( $_POST['slug'] ) ? sanitize_text_field( wp_unslash( $_POST['slug'] ) ) : '';
+	   $locale = isset( $_POST['locale'] ) ? sanitize_text_field( wp_unslash( $_POST['locale'] ) ) : get_locale();
+	   $text   = isset( $_POST['text'] ) ? sanitize_textarea_field( wp_unslash( $_POST['text'] ) ) : '';
 
-       if ( '' === $slug ) {
-               $form_error = bhg_t( 'key_field_is_required', 'Key field is required.' );
-       } else {
-               $exists = (int) $wpdb->get_var(
-                       $wpdb->prepare(
-                               'SELECT COUNT(*) FROM %i WHERE slug = %s AND locale = %s',
-                               $table,
-                               $slug,
-                               $locale
-                       )
-               );
+	   if ( '' === $slug ) {
+			   $form_error = bhg_t( 'key_field_is_required', 'Key field is required.' );
+	   } else {
+			   $exists = (int) $wpdb->get_var(
+					   $wpdb->prepare(
+							   'SELECT COUNT(*) FROM %i WHERE slug = %s AND locale = %s',
+							   $table,
+							   $slug,
+							   $locale
+					   )
+			   );
 
-               if ( $exists ) {
-                       $wpdb->update(
-                               $table,
-                               array( 'text' => $text ),
-                               array(
-                                       'slug'   => $slug,
-                                       'locale' => $locale,
-                               ),
-                               array( '%s' ),
-                               array( '%s', '%s' )
-                       );
-               } else {
-                       $wpdb->insert(
-                               $table,
-                               array(
-                                       'slug'   => $slug,
-                                       'text'   => $text,
-                                       'locale' => $locale,
-                               ),
-                               array( '%s', '%s', '%s' )
-                       );
-               }
+			   if ( $exists ) {
+					   $wpdb->update(
+							   $table,
+							   array( 'text' => $text ),
+							   array(
+									   'slug'   => $slug,
+									   'locale' => $locale,
+							   ),
+							   array( '%s' ),
+							   array( '%s', '%s' )
+					   );
+			   } else {
+					   $wpdb->insert(
+							   $table,
+							   array(
+									   'slug'   => $slug,
+									   'text'   => $text,
+									   'locale' => $locale,
+							   ),
+							   array( '%s', '%s', '%s' )
+					   );
+			   }
 
-               // Invalidate cached value so updates appear immediately.
-               wp_cache_delete( 'bhg_t_' . $slug . '_' . $locale );
-               $notice = bhg_t( 'translation_saved', 'Translation saved.' );
-       }
+			   // Invalidate cached value so updates appear immediately.
+			   wp_cache_delete( 'bhg_t_' . $slug . '_' . $locale );
+			   $notice = bhg_t( 'translation_saved', 'Translation saved.' );
+	   }
 }
 
 // Fetch rows with pagination and optional search.
 if ( $search_term ) {
-        $like  = '%' . $wpdb->esc_like( $search_term ) . '%';
-        $total = (int) $wpdb->get_var(
-                $wpdb->prepare(
-                        'SELECT COUNT(*) FROM %i WHERE slug LIKE %s OR text LIKE %s OR default_text LIKE %s',
-                        $table,
-                        $like,
-                        $like,
-                        $like
-                )
-        );
-       $rows = $wpdb->get_results(
-               $wpdb->prepare(
-                       'SELECT slug, default_text, text, locale FROM %i WHERE slug LIKE %s OR text LIKE %s OR default_text LIKE %s ORDER BY slug ASC LIMIT %d OFFSET %d',
-                       $table,
-                       $like,
-                       $like,
-                       $like,
-                       $items_per_page,
-                       $offset
-               )
-       );
+		$like  = '%' . $wpdb->esc_like( $search_term ) . '%';
+		$total = (int) $wpdb->get_var(
+				$wpdb->prepare(
+						'SELECT COUNT(*) FROM %i WHERE slug LIKE %s OR text LIKE %s OR default_text LIKE %s',
+						$table,
+						$like,
+						$like,
+						$like
+				)
+		);
+	   $rows = $wpdb->get_results(
+			   $wpdb->prepare(
+					   'SELECT slug, default_text, text, locale FROM %i WHERE slug LIKE %s OR text LIKE %s OR default_text LIKE %s ORDER BY slug ASC LIMIT %d OFFSET %d',
+					   $table,
+					   $like,
+					   $like,
+					   $like,
+					   $items_per_page,
+					   $offset
+			   )
+	   );
 } else {
-        $total = (int) $wpdb->get_var(
-                $wpdb->prepare(
-                        'SELECT COUNT(*) FROM %i',
-                        $table
-                )
-        );
-       $rows  = $wpdb->get_results(
-               $wpdb->prepare(
-                       'SELECT slug, default_text, text, locale FROM %i ORDER BY slug ASC LIMIT %d OFFSET %d',
-                       $table,
-                       $items_per_page,
-                       $offset
-               )
-       );
+		$total = (int) $wpdb->get_var(
+				$wpdb->prepare(
+						'SELECT COUNT(*) FROM %i',
+						$table
+				)
+		);
+	   $rows  = $wpdb->get_results(
+			   $wpdb->prepare(
+					   'SELECT slug, default_text, text, locale FROM %i ORDER BY slug ASC LIMIT %d OFFSET %d',
+					   $table,
+					   $items_per_page,
+					   $offset
+			   )
+	   );
 }
 
 // Pagination links.
@@ -140,16 +140,16 @@ $pagination  = paginate_links(
 // Group rows by context (prefix before the first underscore).
 $grouped = array();
 if ( $rows ) {
-        foreach ( $rows as $r ) {
-                list( $context )       = array_pad( explode( '_', $r->slug, 2 ), 2, 'misc' );
-                $grouped[ $context ][] = $r;
-        }
+		foreach ( $rows as $r ) {
+				list( $context )       = array_pad( explode( '_', $r->slug, 2 ), 2, 'misc' );
+				$grouped[ $context ][] = $r;
+		}
 	ksort( $grouped );
 	foreach ( $grouped as &$items ) {
 		usort(
 			$items,
 			static function ( $a, $b ) {
-                                return strcmp( $a->slug, $b->slug );
+								return strcmp( $a->slug, $b->slug );
 			}
 		);
 	}
@@ -167,23 +167,23 @@ if ( $rows ) {
 		<div class="notice notice-error"><p><?php echo esc_html( $form_error ); ?></p></div>
 	<?php endif; ?>
 
-       <form method="post">
-               <?php wp_nonce_field( 'bhg_save_translation_action', 'bhg_nonce' ); ?>
-               <input type="hidden" name="locale" value="<?php echo esc_attr( get_locale() ); ?>" />
-               <table class="form-table" role="presentation">
-                       <tbody>
-                               <tr>
-                                       <th scope="row"><label for="slug"><?php echo esc_html( bhg_t( 'slug', 'Slug' ) ); ?></label></th>
-                                       <td><input name="slug" id="slug" type="text" class="regular-text" required></td>
-                               </tr>
-                               <tr>
-                                       <th scope="row"><label for="text"><?php echo esc_html( bhg_t( 'value', 'Value' ) ); ?></label></th>
-                                       <td><textarea name="text" id="text" class="large-text" rows="4"></textarea></td>
-                               </tr>
-                       </tbody>
-               </table>
-               <p class="submit"><button type="submit" name="bhg_save_translation" class="button button-primary"><?php echo esc_html( bhg_t( 'button_save', 'Save' ) ); ?></button></p>
-       </form>
+	   <form method="post">
+			   <?php wp_nonce_field( 'bhg_save_translation_action', 'bhg_nonce' ); ?>
+			   <input type="hidden" name="locale" value="<?php echo esc_attr( get_locale() ); ?>" />
+			   <table class="form-table" role="presentation">
+					   <tbody>
+							   <tr>
+									   <th scope="row"><label for="slug"><?php echo esc_html( bhg_t( 'slug', 'Slug' ) ); ?></label></th>
+									   <td><input name="slug" id="slug" type="text" class="regular-text" required></td>
+							   </tr>
+							   <tr>
+									   <th scope="row"><label for="text"><?php echo esc_html( bhg_t( 'value', 'Value' ) ); ?></label></th>
+									   <td><textarea name="text" id="text" class="large-text" rows="4"></textarea></td>
+							   </tr>
+					   </tbody>
+			   </table>
+			   <p class="submit"><button type="submit" name="bhg_save_translation" class="button button-primary"><?php echo esc_html( bhg_t( 'button_save', 'Save' ) ); ?></button></p>
+	   </form>
 
 	<form method="get" class="bhg-translations-search">
 		<input type="hidden" name="page" value="bhg-translations" />
@@ -201,7 +201,7 @@ if ( $rows ) {
 	</form>
 
 	<h2><?php echo esc_html( bhg_t( 'existing_keys', 'Existing keys' ) ); ?></h2>
-        <p class="description"><?php echo esc_html( bhg_t( 'custom_translations_highlighted', 'Custom translations are highlighted.' ) ); ?></p>
+		<p class="description"><?php echo esc_html( bhg_t( 'custom_translations_highlighted', 'Custom translations are highlighted.' ) ); ?></p>
 	<?php if ( $pagination ) : ?>
 		<div class="tablenav"><div class="tablenav-pages"><?php echo wp_kses_post( $pagination ); ?></div></div>
 	<?php endif; ?>
@@ -220,23 +220,23 @@ if ( $rows ) {
 					</thead>
 					<tbody>
 						<?php
-                                               foreach ( $items as $r ) :
-                                                       $row_class = ( '' === $r->text || $r->text === $r->default_text ) ? 'bhg-default-row' : 'bhg-custom-row';
-                                                       ?>
-                                                       <tr class="<?php echo esc_attr( $row_class ); ?>">
-                                                               <td><code><?php echo esc_html( $r->slug ); ?></code></td>
-                                                               <td><?php echo esc_html( $r->default_text ); ?></td>
-                                                               <td>
-                                                                       <form method="post" class="bhg-inline-form">
-                                                                               <?php wp_nonce_field( 'bhg_save_translation_action', 'bhg_nonce' ); ?>
-                                                                               <input type="hidden" name="slug" value="<?php echo esc_attr( $r->slug ); ?>" />
-                                                                               <input type="hidden" name="locale" value="<?php echo esc_attr( $r->locale ); ?>" />
-                                                                               <input type="text" name="text" value="<?php echo esc_attr( $r->text ); ?>" class="regular-text" data-original="<?php echo esc_attr( $r->text ); ?>" placeholder="<?php echo esc_attr( bhg_t( 'placeholder_custom_value', 'Custom value' ) ); ?>" />
-                                                                               <button type="submit" name="bhg_save_translation" class="button button-primary"><?php echo esc_html( bhg_t( 'button_update', 'Update' ) ); ?></button>
-                                                                       </form>
-                                                               </td>
-                                                       </tr>
-                                               <?php endforeach; ?>
+											   foreach ( $items as $r ) :
+													   $row_class = ( '' === $r->text || $r->text === $r->default_text ) ? 'bhg-default-row' : 'bhg-custom-row';
+													   ?>
+													   <tr class="<?php echo esc_attr( $row_class ); ?>">
+															   <td><code><?php echo esc_html( $r->slug ); ?></code></td>
+															   <td><?php echo esc_html( $r->default_text ); ?></td>
+															   <td>
+																	   <form method="post" class="bhg-inline-form">
+																			   <?php wp_nonce_field( 'bhg_save_translation_action', 'bhg_nonce' ); ?>
+																			   <input type="hidden" name="slug" value="<?php echo esc_attr( $r->slug ); ?>" />
+																			   <input type="hidden" name="locale" value="<?php echo esc_attr( $r->locale ); ?>" />
+																			   <input type="text" name="text" value="<?php echo esc_attr( $r->text ); ?>" class="regular-text" data-original="<?php echo esc_attr( $r->text ); ?>" placeholder="<?php echo esc_attr( bhg_t( 'placeholder_custom_value', 'Custom value' ) ); ?>" />
+																			   <button type="submit" name="bhg_save_translation" class="button button-primary"><?php echo esc_html( bhg_t( 'button_update', 'Update' ) ); ?></button>
+																	   </form>
+															   </td>
+													   </tr>
+											   <?php endforeach; ?>
 					</tbody>
 				</table>
 			</div>
@@ -268,12 +268,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
 <style>
 .bhg-modified-row {
-        background-color: #fff3cd;
-        border-left: 4px solid #d97706;
+		background-color: #fff3cd;
+		border-left: 4px solid #d97706;
 }
 .bhg-custom-row {
-        background-color: #e6ffed;
-        border-left: 4px solid #2f855a;
+		background-color: #e6ffed;
+		border-left: 4px solid #2f855a;
 }
 </style>
 

--- a/includes/class-bhg-bonus-hunts.php
+++ b/includes/class-bhg-bonus-hunts.php
@@ -19,39 +19,39 @@ class BHG_Bonus_Hunts {
 		$guesses_table = $wpdb->prefix . 'bhg_guesses';
 		$limit         = max( 1, (int) $limit );
 
-                $hunts = $wpdb->get_results(
-                        $wpdb->prepare(
-                                "SELECT id, title, starting_balance, final_balance, winners_count, closed_at
-                                        FROM %i
-                                        WHERE status = %s AND final_balance IS NOT NULL AND closed_at IS NOT NULL
-                                        ORDER BY closed_at DESC
-                                        LIMIT %d",
-                                $hunts_table,
-                                'closed',
-                                $limit
-                        )
-                );
+				$hunts = $wpdb->get_results(
+						$wpdb->prepare(
+								"SELECT id, title, starting_balance, final_balance, winners_count, closed_at
+										FROM %i
+										WHERE status = %s AND final_balance IS NOT NULL AND closed_at IS NOT NULL
+										ORDER BY closed_at DESC
+										LIMIT %d",
+								$hunts_table,
+								'closed',
+								$limit
+						)
+				);
 
 		$out = array();
 
 		foreach ( (array) $hunts as $h ) {
 			$winners_count = max( 1, (int) $h->winners_count );
-                        $winners       = $wpdb->get_results(
-                                $wpdb->prepare(
-                                        "SELECT g.user_id, u.display_name, g.guess,
-                                                        ABS(g.guess - %f) AS diff
-                                                FROM %i g
-                                                LEFT JOIN %i u ON u.ID = g.user_id
-                                                WHERE g.hunt_id = %d
-                                                ORDER BY diff ASC, g.id ASC
-                                                LIMIT %d",
-                                        $h->final_balance,
-                                        $guesses_table,
-                                        $wpdb->users,
-                                        $h->id,
-                                        $winners_count
-                                )
-                        );
+						$winners       = $wpdb->get_results(
+								$wpdb->prepare(
+										"SELECT g.user_id, u.display_name, g.guess,
+														ABS(g.guess - %f) AS diff
+												FROM %i g
+												LEFT JOIN %i u ON u.ID = g.user_id
+												WHERE g.hunt_id = %d
+												ORDER BY diff ASC, g.id ASC
+												LIMIT %d",
+										$h->final_balance,
+										$guesses_table,
+										$wpdb->users,
+										$h->id,
+										$winners_count
+								)
+						);
 
 			$out[] = array(
 				'hunt'    => $h,
@@ -72,13 +72,13 @@ class BHG_Bonus_Hunts {
 		global $wpdb;
 		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
 
-                return $wpdb->get_row(
-                        $wpdb->prepare(
-                                'SELECT * FROM %i WHERE id=%d',
-                                $hunts_table,
-                                (int) $hunt_id
-                        )
-                );
+				return $wpdb->get_row(
+						$wpdb->prepare(
+								'SELECT * FROM %i WHERE id=%d',
+								$hunts_table,
+								(int) $hunt_id
+						)
+				);
 	}
 
 	/**
@@ -97,32 +97,32 @@ class BHG_Bonus_Hunts {
 			return array(); }
 
 		if ( null !== $hunt->final_balance ) {
-                        return $wpdb->get_results(
-                                $wpdb->prepare(
-                                        "SELECT g.*, u.display_name, ABS(g.guess - %f) AS diff
-                                                FROM %i g
-                                                LEFT JOIN %i u ON u.ID = g.user_id
-                                                WHERE g.hunt_id = %d
-                                                ORDER BY diff ASC, g.id ASC",
-                                        $hunt->final_balance,
-                                        $guesses_table,
-                                        $wpdb->users,
-                                        $hunt_id
-                                )
-                        );
+						return $wpdb->get_results(
+								$wpdb->prepare(
+										"SELECT g.*, u.display_name, ABS(g.guess - %f) AS diff
+												FROM %i g
+												LEFT JOIN %i u ON u.ID = g.user_id
+												WHERE g.hunt_id = %d
+												ORDER BY diff ASC, g.id ASC",
+										$hunt->final_balance,
+										$guesses_table,
+										$wpdb->users,
+										$hunt_id
+								)
+						);
 		}
 
-                return $wpdb->get_results(
-                        $wpdb->prepare(
-                                "SELECT g.*, u.display_name, NULL AS diff
-                                        FROM %i g
-                                        LEFT JOIN %i u ON u.ID = g.user_id
-                                        WHERE g.hunt_id = %d
-                                        ORDER BY g.id ASC",
-                                $guesses_table,
-                                $wpdb->users,
-                                $hunt_id
-                        )
-                );
+				return $wpdb->get_results(
+						$wpdb->prepare(
+								"SELECT g.*, u.display_name, NULL AS diff
+										FROM %i g
+										LEFT JOIN %i u ON u.ID = g.user_id
+										WHERE g.hunt_id = %d
+										ORDER BY g.id ASC",
+								$guesses_table,
+								$wpdb->users,
+								$hunt_id
+						)
+				);
 	}
 }

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -47,18 +47,18 @@ class BHG_DB {
 			starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
 			num_bonuses INT UNSIGNED NOT NULL DEFAULT 0,
 			prizes TEXT NULL,
-                        affiliate_site_id BIGINT UNSIGNED NULL,
-                        tournament_id BIGINT UNSIGNED NULL,
-                        winners_count INT UNSIGNED NOT NULL DEFAULT 3,
-                        final_balance DECIMAL(12,2) NULL,
-                        status VARCHAR(20) NOT NULL DEFAULT 'open',
-                        created_at DATETIME NULL,
-                        updated_at DATETIME NULL,
-                        closed_at DATETIME NULL,
-                        PRIMARY KEY  (id),
-                        KEY status (status),
-                        KEY tournament_id (tournament_id)
-                ) {$charset_collate};";
+						affiliate_site_id BIGINT UNSIGNED NULL,
+						tournament_id BIGINT UNSIGNED NULL,
+						winners_count INT UNSIGNED NOT NULL DEFAULT 3,
+						final_balance DECIMAL(12,2) NULL,
+						status VARCHAR(20) NOT NULL DEFAULT 'open',
+						created_at DATETIME NULL,
+						updated_at DATETIME NULL,
+						closed_at DATETIME NULL,
+						PRIMARY KEY  (id),
+						KEY status (status),
+						KEY tournament_id (tournament_id)
+				) {$charset_collate};";
 
 		// Guesses
 		$sql[] = "CREATE TABLE {$guesses_table} (
@@ -119,56 +119,56 @@ class BHG_DB {
 
 				// Affiliate Websites
 				$sql[] = "CREATE TABLE {$aff_websites_table} (
-                       id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-                       name VARCHAR(190) NOT NULL,
-                       slug VARCHAR(190) NOT NULL,
-                       url VARCHAR(255) NULL,
-                       status VARCHAR(20) NOT NULL DEFAULT 'active',
-                       created_at DATETIME NULL,
-                       updated_at DATETIME NULL,
-                       PRIMARY KEY  (id),
-                       UNIQUE KEY slug_unique (slug)
-               ) {$charset_collate};";
+					   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+					   name VARCHAR(190) NOT NULL,
+					   slug VARCHAR(190) NOT NULL,
+					   url VARCHAR(255) NULL,
+					   status VARCHAR(20) NOT NULL DEFAULT 'active',
+					   created_at DATETIME NULL,
+					   updated_at DATETIME NULL,
+					   PRIMARY KEY  (id),
+					   UNIQUE KEY slug_unique (slug)
+			   ) {$charset_collate};";
 
 				// Hunt Winners
 				$sql[] = "CREATE TABLE {$winners_table} (
-                       id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-                       hunt_id BIGINT UNSIGNED NOT NULL,
-                       user_id BIGINT UNSIGNED NOT NULL,
-                       position INT UNSIGNED NOT NULL,
-                       guess DECIMAL(12,2) NOT NULL,
-                       diff DECIMAL(12,2) NOT NULL,
-                       created_at DATETIME NULL,
-                       PRIMARY KEY  (id),
-                       KEY hunt_id (hunt_id),
-                       KEY user_id (user_id)
-               ) {$charset_collate};";
+					   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+					   hunt_id BIGINT UNSIGNED NOT NULL,
+					   user_id BIGINT UNSIGNED NOT NULL,
+					   position INT UNSIGNED NOT NULL,
+					   guess DECIMAL(12,2) NOT NULL,
+					   diff DECIMAL(12,2) NOT NULL,
+					   created_at DATETIME NULL,
+					   PRIMARY KEY  (id),
+					   KEY hunt_id (hunt_id),
+					   KEY user_id (user_id)
+			   ) {$charset_collate};";
 
-               foreach ( $sql as $statement ) {
-                       dbDelta( $statement );
-               }
+			   foreach ( $sql as $statement ) {
+					   dbDelta( $statement );
+			   }
 
-               // Translations table handled separately.
-               $this->create_table_translations();
+			   // Translations table handled separately.
+			   $this->create_table_translations();
 
 		// Idempotent ensure for columns/indexes
 		try {
-                        // Hunts: winners_count, affiliate_site_id, tournament_id
-                        $need = array(
-                                'winners_count'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN winners_count INT UNSIGNED NOT NULL DEFAULT 3",
-                                'affiliate_site_id' => "ALTER TABLE `{$hunts_table}` ADD COLUMN affiliate_site_id BIGINT UNSIGNED NULL",
-                                'tournament_id'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN tournament_id BIGINT UNSIGNED NULL",
-                                'final_balance'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN final_balance DECIMAL(12,2) NULL",
-                                'status'            => "ALTER TABLE `{$hunts_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'",
-                        );
-                        foreach ( $need as $c => $alter ) {
-                                if ( ! $this->column_exists( $hunts_table, $c ) ) {
-                                        $wpdb->query( $alter );
-                                }
-                        }
-                        if ( ! $this->index_exists( $hunts_table, 'tournament_id' ) ) {
-                                $wpdb->query( "ALTER TABLE `{$hunts_table}` ADD KEY tournament_id (tournament_id)" );
-                        }
+						// Hunts: winners_count, affiliate_site_id, tournament_id
+						$need = array(
+								'winners_count'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN winners_count INT UNSIGNED NOT NULL DEFAULT 3",
+								'affiliate_site_id' => "ALTER TABLE `{$hunts_table}` ADD COLUMN affiliate_site_id BIGINT UNSIGNED NULL",
+								'tournament_id'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN tournament_id BIGINT UNSIGNED NULL",
+								'final_balance'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN final_balance DECIMAL(12,2) NULL",
+								'status'            => "ALTER TABLE `{$hunts_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'",
+						);
+						foreach ( $need as $c => $alter ) {
+								if ( ! $this->column_exists( $hunts_table, $c ) ) {
+										$wpdb->query( $alter );
+								}
+						}
+						if ( ! $this->index_exists( $hunts_table, 'tournament_id' ) ) {
+								$wpdb->query( "ALTER TABLE `{$hunts_table}` ADD KEY tournament_id (tournament_id)" );
+						}
 
 			// Tournaments: make sure common columns exist
 			$tneed = array(
@@ -222,34 +222,34 @@ class BHG_DB {
 							}
 						}
 
-                                               // Translations columns
-                                               $trneed = array(
-                                                       'slug'         => "ALTER TABLE `{$trans_table}` ADD COLUMN slug VARCHAR(191) NOT NULL",
-                                                       'default_text' => "ALTER TABLE `{$trans_table}` ADD COLUMN default_text LONGTEXT NOT NULL",
-                                                       'text'         => "ALTER TABLE `{$trans_table}` ADD COLUMN `text` LONGTEXT NULL",
-                                                       'locale'       => "ALTER TABLE `{$trans_table}` ADD COLUMN locale VARCHAR(20) NOT NULL",
-                                                       'created_at'   => "ALTER TABLE `{$trans_table}` ADD COLUMN created_at DATETIME NULL",
-                                                       'updated_at'   => "ALTER TABLE `{$trans_table}` ADD COLUMN updated_at DATETIME NULL",
-                                               );
-                                               foreach ( $trneed as $c => $alter ) {
-                                                       if ( ! $this->column_exists( $trans_table, $c ) ) {
-                                                               $wpdb->query( $alter );
-                                                       }
-                                               }
-                                               // Ensure composite unique index on (slug, locale).
-                                               // Drop legacy single-column indexes if present first.
-                                              if ( $this->index_exists( $trans_table, 'slug' ) ) {
-                                                      $wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX slug" );
-                                              }
-                                              if ( $this->index_exists( $trans_table, 'slug_unique' ) ) {
-                                                      $wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX slug_unique" );
-                                              }
-                                              if ( $this->index_exists( $trans_table, 'tkey_locale' ) ) {
-                                                      $wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX tkey_locale" );
-                                              }
-                                              if ( ! $this->index_exists( $trans_table, 'slug_locale' ) ) {
-                                                      $wpdb->query( "ALTER TABLE `{$trans_table}` ADD UNIQUE KEY slug_locale (slug, locale)" );
-                                              }
+											   // Translations columns
+											   $trneed = array(
+													   'slug'         => "ALTER TABLE `{$trans_table}` ADD COLUMN slug VARCHAR(191) NOT NULL",
+													   'default_text' => "ALTER TABLE `{$trans_table}` ADD COLUMN default_text LONGTEXT NOT NULL",
+													   'text'         => "ALTER TABLE `{$trans_table}` ADD COLUMN `text` LONGTEXT NULL",
+													   'locale'       => "ALTER TABLE `{$trans_table}` ADD COLUMN locale VARCHAR(20) NOT NULL",
+													   'created_at'   => "ALTER TABLE `{$trans_table}` ADD COLUMN created_at DATETIME NULL",
+													   'updated_at'   => "ALTER TABLE `{$trans_table}` ADD COLUMN updated_at DATETIME NULL",
+											   );
+											   foreach ( $trneed as $c => $alter ) {
+													   if ( ! $this->column_exists( $trans_table, $c ) ) {
+															   $wpdb->query( $alter );
+													   }
+											   }
+											   // Ensure composite unique index on (slug, locale).
+											   // Drop legacy single-column indexes if present first.
+											  if ( $this->index_exists( $trans_table, 'slug' ) ) {
+													  $wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX slug" );
+											  }
+											  if ( $this->index_exists( $trans_table, 'slug_unique' ) ) {
+													  $wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX slug_unique" );
+											  }
+											  if ( $this->index_exists( $trans_table, 'tkey_locale' ) ) {
+													  $wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX tkey_locale" );
+											  }
+											  if ( ! $this->index_exists( $trans_table, 'slug_locale' ) ) {
+													  $wpdb->query( "ALTER TABLE `{$trans_table}` ADD UNIQUE KEY slug_locale (slug, locale)" );
+											  }
 
 												// Affiliate websites columns / unique index
 												$afw_need = array(
@@ -289,38 +289,38 @@ class BHG_DB {
 												if ( ! $this->index_exists( $winners_table, 'user_id' ) ) {
 														$wpdb->query( "ALTER TABLE `{$winners_table}` ADD KEY user_id (user_id)" );
 												}
-               } catch ( Throwable $e ) {
-                       if ( function_exists( 'error_log' ) ) {
-                                               error_log( '[BHG] Schema ensure error: ' . $e->getMessage() );
-                       }
-               }
-       }
+			   } catch ( Throwable $e ) {
+					   if ( function_exists( 'error_log' ) ) {
+											   error_log( '[BHG] Schema ensure error: ' . $e->getMessage() );
+					   }
+			   }
+	   }
 
-       /**
-        * Create or update the translations table.
-        *
-        * @return void
-        */
-       private function create_table_translations() {
-               global $wpdb;
+	   /**
+		* Create or update the translations table.
+		*
+		* @return void
+		*/
+	   private function create_table_translations() {
+			   global $wpdb;
 
-               $table           = $wpdb->prefix . 'bhg_translations';
-               $charset_collate = $wpdb->get_charset_collate();
+			   $table           = $wpdb->prefix . 'bhg_translations';
+			   $charset_collate = $wpdb->get_charset_collate();
 
-               $sql = "CREATE TABLE {$table} (
-                       id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-                       slug VARCHAR(191) NOT NULL,
-                       default_text LONGTEXT NOT NULL,
-                       text LONGTEXT NULL,
-                       locale VARCHAR(20) NOT NULL,
-                       created_at DATETIME NULL,
-                       updated_at DATETIME NULL,
-                       PRIMARY KEY  (id),
-                       UNIQUE KEY slug_locale (slug, locale)
-               ) {$charset_collate};";
+			   $sql = "CREATE TABLE {$table} (
+					   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+					   slug VARCHAR(191) NOT NULL,
+					   default_text LONGTEXT NOT NULL,
+					   text LONGTEXT NULL,
+					   locale VARCHAR(20) NOT NULL,
+					   created_at DATETIME NULL,
+					   updated_at DATETIME NULL,
+					   PRIMARY KEY  (id),
+					   UNIQUE KEY slug_locale (slug, locale)
+			   ) {$charset_collate};";
 
-               dbDelta( $sql );
-       }
+			   dbDelta( $sql );
+	   }
 
 		/**
 		 * Retrieve all affiliate websites.

--- a/includes/class-bhg-front-menus.php
+++ b/includes/class-bhg-front-menus.php
@@ -29,13 +29,13 @@ class BHG_Front_Menus {
 	 * @return void
 	 */
 	public function register_locations() {
-               register_nav_menus(
-                       array(
-                               'bhg_menu_admin' => bhg_t( 'bhg_menu_admin', 'BHG Menu — Admin/Moderators' ),
-                               'bhg_menu_user'  => bhg_t( 'bhg_menu_loggedin', 'BHG Menu — Logged-in Users' ),
-                               'bhg_menu_guest' => bhg_t( 'bhg_menu_guests', 'BHG Menu — Guests' ),
-                       )
-               );
+			   register_nav_menus(
+					   array(
+							   'bhg_menu_admin' => bhg_t( 'bhg_menu_admin', 'BHG Menu — Admin/Moderators' ),
+							   'bhg_menu_user'  => bhg_t( 'bhg_menu_loggedin', 'BHG Menu — Logged-in Users' ),
+							   'bhg_menu_guest' => bhg_t( 'bhg_menu_guests', 'BHG Menu — Guests' ),
+					   )
+			   );
 	}
 
 	/**
@@ -96,10 +96,10 @@ class BHG_Front_Menus {
 		);
 		$args     = wp_parse_args( $args, $defaults );
 		$menu     = wp_nav_menu( $args );
-               if ( ! $menu ) {
-                       // Fallback message is escaped.
-                       $menu = '<nav class="bhg-menu"><ul><li>' . esc_html( bhg_t( 'menu_not_assigned', 'Menu not assigned.' ) ) . '</li></ul></nav>';
-               }
+			   if ( ! $menu ) {
+					   // Fallback message is escaped.
+					   $menu = '<nav class="bhg-menu"><ul><li>' . esc_html( bhg_t( 'menu_not_assigned', 'Menu not assigned.' ) ) . '</li></ul></nav>';
+			   }
 		return $menu;
 	}
 

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -63,15 +63,15 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 
 			/** [bhg_active_hunt] — list all open hunts */
 		public function active_hunt_shortcode( $atts ) {
-		       global $wpdb;
-		       $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-		       // db call ok; no-cache ok.
-		       $sql         = $wpdb->prepare(
-			       'SELECT * FROM %i WHERE status = %s ORDER BY created_at DESC',
-			       $hunts_table,
-			       'open'
-		       );
-		       $hunts       = $wpdb->get_results( $sql );
+			   global $wpdb;
+			   $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			   // db call ok; no-cache ok.
+			   $sql         = $wpdb->prepare(
+				   'SELECT * FROM %i WHERE status = %s ORDER BY created_at DESC',
+				   $hunts_table,
+				   'open'
+			   );
+			   $hunts       = $wpdb->get_results( $sql );
 
 			if ( ! $hunts ) {
 				return '<div class="bhg-active-hunt"><p>' . esc_html( bhg_t( 'notice_no_active_hunts', 'No active bonus hunts at the moment.' ) ) . '</p></div>';
@@ -116,15 +116,15 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				. '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html( bhg_t( 'button_log_in', 'Log in' ) ) . '</a></p>';
 			}
 
-				       global $wpdb;
-				       $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-				       // db call ok; no-cache ok.
-				       $sql         = $wpdb->prepare(
-					       'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC',
-					       $hunts_table,
-					       'open'
-				       );
-				       $open_hunts  = $wpdb->get_results( $sql );
+					   global $wpdb;
+					   $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+					   // db call ok; no-cache ok.
+					   $sql         = $wpdb->prepare(
+						   'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC',
+						   $hunts_table,
+						   'open'
+					   );
+					   $open_hunts  = $wpdb->get_results( $sql );
 
 			if ( $hunt_id <= 0 ) {
 				if ( ! $open_hunts ) {
@@ -135,21 +135,21 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				}
 			}
 
-				       $user_id = get_current_user_id();
-				       $table   = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
-				       // db call ok; no-cache ok.
-				       $existing_id = $hunt_id > 0 ? (int) $wpdb->get_var(
-					       $wpdb->prepare(
-						       'SELECT id FROM %i WHERE user_id = %d AND hunt_id = %d',
-						       $table,
-						       $user_id,
-						       $hunt_id
-					       )
-				       ) : 0;
-				       // db call ok; no-cache ok.
-				       $existing_guess = $existing_id ? (float) $wpdb->get_var(
-					       $wpdb->prepare( 'SELECT guess FROM %i WHERE id = %d', $table, $existing_id )
-				       ) : '';
+					   $user_id = get_current_user_id();
+					   $table   = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
+					   // db call ok; no-cache ok.
+					   $existing_id = $hunt_id > 0 ? (int) $wpdb->get_var(
+						   $wpdb->prepare(
+							   'SELECT id FROM %i WHERE user_id = %d AND hunt_id = %d',
+							   $table,
+							   $user_id,
+							   $hunt_id
+						   )
+					   ) : 0;
+					   // db call ok; no-cache ok.
+					   $existing_guess = $existing_id ? (float) $wpdb->get_var(
+						   $wpdb->prepare( 'SELECT guess FROM %i WHERE id = %d', $table, $existing_id )
+					   ) : '';
 
 			$settings = get_option( 'bhg_plugin_settings' );
 			$min      = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
@@ -208,75 +208,75 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			 * Supports ranking (1-10) and fields (comma-separated list).
 			 */
 		public function leaderboard_shortcode( $atts ) {
-                                        $a = shortcode_atts(
-                                                array(
-                                                        'hunt_id' => 0,
-                                                        'orderby' => 'guess', // guess|user|position
-                                                        'order'   => 'ASC',
-                                                        'ranking' => 10, // top N results (1–10)
-                                                        'fields'  => 'position,user,guess',
-                                                ),
-                                                $atts,
-                                                'bhg_leaderboard'
-                                        );
+										$a = shortcode_atts(
+												array(
+														'hunt_id' => 0,
+														'orderby' => 'guess', // guess|user|position
+														'order'   => 'ASC',
+														'ranking' => 10, // top N results (1–10)
+														'fields'  => 'position,user,guess',
+												),
+												$atts,
+												'bhg_leaderboard'
+										);
 
-				       global $wpdb;
-				       $hunt_id = (int) $a['hunt_id'];
-		       if ( $hunt_id <= 0 ) {
-				       $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-				       $sql         = $wpdb->prepare( 'SELECT id FROM %i ORDER BY created_at DESC LIMIT 1', $hunts_table );
-				       $hunt_id     = (int) $wpdb->get_var( $sql ); // db call ok; no-cache ok.
-			       if ( $hunt_id <= 0 ) {
-				       return '<p>' . esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ) . '</p>';
-			       }
-		       }
+					   global $wpdb;
+					   $hunt_id = (int) $a['hunt_id'];
+			   if ( $hunt_id <= 0 ) {
+					   $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+					   $sql         = $wpdb->prepare( 'SELECT id FROM %i ORDER BY created_at DESC LIMIT 1', $hunts_table );
+					   $hunt_id     = (int) $wpdb->get_var( $sql ); // db call ok; no-cache ok.
+				   if ( $hunt_id <= 0 ) {
+					   return '<p>' . esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ) . '</p>';
+				   }
+			   }
 
 			$g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
 			$u = $this->sanitize_table( $wpdb->users );
 
-                        $allowed_orders = array( 'ASC', 'DESC' );
-                        $order          = strtoupper( sanitize_key( $a['order'] ) );
-                        if ( ! in_array( $order, $allowed_orders, true ) ) {
-                                $order = 'ASC';
-                        }
-                        $allowed_orderby = array(
-                                'guess'    => 'g.guess',
-                                'user'     => 'u.user_login',
-                                'position' => 'g.id', // stable proxy
-                        );
-                        $orderby_key = sanitize_key( $a['orderby'] );
-                        if ( ! isset( $allowed_orderby[ $orderby_key ] ) ) {
-                                $orderby_key = 'guess';
-                        }
-                        $orderby = $allowed_orderby[ $orderby_key ];
+						$allowed_orders = array( 'ASC', 'DESC' );
+						$order          = strtoupper( sanitize_key( $a['order'] ) );
+						if ( ! in_array( $order, $allowed_orders, true ) ) {
+								$order = 'ASC';
+						}
+						$allowed_orderby = array(
+								'guess'    => 'g.guess',
+								'user'     => 'u.user_login',
+								'position' => 'g.id', // stable proxy
+						);
+						$orderby_key = sanitize_key( $a['orderby'] );
+						if ( ! isset( $allowed_orderby[ $orderby_key ] ) ) {
+								$orderby_key = 'guess';
+						}
+						$orderby = $allowed_orderby[ $orderby_key ];
 
-                                        $ranking = max( 1, min( 10, (int) $a['ranking'] ) );
+										$ranking = max( 1, min( 10, (int) $a['ranking'] ) );
 
-                                        $fields_raw    = explode( ',', (string) $a['fields'] );
-                                        $allowed_field = array( 'position', 'user', 'guess' );
-                                        $fields        = array_values( array_intersect( $allowed_field, array_map( 'sanitize_key', array_map( 'trim', $fields_raw ) ) ) );
-                                        if ( empty( $fields ) ) {
-                                                        $fields = $allowed_field;
-                                        }
+										$fields_raw    = explode( ',', (string) $a['fields'] );
+										$allowed_field = array( 'position', 'user', 'guess' );
+										$fields        = array_values( array_intersect( $allowed_field, array_map( 'sanitize_key', array_map( 'trim', $fields_raw ) ) ) );
+										if ( empty( $fields ) ) {
+														$fields = $allowed_field;
+										}
 
-                                       $total = (int) $wpdb->get_var(
-                                               $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE hunt_id = %d', $g, $hunt_id )
-                                       ); // db call ok; no-cache ok.
-                        if ( $total < 1 ) {
-                                        return '<p>' . esc_html( bhg_t( 'notice_no_guesses_yet', 'No guesses yet.' ) ) . '</p>';
-                        }
+									   $total = (int) $wpdb->get_var(
+											   $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE hunt_id = %d', $g, $hunt_id )
+									   ); // db call ok; no-cache ok.
+						if ( $total < 1 ) {
+										return '<p>' . esc_html( bhg_t( 'notice_no_guesses_yet', 'No guesses yet.' ) ) . '</p>';
+						}
 
-                                        $hunts_table     = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-                                        $query = $wpdb->prepare(
-                               'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id FROM %i g LEFT JOIN %i u ON u.ID = g.user_id LEFT JOIN %i h ON h.id = g.hunt_id WHERE g.hunt_id = %d',
-                               $g,
-                               $u,
-                               $hunts_table,
-                               $hunt_id
-                       );
-                       $query .= ' ORDER BY ' . $orderby . ' ' . $order; 
-                       $query .= $wpdb->prepare( ' LIMIT %d', $ranking );
-                                                                                                                               $rows   = $wpdb->get_results( $query ); // db call ok; no-cache ok.
+										$hunts_table     = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+										$query = $wpdb->prepare(
+							   'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id FROM %i g LEFT JOIN %i u ON u.ID = g.user_id LEFT JOIN %i h ON h.id = g.hunt_id WHERE g.hunt_id = %d',
+							   $g,
+							   $u,
+							   $hunts_table,
+							   $hunt_id
+					   );
+					   $query .= ' ORDER BY ' . $orderby . ' ' . $order; 
+					   $query .= $wpdb->prepare( ' LIMIT %d', $ranking );
+																															   $rows   = $wpdb->get_results( $query ); // db call ok; no-cache ok.
 
 					wp_enqueue_style(
 						'bhg-shortcodes',
@@ -299,9 +299,9 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			}
 				echo '</tr></thead><tbody>';
 
-                                $pos       = 1;
-                                $need_user = in_array( 'user', $fields, true );
-                        foreach ( $rows as $r ) {
+								$pos       = 1;
+								$need_user = in_array( 'user', $fields, true );
+						foreach ( $rows as $r ) {
 				if ( $need_user ) {
 					$site_id = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
 					$is_aff  = $site_id > 0
@@ -323,12 +323,12 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					}
 				}
 						echo '</tr>';
-                                                ++$pos;
-                        }
-                                echo '</tbody></table>';
+												++$pos;
+						}
+								echo '</tbody></table>';
 
-                                return ob_get_clean();
-                }
+								return ob_get_clean();
+				}
 
 			/**
 			 * [bhg_user_guesses]
@@ -380,12 +380,12 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 						$g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
 						$h = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
 
-		       // Ensure hunts table has created_at column. If missing, attempt migration and fall back.
-		       $has_created_at = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $h, 'created_at' ) );
-		       if ( empty( $has_created_at ) && class_exists( 'BHG_DB' ) ) {
-			       BHG_DB::migrate();
-			       $has_created_at = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $h, 'created_at' ) );
-		       }
+			   // Ensure hunts table has created_at column. If missing, attempt migration and fall back.
+			   $has_created_at = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $h, 'created_at' ) );
+			   if ( empty( $has_created_at ) && class_exists( 'BHG_DB' ) ) {
+				   BHG_DB::migrate();
+				   $has_created_at = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $h, 'created_at' ) );
+			   }
 
 			$where  = array( 'g.user_id = %d' );
 			$params = array( $user_id );
@@ -415,19 +415,19 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				$params[] = $since;
 			}
 					
-                        $allowed_orders = array( 'ASC', 'DESC' );
-                        $order          = strtoupper( sanitize_key( $a['order'] ) );
-                        if ( ! in_array( $order, $allowed_orders, true ) ) {
-                                $order = 'DESC';
-                        }
-                        $orderby_map = array(
-                                'guess' => 'g.guess',
-                                'hunt'  => $has_created_at ? 'h.created_at' : 'h.id',
-                        );
-                        $orderby_key = sanitize_key( $a['orderby'] );
-                        if ( ! isset( $orderby_map[ $orderby_key ] ) ) {
-                                $orderby_key = 'hunt';
-                        }
+						$allowed_orders = array( 'ASC', 'DESC' );
+						$order          = strtoupper( sanitize_key( $a['order'] ) );
+						if ( ! in_array( $order, $allowed_orders, true ) ) {
+								$order = 'DESC';
+						}
+						$orderby_map = array(
+								'guess' => 'g.guess',
+								'hunt'  => $has_created_at ? 'h.created_at' : 'h.id',
+						);
+						$orderby_key = sanitize_key( $a['orderby'] );
+						if ( ! isset( $orderby_map[ $orderby_key ] ) ) {
+								$orderby_key = 'hunt';
+						}
 $orderby = $orderby_map[ $orderby_key ];
 
 $params = array_merge( array( $g, $h ), $params );
@@ -548,20 +548,20 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 				$params[] = $since;
 			}
 
-		       $sql = 'SELECT h.id, h.title, h.starting_balance, h.final_balance, h.status, h.created_at, h.closed_at, a.name AS aff_name FROM %i h LEFT JOIN %i a ON a.id = h.affiliate_site_id';
-		       if ( $where ) {
-			       $sql .= ' WHERE ' . implode( ' AND ', $where );
-		       }
-		       $order_clause = ' ORDER BY h.created_at DESC';
-		       if ( 'recent' === strtolower( $a['timeline'] ) ) {
-			       $order_clause .= ' LIMIT 10';
-		       }
+			   $sql = 'SELECT h.id, h.title, h.starting_balance, h.final_balance, h.status, h.created_at, h.closed_at, a.name AS aff_name FROM %i h LEFT JOIN %i a ON a.id = h.affiliate_site_id';
+			   if ( $where ) {
+				   $sql .= ' WHERE ' . implode( ' AND ', $where );
+			   }
+			   $order_clause = ' ORDER BY h.created_at DESC';
+			   if ( 'recent' === strtolower( $a['timeline'] ) ) {
+				   $order_clause .= ' LIMIT 10';
+			   }
 
-		       // db call ok; no-cache ok.
-		       $prep_args = array_merge( array( $h, $aff_table ), $params );
-		       $sql       = $wpdb->prepare( $sql, ...$prep_args );
-		       $sql      .= $order_clause;
-		       $rows      = $wpdb->get_results( $sql );
+			   // db call ok; no-cache ok.
+			   $prep_args = array_merge( array( $h, $aff_table ), $params );
+			   $sql       = $wpdb->prepare( $sql, ...$prep_args );
+			   $sql      .= $order_clause;
+			   $rows      = $wpdb->get_results( $sql );
 			if ( ! $rows ) {
 				return '<p>' . esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ) . '</p>';
 			}
@@ -599,10 +599,10 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 						 * [bhg_leaderboards] — overall wins leaderboard.
 						 *
 						 * Attributes:
-					       * - fields: comma-separated list of columns to display.
-					       *   Allowed: pos,user,wins,avg,aff,site,hunt,tournament.
-					       * - ranking: range of positions to display (e.g. 1-10 or 5).
-					       * - timeline: optional window (day|week|month|year).
+						   * - fields: comma-separated list of columns to display.
+						   *   Allowed: pos,user,wins,avg,aff,site,hunt,tournament.
+						   * - ranking: range of positions to display (e.g. 1-10 or 5).
+						   * - timeline: optional window (day|week|month|year).
 						 */
 		public function leaderboards_shortcode( $atts ) {
 			$a = shortcode_atts(
@@ -615,24 +615,24 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 				'bhg_leaderboards'
 			);
 
-		       $raw_fields                = array_map( 'trim', explode( ',', (string) $a['fields'] ) );
-		       $allowed_field             = array( 'pos', 'user', 'wins', 'avg', 'aff', 'site', 'hunt', 'tournament' );
-		       $fields_arr                = array_values( array_unique( array_intersect( $allowed_field, array_map( 'sanitize_key', $raw_fields ) ) ) );
-		       if ( empty( $fields_arr ) ) {
-			       $fields_arr = array( 'pos', 'user', 'wins' );
-		       }
+			   $raw_fields                = array_map( 'trim', explode( ',', (string) $a['fields'] ) );
+			   $allowed_field             = array( 'pos', 'user', 'wins', 'avg', 'aff', 'site', 'hunt', 'tournament' );
+			   $fields_arr                = array_values( array_unique( array_intersect( $allowed_field, array_map( 'sanitize_key', $raw_fields ) ) ) );
+			   if ( empty( $fields_arr ) ) {
+				   $fields_arr = array( 'pos', 'user', 'wins' );
+			   }
 
-		       global $wpdb;
+			   global $wpdb;
 
-		       $ranking_raw = trim( (string) $a['ranking'] );
-		       if ( preg_match( '/^(\d+)-(\d+)$/', $ranking_raw, $m ) ) {
-			       $start = max( 1, min( 10, (int) $m[1] ) );
-			       $end   = max( $start, min( 10, (int) $m[2] ) );
-		       } else {
-			       $start = 1;
-			       $end   = max( 1, min( 10, (int) $ranking_raw ) );
-		       }
-		       $count = $end - $start + 1;
+			   $ranking_raw = trim( (string) $a['ranking'] );
+			   if ( preg_match( '/^(\d+)-(\d+)$/', $ranking_raw, $m ) ) {
+				   $start = max( 1, min( 10, (int) $m[1] ) );
+				   $end   = max( $start, min( 10, (int) $m[2] ) );
+			   } else {
+				   $start = 1;
+				   $end   = max( 1, min( 10, (int) $ranking_raw ) );
+			   }
+			   $count = $end - $start + 1;
 
 			// Optional timeline filter.
 			$where      = '';
@@ -656,35 +656,35 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 			$need_hunt       = in_array( 'hunt', $fields_arr, true );
 			$need_aff        = in_array( 'aff', $fields_arr, true );
 
-		       $r  = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
-		       $u  = $this->sanitize_table( $wpdb->users );
-		       $t  = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
-		       $w  = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliate_websites' );
-		       $hw = $this->sanitize_table( $wpdb->prefix . 'bhg_hunt_winners' );
-		       $h  = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			   $r  = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
+			   $u  = $this->sanitize_table( $wpdb->users );
+			   $t  = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
+			   $w  = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliate_websites' );
+			   $hw = $this->sanitize_table( $wpdb->prefix . 'bhg_hunt_winners' );
+			   $h  = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
 
-		       // db call ok; no-cache ok.
-		       $sql         = 'SELECT r.user_id, u.user_login, SUM(r.wins) AS total_wins';
-		       $prep_tables = array();
-		       if ( $need_avg ) {
-			       $sql          .= ', (SELECT AVG(hw.position) FROM %i hw WHERE hw.user_id = r.user_id) AS avg_rank';
-			       $prep_tables[] = $hw;
-		       }
-		       $sql          .= ' FROM %i r INNER JOIN %i u ON u.ID = r.user_id';
-		       $prep_tables[] = $r;
-		       $prep_tables[] = $u;
-		       if ( $where ) {
-			       $sql         .= $where;
-			       $prep_tables = array_merge( $prep_tables, $prep_where );
-		       }
-		       $sql  .= ' GROUP BY r.user_id, u.user_login';
-		       $sql   = $wpdb->prepare( $sql, ...$prep_tables );
-		       $sql  .= ' ORDER BY total_wins DESC, u.user_login ASC';
-		       $sql  .= $wpdb->prepare( ' LIMIT %d', $end );
-		       $rows  = $wpdb->get_results( $sql );
-		       if ( $start > 1 ) {
-			       $rows = array_slice( $rows, $start - 1, $count );
-		       }
+			   // db call ok; no-cache ok.
+			   $sql         = 'SELECT r.user_id, u.user_login, SUM(r.wins) AS total_wins';
+			   $prep_tables = array();
+			   if ( $need_avg ) {
+				   $sql          .= ', (SELECT AVG(hw.position) FROM %i hw WHERE hw.user_id = r.user_id) AS avg_rank';
+				   $prep_tables[] = $hw;
+			   }
+			   $sql          .= ' FROM %i r INNER JOIN %i u ON u.ID = r.user_id';
+			   $prep_tables[] = $r;
+			   $prep_tables[] = $u;
+			   if ( $where ) {
+				   $sql         .= $where;
+				   $prep_tables = array_merge( $prep_tables, $prep_where );
+			   }
+			   $sql  .= ' GROUP BY r.user_id, u.user_login';
+			   $sql   = $wpdb->prepare( $sql, ...$prep_tables );
+			   $sql  .= ' ORDER BY total_wins DESC, u.user_login ASC';
+			   $sql  .= $wpdb->prepare( ' LIMIT %d', $end );
+			   $rows  = $wpdb->get_results( $sql );
+			   if ( $start > 1 ) {
+				   $rows = array_slice( $rows, $start - 1, $count );
+			   }
 
 			if ( ! $rows ) {
 				return '<p>' . esc_html( bhg_t( 'notice_no_data_available', 'No data available.' ) ) . '</p>';
@@ -692,16 +692,16 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 
 			foreach ( $rows as $row ) {
 				if ( $need_site || $need_tournament ) {
-						       // Last tournament and site.
-						       $last_sql = $wpdb->prepare(
-							       'SELECT t.title AS tournament_title, w.name AS site_name FROM %i r INNER JOIN %i t ON t.id = r.tournament_id LEFT JOIN %i w ON w.id = t.affiliate_site_id WHERE r.user_id = %d',
-							       $r,
-							       $t,
-							       $w,
-							       $row->user_id
-						       );
-						       $last_sql .= ' ORDER BY r.last_win_date DESC LIMIT 1';
-						       $last      = $wpdb->get_row( $last_sql );
+							   // Last tournament and site.
+							   $last_sql = $wpdb->prepare(
+								   'SELECT t.title AS tournament_title, w.name AS site_name FROM %i r INNER JOIN %i t ON t.id = r.tournament_id LEFT JOIN %i w ON w.id = t.affiliate_site_id WHERE r.user_id = %d',
+								   $r,
+								   $t,
+								   $w,
+								   $row->user_id
+							   );
+							   $last_sql .= ' ORDER BY r.last_win_date DESC LIMIT 1';
+							   $last      = $wpdb->get_row( $last_sql );
 					if ( $need_tournament ) {
 						$row->tournament_title = $last && isset( $last->tournament_title ) ? $last->tournament_title : '';
 					}
@@ -711,14 +711,14 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 				}
 
 				if ( $need_hunt ) {
-							       // Last hunt won.
-							       $hunt_sql = $wpdb->prepare(
-								       'SELECT h.title FROM %i hw INNER JOIN %i h ON h.id = hw.hunt_id WHERE hw.user_id = %d',
-								       $hw,
-								       $h,
-								       $row->user_id
-							       );
-							       $hunt_sql .= ' ORDER BY hw.created_at DESC LIMIT 1';
+								   // Last hunt won.
+								   $hunt_sql = $wpdb->prepare(
+									   'SELECT h.title FROM %i hw INNER JOIN %i h ON h.id = hw.hunt_id WHERE hw.user_id = %d',
+									   $hw,
+									   $h,
+									   $row->user_id
+								   );
+								   $hunt_sql .= ' ORDER BY hw.created_at DESC LIMIT 1';
 								$hunt_title      = $wpdb->get_var( $hunt_sql );
 								$row->hunt_title = $hunt_title ? $hunt_title : '';
 				}
@@ -755,8 +755,8 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 			}
 			echo '</tr></thead><tbody>';
 
-		       $pos = $start;
-		       foreach ( $rows as $row ) {
+			   $pos = $start;
+			   foreach ( $rows as $row ) {
 				if ( $need_aff ) {
 					$is_aff = (int) get_user_meta( (int) $row->user_id, 'bhg_is_affiliate', true );
 					$aff    = $is_aff ? $this->render_affiliate_dot( 'green' ) : $this->render_affiliate_dot( 'red' );
@@ -812,46 +812,46 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 			// Details screen
 			$details_id = isset( $_GET['bhg_tournament_id'] ) ? absint( wp_unslash( $_GET['bhg_tournament_id'] ) ) : 0;
 			if ( $details_id > 0 ) {
-				       $t = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
-				       $r = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
-				       $u = $this->sanitize_table( $wpdb->users );
+					   $t = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
+					   $r = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
+					   $u = $this->sanitize_table( $wpdb->users );
 
-				       // db call ok; no-cache ok.
-				       $tournament = $wpdb->get_row(
-					       $wpdb->prepare(
-						       'SELECT id, type, start_date, end_date, status FROM %i WHERE id = %d',
-						       $t,
-						       $details_id
-					       )
-				       );
+					   // db call ok; no-cache ok.
+					   $tournament = $wpdb->get_row(
+						   $wpdb->prepare(
+							   'SELECT id, type, start_date, end_date, status FROM %i WHERE id = %d',
+							   $t,
+							   $details_id
+						   )
+					   );
 				if ( ! $tournament ) {
 					return '<p>' . esc_html( bhg_t( 'notice_tournament_not_found', 'Tournament not found.' ) ) . '</p>';
 				}
 
-                        $orderby        = isset( $_GET['orderby'] ) ? strtolower( sanitize_key( wp_unslash( $_GET['orderby'] ) ) ) : 'wins';
-                        $allowed_orders = array( 'asc', 'desc' );
-                        $order          = isset( $_GET['order'] ) ? strtolower( sanitize_key( wp_unslash( $_GET['order'] ) ) ) : 'desc';
+						$orderby        = isset( $_GET['orderby'] ) ? strtolower( sanitize_key( wp_unslash( $_GET['orderby'] ) ) ) : 'wins';
+						$allowed_orders = array( 'asc', 'desc' );
+						$order          = isset( $_GET['order'] ) ? strtolower( sanitize_key( wp_unslash( $_GET['order'] ) ) ) : 'desc';
 
-                        $allowed = array(
-                                'wins'        => 'r.wins',
-                                'username'    => 'u.user_login',
-                                'last_win_at' => 'r.last_win_date',
-                        );
-                        if ( ! isset( $allowed[ $orderby ] ) ) {
-                                $orderby = 'wins';
-                        }
-                        if ( ! in_array( $order, $allowed_orders, true ) ) {
-                                $order = 'desc';
-                        }
-                        $orderby_column = $allowed[ $orderby ];
-                        $order          = strtoupper( $order );
+						$allowed = array(
+								'wins'        => 'r.wins',
+								'username'    => 'u.user_login',
+								'last_win_at' => 'r.last_win_date',
+						);
+						if ( ! isset( $allowed[ $orderby ] ) ) {
+								$orderby = 'wins';
+						}
+						if ( ! in_array( $order, $allowed_orders, true ) ) {
+								$order = 'desc';
+						}
+						$orderby_column = $allowed[ $orderby ];
+						$order          = strtoupper( $order );
 
-							       $query = $wpdb->prepare(
-								       'SELECT r.user_id, r.wins, r.last_win_date, u.user_login FROM %i r INNER JOIN %i u ON u.ID = r.user_id WHERE r.tournament_id = %d',
-								       $r,
-								       $u,
-								       $tournament->id
-							       );
+								   $query = $wpdb->prepare(
+									   'SELECT r.user_id, r.wins, r.last_win_date, u.user_login FROM %i r INNER JOIN %i u ON u.ID = r.user_id WHERE r.tournament_id = %d',
+									   $r,
+									   $u,
+									   $tournament->id
+								   );
 								$query                                .= ' ORDER BY ' . $orderby_column . ' ' . $order . ', r.user_id ASC';
 								$rows                                  = $wpdb->get_results( $query ); // db call ok; no-cache ok.
 
@@ -964,15 +964,15 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 				$args[]  = $website;
 			}
 
-		       $query = 'SELECT * FROM %i';
-		       if ( $where ) {
-			       $query .= ' WHERE ' . implode( ' AND ', $where );
-		       }
-		       $query .= ' ORDER BY start_date DESC, id DESC';
+			   $query = 'SELECT * FROM %i';
+			   if ( $where ) {
+				   $query .= ' WHERE ' . implode( ' AND ', $where );
+			   }
+			   $query .= ' ORDER BY start_date DESC, id DESC';
 
-		       $prep_args = array_merge( array( $t ), $args );
-		       $query     = $wpdb->prepare( $query, ...$prep_args );
-		       $rows      = $wpdb->get_results( $query ); // db call ok; no-cache ok.
+			   $prep_args = array_merge( array( $t ), $args );
+			   $query     = $wpdb->prepare( $query, ...$prep_args );
+			   $rows      = $wpdb->get_results( $query ); // db call ok; no-cache ok.
 			if ( ! $rows ) {
 				return '<p>' . esc_html( bhg_t( 'notice_no_tournaments_found', 'No tournaments found.' ) ) . '</p>';
 			}
@@ -1063,15 +1063,15 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 				'bhg_winner_notifications'
 			);
 
-		       $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-		       // db call ok; no-cache ok.
-		       $sql         = $wpdb->prepare(
-			       'SELECT id, title, final_balance, winners_count, closed_at FROM %i WHERE status = %s ORDER BY closed_at DESC LIMIT %d',
-			       $hunts_table,
-			       'closed',
-			       (int) $a['limit']
-		       );
-		       $hunts       = $wpdb->get_results( $sql );
+			   $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			   // db call ok; no-cache ok.
+			   $sql         = $wpdb->prepare(
+				   'SELECT id, title, final_balance, winners_count, closed_at FROM %i WHERE status = %s ORDER BY closed_at DESC LIMIT %d',
+				   $hunts_table,
+				   'closed',
+				   (int) $a['limit']
+			   );
+			   $hunts       = $wpdb->get_results( $sql );
 
 			if ( ! $hunts ) {
 				return '<p>' . esc_html( bhg_t( 'notice_no_closed_hunts', 'No closed hunts yet.' ) ) . '</p>';
@@ -1134,9 +1134,9 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 		public function best_guessers_shortcode( $atts ) {
 			global $wpdb;
 
-		       $wins_tbl  = $wpdb->prefix . 'bhg_tournament_results';
-		       $tours_tbl = $wpdb->prefix . 'bhg_tournaments';
-		       $users_tbl = $wpdb->users;
+			   $wins_tbl  = $wpdb->prefix . 'bhg_tournament_results';
+			   $tours_tbl = $wpdb->prefix . 'bhg_tournaments';
+			   $users_tbl = $wpdb->users;
 
 			$now_ts        = current_time( 'timestamp' );
 			$current_month = wp_date( 'Y-m', $now_ts );
@@ -1171,41 +1171,41 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 
 			$results = array();
 			foreach ( $periods as $key => $info ) {
-			       if ( $info['type'] ) {
-				       $where  = 't.type = %s';
-				       $params = array( $info['type'] );
-				       if ( ! empty( $info['start'] ) && ! empty( $info['end'] ) ) {
-					       $where   .= ' AND t.start_date >= %s AND t.end_date <= %s';
-					       $params[] = $info['start'];
-					       $params[] = $info['end'];
-				       }
-				       $sql = 'SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins'
-					       . ' FROM %i r'
-					       . ' INNER JOIN %i u ON u.ID = r.user_id'
-					       . ' INNER JOIN %i t ON t.id = r.tournament_id'
-					       . ' WHERE ' . $where . "\n                                                       GROUP BY u.ID, u.user_login";
-				       // db call ok; no-cache ok.
-				       $sql      = $wpdb->prepare( $sql, $wins_tbl, $users_tbl, $tours_tbl, ...$params );
-				       $sql     .= ' ORDER BY total_wins DESC, u.user_login ASC LIMIT 50';
-				       $results[ $key ] = $wpdb->get_results( $sql );
-			       } else {
-				       $sql = 'SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins'
-					       . ' FROM %i r'
-					       . ' INNER JOIN %i u ON u.ID = r.user_id'
-					       . ' GROUP BY u.ID, u.user_login';
-				       // db call ok; no-cache ok.
-				       $sql     .= ' ORDER BY total_wins DESC, u.user_login ASC LIMIT 50';
-				       $results[ $key ] = $wpdb->get_results( $wpdb->prepare( $sql, $wins_tbl, $users_tbl ) );
-			       }
+				   if ( $info['type'] ) {
+					   $where  = 't.type = %s';
+					   $params = array( $info['type'] );
+					   if ( ! empty( $info['start'] ) && ! empty( $info['end'] ) ) {
+						   $where   .= ' AND t.start_date >= %s AND t.end_date <= %s';
+						   $params[] = $info['start'];
+						   $params[] = $info['end'];
+					   }
+					   $sql = 'SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins'
+						   . ' FROM %i r'
+						   . ' INNER JOIN %i u ON u.ID = r.user_id'
+						   . ' INNER JOIN %i t ON t.id = r.tournament_id'
+						   . ' WHERE ' . $where . "\n                                                       GROUP BY u.ID, u.user_login";
+					   // db call ok; no-cache ok.
+					   $sql      = $wpdb->prepare( $sql, $wins_tbl, $users_tbl, $tours_tbl, ...$params );
+					   $sql     .= ' ORDER BY total_wins DESC, u.user_login ASC LIMIT 50';
+					   $results[ $key ] = $wpdb->get_results( $sql );
+				   } else {
+					   $sql = 'SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins'
+						   . ' FROM %i r'
+						   . ' INNER JOIN %i u ON u.ID = r.user_id'
+						   . ' GROUP BY u.ID, u.user_login';
+					   // db call ok; no-cache ok.
+					   $sql     .= ' ORDER BY total_wins DESC, u.user_login ASC LIMIT 50';
+					   $results[ $key ] = $wpdb->get_results( $wpdb->prepare( $sql, $wins_tbl, $users_tbl ) );
+				   }
 			}
 
-			       $hunts_tbl = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-			       $hunts_sql = $wpdb->prepare(
-				       'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC LIMIT 50',
-				       $hunts_tbl,
-				       'closed'
-			       );
-			       $hunts     = $wpdb->get_results( $hunts_sql );
+				   $hunts_tbl = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+				   $hunts_sql = $wpdb->prepare(
+					   'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC LIMIT 50',
+					   $hunts_tbl,
+					   'closed'
+				   );
+				   $hunts     = $wpdb->get_results( $hunts_sql );
 
 						wp_enqueue_style(
 							'bhg-shortcodes',

--- a/includes/class-bhg-utils.php
+++ b/includes/class-bhg-utils.php
@@ -87,16 +87,16 @@ class BHG_Utils {
 	 * @return void
 	 */
 	public static function require_cap() {
-               if ( ! current_user_can( 'manage_options' ) ) {
-                       wp_die(
-                               esc_html(
-                                       bhg_t(
-                                               'you_do_not_have_permission_to_access_this_page',
-                                               'You do not have permission to access this page'
-                                       )
-                               )
-                       );
-               }
+			   if ( ! current_user_can( 'manage_options' ) ) {
+					   wp_die(
+							   esc_html(
+									   bhg_t(
+											   'you_do_not_have_permission_to_access_this_page',
+											   'You do not have permission to access this page'
+									   )
+							   )
+					   );
+			   }
 	}
 
 	/**

--- a/includes/helpers-aff-dot.php
+++ b/includes/helpers-aff-dot.php
@@ -26,9 +26,9 @@ if ( ! function_exists( 'bhg_render_affiliate_dot' ) ) {
 				$is_aff = (bool) bhg_is_user_affiliate( $user_id );
 		}
 
-               $cls   = $is_aff ? 'bhg-aff-green' : 'bhg-aff-red';
-               $label = $is_aff ? bhg_t( 'label_affiliate', 'Affiliate' ) : bhg_t( 'label_non_affiliate', 'Non-affiliate' );
+			   $cls   = $is_aff ? 'bhg-aff-green' : 'bhg-aff-red';
+			   $label = $is_aff ? bhg_t( 'label_affiliate', 'Affiliate' ) : bhg_t( 'label_non_affiliate', 'Non-affiliate' );
 
-               return '<span class="bhg-aff-dot ' . esc_attr( $cls ) . '" aria-label="' . esc_attr( $label ) . '"></span>';
-       }
+			   return '<span class="bhg-aff-dot ' . esc_attr( $cls ) . '" aria-label="' . esc_attr( $label ) . '"></span>';
+	   }
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -19,10 +19,10 @@ function bhg_log( $message ) {
 	if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
 		return;
 	}
-       if ( is_array( $message ) || is_object( $message ) ) {
-               $message = wp_json_encode( $message );
-       }
-       error_log( '[BHG] ' . $message );
+	   if ( is_array( $message ) || is_object( $message ) ) {
+			   $message = wp_json_encode( $message );
+	   }
+	   error_log( '[BHG] ' . $message );
 }
 
 /**
@@ -60,9 +60,9 @@ function bhg_admin_cap() {
 
 // Smart login redirect back to referring page.
 add_filter(
-       'login_redirect',
-       function ( $redirect_to, $requested_redirect_to, $user ) {
-               $r = isset( $_REQUEST['bhg_redirect'] ) ? wp_unslash( $_REQUEST['bhg_redirect'] ) : '';
+	   'login_redirect',
+	   function ( $redirect_to, $requested_redirect_to, $user ) {
+			   $r = isset( $_REQUEST['bhg_redirect'] ) ? wp_unslash( $_REQUEST['bhg_redirect'] ) : '';
 		if ( ! empty( $r ) ) {
 			$safe      = esc_url_raw( $r );
 			$home_host = wp_parse_url( home_url(), PHP_URL_HOST );
@@ -87,45 +87,45 @@ function bhg_is_frontend() {
 }
 
 if ( ! function_exists( 'bhg_t' ) ) {
-       /**
-        * Retrieve a translation value from the database.
-        *
-        * @param string $slug    Translation slug.
-        * @param string $default Default text if not found.
-        * @param string $locale  Locale to use. Defaults to current locale.
-        * @return string
-        */
-       function bhg_t( $slug, $default = '', $locale = '' ) {
-               global $wpdb;
+	   /**
+		* Retrieve a translation value from the database.
+		*
+		* @param string $slug    Translation slug.
+		* @param string $default Default text if not found.
+		* @param string $locale  Locale to use. Defaults to current locale.
+		* @return string
+		*/
+	   function bhg_t( $slug, $default = '', $locale = '' ) {
+			   global $wpdb;
 
-               $slug      = (string) $slug;
-               $locale    = $locale ? (string) $locale : get_locale();
-               $cache_key = 'bhg_t_' . $slug . '_' . $locale;
-               $cached    = wp_cache_get( $cache_key );
+			   $slug      = (string) $slug;
+			   $locale    = $locale ? (string) $locale : get_locale();
+			   $cache_key = 'bhg_t_' . $slug . '_' . $locale;
+			   $cached    = wp_cache_get( $cache_key );
 
-               if ( false !== $cached ) {
-                       return (string) $cached;
-               }
+			   if ( false !== $cached ) {
+					   return (string) $cached;
+			   }
 
-               $table = $wpdb->prefix . 'bhg_translations';
-               $row   = $wpdb->get_row(
-                       $wpdb->prepare(
-                               'SELECT text, default_text FROM %i WHERE slug = %s AND locale = %s',
-                               $table,
-                               $slug,
-                               $locale
-                       )
-               );
+			   $table = $wpdb->prefix . 'bhg_translations';
+			   $row   = $wpdb->get_row(
+					   $wpdb->prepare(
+							   'SELECT text, default_text FROM %i WHERE slug = %s AND locale = %s',
+							   $table,
+							   $slug,
+							   $locale
+					   )
+			   );
 
-               if ( $row ) {
-                       $value = '' !== $row->text ? (string) $row->text : (string) $row->default_text;
-                       wp_cache_set( $cache_key, $value );
-                       return $value;
-               }
+			   if ( $row ) {
+					   $value = '' !== $row->text ? (string) $row->text : (string) $row->default_text;
+					   wp_cache_set( $cache_key, $value );
+					   return $value;
+			   }
 
-               wp_cache_set( $cache_key, (string) $default );
-               return (string) $default;
-       }
+			   wp_cache_set( $cache_key, (string) $default );
+			   return (string) $default;
+	   }
 }
 
 if ( ! function_exists( 'bhg_get_default_translations' ) ) {
@@ -146,27 +146,27 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'menu_users'                                   => 'Users',
 			'menu_affiliates'                              => 'Affiliate Websites',
 			'menu_advertising'                             => 'Advertising',
-                        'menu_translations'                            => 'Translations',
-                        'menu_settings'                               => 'Settings',
-                        'menu_database'                               => 'Database',
-                        'menu_tools'                                   => 'Tools',
-                        'menu_ads'                                     => 'Ads',
-                        'bhg_menu_admin'                               => 'BHG Menu — Admin/Moderators',
-                        'bhg_menu_loggedin'                            => 'BHG Menu — Logged-in Users',
-                        'bhg_menu_guests'                              => 'BHG Menu — Guests',
+						'menu_translations'                            => 'Translations',
+						'menu_settings'                               => 'Settings',
+						'menu_database'                               => 'Database',
+						'menu_tools'                                   => 'Tools',
+						'menu_ads'                                     => 'Ads',
+						'bhg_menu_admin'                               => 'BHG Menu — Admin/Moderators',
+						'bhg_menu_loggedin'                            => 'BHG Menu — Logged-in Users',
+						'bhg_menu_guests'                              => 'BHG Menu — Guests',
 
-                        // Standalone labels.
-                        'dashboard'                                    => 'Dashboard',
-                        'bonus_hunts'                                  => 'Bonus Hunts',
-                        'results'                                      => 'Results',
-                        'affiliate_websites'                           => 'Affiliate Websites',
-                        'advertising'                                  => 'Advertising',
-                        'translations'                                 => 'Translations',
-                        'tools'                                        => 'Tools',
-                        'tournament'                                   => 'Tournament',
+						// Standalone labels.
+						'dashboard'                                    => 'Dashboard',
+						'bonus_hunts'                                  => 'Bonus Hunts',
+						'results'                                      => 'Results',
+						'affiliate_websites'                           => 'Affiliate Websites',
+						'advertising'                                  => 'Advertising',
+						'translations'                                 => 'Translations',
+						'tools'                                        => 'Tools',
+						'tournament'                                   => 'Tournament',
 
-                        // Form/field labels.
-                        'label_start_balance'                          => 'Starting Balance',
+						// Form/field labels.
+						'label_start_balance'                          => 'Starting Balance',
 			'label_number_bonuses'                         => 'Number of Bonuses',
 			'label_prizes'                                 => 'Prizes',
 			'label_submit_guess'                           => 'Submit Guess',
@@ -174,12 +174,12 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'label_username'                               => 'Username',
 			'label_position'                               => 'Position',
 			'label_final_balance'                          => 'Final Balance',
-                        'label_difference'                             => 'Difference',
-                        'label_leaderboard'                            => 'Leaderboard',
-                        'label_best_guessers'                          => 'Best Guessers',
-                        'label_leaderboard_history'                    => 'Leaderboard History',
-                        'label_affiliate'                              => 'Affiliate',
-                        'label_non_affiliate'                          => 'Non-affiliate',
+						'label_difference'                             => 'Difference',
+						'label_leaderboard'                            => 'Leaderboard',
+						'label_best_guessers'                          => 'Best Guessers',
+						'label_leaderboard_history'                    => 'Leaderboard History',
+						'label_affiliate'                              => 'Affiliate',
+						'label_non_affiliate'                          => 'Non-affiliate',
 			'label_affiliate_status'                       => 'Affiliate Status',
 			'label_site'                                   => 'Site',
 			'label_tournament'                             => 'Tournament',
@@ -208,13 +208,13 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'label_end_date'                               => 'End Date',
 			'label_email'                                  => 'Email',
 			'label_real_name'                              => 'Real Name',
-                        'label_search'                                 => 'Search',
-                        'label_user'                                   => 'User',
-                        'label_users'                                  => 'Users',
-                        'label_role'                                   => 'Role',
-                        'label_guesses'                                => 'Guesses',
-                        'label_profile'                                => 'Profile',
-                        'label_start'                                  => 'Start',
+						'label_search'                                 => 'Search',
+						'label_user'                                   => 'User',
+						'label_users'                                  => 'Users',
+						'label_role'                                   => 'Role',
+						'label_guesses'                                => 'Guesses',
+						'label_profile'                                => 'Profile',
+						'label_start'                                  => 'Start',
 			'label_end'                                    => 'End',
 			'label_status'                                 => 'Status',
 			'label_status_colon'                           => 'Status:',
@@ -272,15 +272,15 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'monthly'                                      => 'Monthly',
 			'quarterly'                                    => 'Quarterly',
 			'yearly'                                       => 'Yearly',
-                        'alltime'                                      => 'All-time',
-                        'label_guests'                                 => 'Guests',
-                        'label_logged_in'                              => 'Logged In',
-                        'label_affiliates'                             => 'Affiliates',
-                        'label_log_in'                                 => 'Log in',
-                        'label_log_out'                                => 'Log out',
-                        'label_non_affiliates'                         => 'Non Affiliates',
-                        'label_affiliate_website'                      => 'Affiliate Website',
-                        'label_affiliate_websites'                     => 'Affiliate Websites',
+						'alltime'                                      => 'All-time',
+						'label_guests'                                 => 'Guests',
+						'label_logged_in'                              => 'Logged In',
+						'label_affiliates'                             => 'Affiliates',
+						'label_log_in'                                 => 'Log in',
+						'label_log_out'                                => 'Log out',
+						'label_non_affiliates'                         => 'Non Affiliates',
+						'label_affiliate_website'                      => 'Affiliate Website',
+						'label_affiliate_websites'                     => 'Affiliate Websites',
 			'label_affiliate_user_title'                   => 'Affiliate User',
 			'label_footer'                                 => 'Footer',
 			'label_bottom'                                 => 'Bottom',
@@ -312,10 +312,10 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'notice_guess_saved'                           => 'Your guess has been saved.',
 			'notice_guess_updated'                         => 'Your guess has been updated.',
 			'notice_hunt_closed'                           => 'This bonus hunt is closed.',
-                        'notice_invalid_guess'                         => 'Please enter a valid guess.',
-                        'notice_ajax_error'                            => 'An error occurred. Please try again.',
-                        'error_loading_leaderboard'                    => 'Error loading leaderboard.',
-                        'notice_not_authorized'                        => 'You are not authorized to perform this action.',
+						'notice_invalid_guess'                         => 'Please enter a valid guess.',
+						'notice_ajax_error'                            => 'An error occurred. Please try again.',
+						'error_loading_leaderboard'                    => 'Error loading leaderboard.',
+						'notice_not_authorized'                        => 'You are not authorized to perform this action.',
 			'notice_translations_saved'                    => 'Translations saved.',
 			'notice_translations_reset'                    => 'Translations reset.',
 			'notice_security_check_failed'                 => 'Security check failed.',
@@ -376,9 +376,9 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'sc_affiliate'                                 => 'Affiliate',
 			'sc_position'                                  => 'Position',
 			'sc_user'                                      => 'User',
-                        'sc_wins'                                      => 'Wins',
-                        'sc_avg_rank'                                  => 'Avg Rank',
-                        'sc_start'                                     => 'Start',
+						'sc_wins'                                      => 'Wins',
+						'sc_avg_rank'                                  => 'Avg Rank',
+						'sc_start'                                     => 'Start',
 			'sc_end'                                       => 'End',
 			'sc_prizes'                                    => 'Prizes',
 
@@ -391,7 +391,7 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'add_tournament'                               => 'Add Tournament',
 			'ads'                                          => 'Ads:',
 			'ads_enabled'                                  => 'Enable Ads',
-                        'affiliate_site'                               => 'Affiliate Site',
+						'affiliate_site'                               => 'Affiliate Site',
 			'affiliate_user'                               => 'Affiliate',
 			'non_affiliate_user'                           => 'Non-affiliate',
 			'affiliate_management_ui_not_provided_yet'     => 'Affiliate management UI not provided yet.',
@@ -450,21 +450,21 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'edit_bonus_hunt'                              => 'Edit Bonus Hunt',
 			'edit_hunt_s'                                  => 'Edit Hunt — %s',
 			'edit_tournament'                              => 'Edit Tournament',
-                        'email_from'                                   => 'Email From Address',
+						'email_from'                                   => 'Email From Address',
 
-                        // Email notifications.
-                        'email_results_title'                          => 'The Bonus Hunt has been closed!',
-                        'email_final_balance'                          => 'Final Balance',
-                        'email_winner'                                 => 'Winner',
-                        'email_congrats_subject'                       => 'Congratulations! You won the Bonus Hunt',
-                        'email_congrats_body'                          => 'You had the closest guess. Great job!',
-                        'email_hunt'                                   => 'Hunt',
+						// Email notifications.
+						'email_results_title'                          => 'The Bonus Hunt has been closed!',
+						'email_final_balance'                          => 'Final Balance',
+						'email_winner'                                 => 'Winner',
+						'email_congrats_subject'                       => 'Congratulations! You won the Bonus Hunt',
+						'email_congrats_body'                          => 'You had the closest guess. Great job!',
+						'email_hunt'                                   => 'Hunt',
 
-                        'enable_ads'                                   => 'Enable Ads',
-                        'existing_ads'                                 => 'Existing Ads',
-                        'existing_keys'                                => 'Existing keys',
-                        'custom_translations_highlighted'              => 'Custom translations are highlighted.',
-                        'exists'                                       => 'Exists',
+						'enable_ads'                                   => 'Enable Ads',
+						'existing_ads'                                 => 'Existing Ads',
+						'existing_keys'                                => 'Existing keys',
+						'custom_translations_highlighted'              => 'Custom translations are highlighted.',
+						'exists'                                       => 'Exists',
 			'final_balance_optional'                       => 'Final Balance (optional)',
 			'gift_card_swag'                               => 'Gift card + swag',
 			'guess_must_be_between_0_and_100000'           => 'Guess must be between €0 and €100,000.',
@@ -524,10 +524,10 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'inactive'                                     => 'Inactive',
 			'optimize_database_tables'                     => 'Optimize Database Tables',
 			'participants'                                 => 'Participants',
-                       'period'                                       => 'Period:',
-                       'placement'                                    => 'Placement',
-                       'play_responsibly'                             => 'Play responsibly.',
-                       'please_enter_a_guess'                         => 'Please enter a guess.',
+					   'period'                                       => 'Period:',
+					   'placement'                                    => 'Placement',
+					   'play_responsibly'                             => 'Play responsibly.',
+					   'please_enter_a_guess'                         => 'Please enter a guess.',
 			'guess_required'                               => 'Please enter a guess.',
 			'please_enter_a_valid_number'                  => 'Please enter a valid number.',
 			'guess_numeric'                                => 'Please enter a valid number.',
@@ -552,14 +552,14 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'save_settings'                                => 'Save Settings',
 			'search_users'                                 => 'Search Users',
 			'search_users_2'                               => 'Search users',
-                        'security_check_failed'                        => 'Security check failed. Please try again.',
+						'security_check_failed'                        => 'Security check failed. Please try again.',
 			'security_check_failed_2'                      => 'Security check failed.',
-                       'security_check_failed_please_retry'           => 'Security check failed. Please retry.',
-                       'security_check_failed_please_try_again'       => 'Security check failed. Please try again.',
-                       'see_promo'                                    => 'See promo',
-                       'settings'                                     => 'Settings',
-                       'settings_saved_successfully'                  => 'Settings saved successfully.',
-                       'settings_currently_unavailable'               => 'Settings management is currently unavailable.',
+					   'security_check_failed_please_retry'           => 'Security check failed. Please retry.',
+					   'security_check_failed_please_try_again'       => 'Security check failed. Please try again.',
+					   'see_promo'                                    => 'See promo',
+					   'settings'                                     => 'Settings',
+					   'settings_saved_successfully'                  => 'Settings saved successfully.',
+					   'settings_currently_unavailable'               => 'Settings management is currently unavailable.',
 			'show_ads_block_on_selected_pages'             => 'Show ads block on selected pages.',
 			'status'                                       => 'Status:',
 			'tshirt'                                       => 'T-shirt',
@@ -607,42 +607,42 @@ if ( ! function_exists( 'bhg_seed_default_translations' ) ) {
 		 *
 		 * @return void
 		 */
-       function bhg_seed_default_translations() {
-               global $wpdb;
+	   function bhg_seed_default_translations() {
+			   global $wpdb;
 
-               $table  = $wpdb->prefix . 'bhg_translations';
-               $locale = get_locale();
+			   $table  = $wpdb->prefix . 'bhg_translations';
+			   $locale = get_locale();
 
-               foreach ( bhg_get_default_translations() as $slug => $def_text ) {
-                       $slug = trim( (string) $slug );
-                       if ( '' === $slug ) {
-                               continue; // Skip invalid keys.
-                       }
+			   foreach ( bhg_get_default_translations() as $slug => $def_text ) {
+					   $slug = trim( (string) $slug );
+					   if ( '' === $slug ) {
+							   continue; // Skip invalid keys.
+					   }
 
-                       $exists = $wpdb->get_var(
-                               // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is safe.
-                               $wpdb->prepare(
-                                       "SELECT COUNT(*) FROM {$table} WHERE slug = %s AND locale = %s",
-                                       $slug,
-                                       $locale
-                               )
-                       );
-                       if ( $exists ) {
-                               continue;
-                       }
+					   $exists = $wpdb->get_var(
+							   // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is safe.
+							   $wpdb->prepare(
+									   "SELECT COUNT(*) FROM {$table} WHERE slug = %s AND locale = %s",
+									   $slug,
+									   $locale
+							   )
+					   );
+					   if ( $exists ) {
+							   continue;
+					   }
 
-                       $wpdb->insert(
-                               $table,
-                               array(
-                                       'slug'         => $slug,
-                                       'default_text' => (string) $def_text,
-                                       'text'         => '',
-                                       'locale'       => $locale,
-                               ),
-                               array( '%s', '%s', '%s', '%s' )
-                       );
-               }
-       }
+					   $wpdb->insert(
+							   $table,
+							   array(
+									   'slug'         => $slug,
+									   'default_text' => (string) $def_text,
+									   'text'         => '',
+									   'locale'       => $locale,
+							   ),
+							   array( '%s', '%s', '%s', '%s' )
+					   );
+			   }
+	   }
 }
 
 if ( ! function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
@@ -705,17 +705,17 @@ function bhg_validate_guess( $guess ) {
  * @return string Display name with optional affiliate indicator.
  */
 function bhg_get_user_display_name( $user_id ) {
-       $user = get_userdata( (int) $user_id );
-       if ( ! $user ) {
-               return bhg_t( 'unknown_user', 'Unknown User' );
-       }
+	   $user = get_userdata( (int) $user_id );
+	   if ( ! $user ) {
+			   return bhg_t( 'unknown_user', 'Unknown User' );
+	   }
 
 	$display_name = $user->display_name ? $user->display_name : $user->user_login;
 	$is_affiliate = bhg_is_user_affiliate( (int) $user_id );
 
-       if ( $is_affiliate ) {
-               $display_name .= ' <span class="bhg-affiliate-indicator" title="' . esc_attr( bhg_t( 'label_affiliate_user_title', 'Affiliate User' ) ) . '">★</span>';
-       }
+	   if ( $is_affiliate ) {
+			   $display_name .= ' <span class="bhg-affiliate-indicator" title="' . esc_attr( bhg_t( 'label_affiliate_user_title', 'Affiliate User' ) ) . '">★</span>';
+	   }
 
 	return $display_name;
 }
@@ -801,26 +801,26 @@ if ( ! function_exists( 'bhg_render_affiliate_dot' ) ) {
 	 */
 	function bhg_render_affiliate_dot( $user_id, $hunt_affiliate_site_id = 0 ) {
 		$is_aff = bhg_is_user_affiliate_for_site( (int) $user_id, (int) $hunt_affiliate_site_id );
-               $cls   = $is_aff ? 'bhg-aff-green' : 'bhg-aff-red';
-               $label = $is_aff ? bhg_t( 'label_affiliate', 'Affiliate' ) : bhg_t( 'label_non_affiliate', 'Non-affiliate' );
-               return '<span class="bhg-aff-dot ' . esc_attr( $cls ) . '" aria-label="' . esc_attr( $label ) . '"></span>';
-       }
+			   $cls   = $is_aff ? 'bhg-aff-green' : 'bhg-aff-red';
+			   $label = $is_aff ? bhg_t( 'label_affiliate', 'Affiliate' ) : bhg_t( 'label_non_affiliate', 'Non-affiliate' );
+			   return '<span class="bhg-aff-dot ' . esc_attr( $cls ) . '" aria-label="' . esc_attr( $label ) . '"></span>';
+	   }
 }
 
 if ( ! function_exists( 'bhg_cleanup_translation_duplicates' ) ) {
-       /**
-        * Remove duplicate translation rows keeping the lowest ID.
-        *
-        * @return void
-        */
-       function bhg_cleanup_translation_duplicates() {
-               global $wpdb;
+	   /**
+		* Remove duplicate translation rows keeping the lowest ID.
+		*
+		* @return void
+		*/
+	   function bhg_cleanup_translation_duplicates() {
+			   global $wpdb;
 
-               $table = $wpdb->prefix . 'bhg_translations';
+			   $table = $wpdb->prefix . 'bhg_translations';
 
-               // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is safe.
-               $wpdb->query( "DELETE t1 FROM {$table} t1 INNER JOIN {$table} t2 ON t1.slug = t2.slug AND t1.locale = t2.locale AND t1.id > t2.id" );
-       }
+			   // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is safe.
+			   $wpdb->query( "DELETE t1 FROM {$table} t1 INNER JOIN {$table} t2 ON t1.slug = t2.slug AND t1.locale = t2.locale AND t1.id > t2.id" );
+	   }
 }
 
 /**
@@ -841,18 +841,18 @@ function bhg_render_ads( $placement = 'footer', $hunt_id = 0 ) {
 				$placement
 			)
 		);
-       $hunt_site_id = 0;
+	   $hunt_site_id = 0;
 
-       if ( $hunt_id ) {
-               $hunts_tbl   = $wpdb->prefix . 'bhg_bonus_hunts';
-               $hunt_site_id = (int) $wpdb->get_var(
-                       $wpdb->prepare(
-                               'SELECT affiliate_site_id FROM %i WHERE id=%d',
-                               $hunts_tbl,
-                               (int) $hunt_id
-                       )
-               );
-       }
+	   if ( $hunt_id ) {
+			   $hunts_tbl   = $wpdb->prefix . 'bhg_bonus_hunts';
+			   $hunt_site_id = (int) $wpdb->get_var(
+					   $wpdb->prepare(
+							   'SELECT affiliate_site_id FROM %i WHERE id=%d',
+							   $hunts_tbl,
+							   (int) $hunt_id
+					   )
+			   );
+	   }
 
 	if ( ! $rows ) {
 		return '';
@@ -1120,11 +1120,11 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 		}
 	}
 
-                global $wpdb;
-                $p      = $wpdb->prefix;
+				global $wpdb;
+				$p      = $wpdb->prefix;
 
-                // Seed ads.
-                $ads_tbl = "{$p}bhg_ads";
+				// Seed ads.
+				$ads_tbl = "{$p}bhg_ads";
 	if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $ads_tbl ) ) === $ads_tbl ) {
 		// Remove any duplicate ads, keeping the lowest ID for identical content/placement pairs.
 		$wpdb->query(
@@ -1160,15 +1160,15 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 	$p      = $wpdb->prefix;
 	$tr_tbl = "{$p}bhg_translations";
 	
-        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $tr_tbl ) ) === $tr_tbl ) {
-                bhg_seed_default_translations_if_empty();
-        }
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $tr_tbl ) ) === $tr_tbl ) {
+				bhg_seed_default_translations_if_empty();
+		}
 
-        return true;
-        }
+		return true;
+		}
 
 // Ensure default translations are seeded on load so newly added keys appear
 // in the Translations page without requiring manual intervention.
 if ( function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
-       bhg_seed_default_translations_if_empty();
+	   bhg_seed_default_translations_if_empty();
 }

--- a/includes/upgrade/add-winners-limit.php
+++ b/includes/upgrade/add-winners-limit.php
@@ -23,21 +23,21 @@ function bhg_upgrade_add_winners_limit_column() {
 
 	// Ensure table exists and has winners_count column.
 	$sql = "CREATE TABLE {$hunts} (
-            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-            title VARCHAR(190) NOT NULL,
-            starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
-            num_bonuses INT UNSIGNED NOT NULL DEFAULT 0,
-            prizes TEXT NULL,
-            affiliate_site_id BIGINT UNSIGNED NULL,
-            winners_count INT UNSIGNED NOT NULL DEFAULT 3,
-            final_balance DECIMAL(12,2) NULL,
-            status VARCHAR(20) NOT NULL DEFAULT 'open',
-            created_at DATETIME NULL,
-            updated_at DATETIME NULL,
-            closed_at DATETIME NULL,
-            PRIMARY KEY  (id),
-            KEY status (status)
-    ) {$charset_collate};";
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			title VARCHAR(190) NOT NULL,
+			starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+			num_bonuses INT UNSIGNED NOT NULL DEFAULT 0,
+			prizes TEXT NULL,
+			affiliate_site_id BIGINT UNSIGNED NULL,
+			winners_count INT UNSIGNED NOT NULL DEFAULT 3,
+			final_balance DECIMAL(12,2) NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'open',
+			created_at DATETIME NULL,
+			updated_at DATETIME NULL,
+			closed_at DATETIME NULL,
+			PRIMARY KEY  (id),
+			KEY status (status)
+	) {$charset_collate};";
 
 	dbDelta( $sql );
 }


### PR DESCRIPTION
## Summary
- Convert leading spaces to tabs across PHP sources to better match WordPress coding standards.
- Ran PHPCS with `phpcs.xml` ruleset to check coding-style compliance.

## Testing
- `composer phpcs` *(fails: indentation issues remain)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0dbc54e48333b043fc4f157aab5e