### PR TITLE
Fix demo reseed, affiliate indicator, and ad placement

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -564,21 +564,63 @@ class BHG_Admin {
 		exit;
 	}
 
-	/**
-	 * Handle submission of the Tools page.
-	 */
-	public function handle_tools_action() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html( bhg_t( 'no_permission', 'No permission' ) ) );
-		}
+        /**
+         * Handle submission of the Tools page.
+         */
+        public function handle_tools_action() {
+                if ( ! current_user_can( 'manage_options' ) ) {
+                        wp_die( esc_html( bhg_t( 'no_permission', 'No permission' ) ) );
+                }
 
-		// Verify nonce for tools action submission.
-		check_admin_referer( 'bhg_tools_action', 'bhg_tools_nonce' );
+                // Verify nonce for tools action submission.
+                check_admin_referer( 'bhg_tools_action', 'bhg_tools_nonce' );
 
-		// Redirect back to the tools page with a success message.
-		wp_safe_redirect( admin_url( 'admin.php?page=bhg-tools&bhg_msg=tools_success' ) );
-		exit;
-	}
+                global $wpdb;
+
+                $hunts_table       = $wpdb->prefix . 'bhg_bonus_hunts';
+                $tournaments_table = $wpdb->prefix . 'bhg_tournaments';
+
+                // Remove existing demo data.
+                // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names cannot be parameterized.
+                $wpdb->query(
+                        $wpdb->prepare(
+                                "DELETE FROM {$hunts_table} WHERE title LIKE %s",
+                                '%(Demo)%'
+                        )
+                );
+
+                // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names cannot be parameterized.
+                $wpdb->query(
+                        $wpdb->prepare(
+                                "DELETE FROM {$tournaments_table} WHERE title LIKE %s",
+                                '%(Demo)%'
+                        )
+                );
+
+                // Seed demo hunt.
+                $wpdb->insert(
+                        $hunts_table,
+                        array(
+                                'title'            => 'Sample Hunt (Demo)',
+                                'starting_balance' => 1000,
+                                'num_bonuses'      => 5,
+                                'status'           => 'open',
+                        )
+                );
+
+                // Seed demo tournament.
+                $wpdb->insert(
+                        $tournaments_table,
+                        array(
+                                'title'  => 'August Tournament (Demo)',
+                                'status' => 'active',
+                        )
+                );
+
+                // Redirect back to the tools page with a success message.
+                wp_safe_redirect( admin_url( 'admin.php?page=bhg-tools&bhg_msg=tools_success' ) );
+                exit;
+        }
 
 	/**
 	 * Display admin notices for tournament actions.

--- a/assets/css/public.css
+++ b/assets/css/public.css
@@ -4,7 +4,7 @@
 .bhg-leaderboard{width:100%;border-collapse:collapse}
 .bhg-leaderboard th,.bhg-leaderboard td{border:1px solid #e2e8f0;padding:8px}
 
-.bhg-tabs{display:flex;gap:8px;margin-bottom:8px}.bhg-tab{border:1px solid #cbd5e1;border-radius:8px;padding:6px 10px;background:#fff;cursor:pointer}.bhg-ads-footer{margin-top:16px}.bhg-ad-item{border:1px dashed #cbd5e1;border-radius:8px;padding:8px;margin-top:8px}
+.bhg-tabs{display:flex;gap:8px;margin-bottom:8px}.bhg-tab{border:1px solid #cbd5e1;border-radius:8px;padding:6px 10px;background:#fff;cursor:pointer}.bhg-ads-footer{margin-top:16px}.bhg-ads-bottom{margin-top:16px}.bhg-ad-item{border:1px dashed #cbd5e1;border-radius:8px;padding:8px;margin-top:8px}
 
 /* BHG button standard */
 .bhg-btn-submit{display:inline-block;padding:10px 16px;border-radius:10px;border:1px solid #0f172a;background:#0ea5e9;color:#fff;cursor:pointer}

--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -47,10 +47,10 @@ class BHG_Ads {
 	 * @return bool
 	 */
 	protected static function ads_enabled() {
-		$settings = get_option( 'bhg_plugin_settings', array() );
-		$enabled  = isset( $settings['ads_enabled'] ) ? (int) $settings['ads_enabled'] : 0;
-		return 1 === $enabled;
-	}
+               $settings = get_option( 'bhg_plugin_settings', array() );
+               $enabled  = isset( $settings['ads_enabled'] ) ? (int) $settings['ads_enabled'] : 1;
+               return 1 === $enabled;
+       }
 
 	/**
 	 * Determine current user's affiliate status (global toggle).
@@ -188,28 +188,31 @@ class BHG_Ads {
 			return;
 		}
 
-		$ads = self::get_ads_for_placement( 'footer' );
-		if ( empty( $ads ) ) {
-			return;
-		}
+               $placements = array( 'footer', 'bottom' );
+               foreach ( $placements as $place ) {
+                       $ads = self::get_ads_for_placement( $place );
+                       if ( empty( $ads ) ) {
+                               continue;
+                       }
 
-		$out = array();
-		foreach ( $ads as $row ) {
-			if ( ! self::visibility_ok( $row->visible_to ) ) {
-				continue;
-			}
-			if ( ! self::page_target_ok( $row->target_pages ) ) {
-				continue;
-			}
-			$out[] = self::render_ad_row( $row );
-		}
+                       $out = array();
+                       foreach ( $ads as $row ) {
+                               if ( ! self::visibility_ok( $row->visible_to ) ) {
+                                       continue;
+                               }
+                               if ( ! self::page_target_ok( $row->target_pages ) ) {
+                                       continue;
+                               }
+                               $out[] = self::render_ad_row( $row );
+                       }
 
-		if ( ! empty( $out ) ) {
-			echo '<div class="bhg-ads bhg-ads-footer" style="margin:16px 0;text-align:center;">';
-			echo wp_kses_post( implode( "\n", $out ) );
-			echo '</div>';
-		}
-	}
+                       if ( ! empty( $out ) ) {
+                               echo '<div class="bhg-ads bhg-ads-' . esc_attr( $place ) . '" style="margin:16px 0;text-align:center;">';
+                               echo wp_kses_post( implode( "\n", $out ) );
+                               echo '</div>';
+                       }
+               }
+       }
 
 	/**
 	 * Shortcode handler for rendering a single ad row regardless of placement.

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -304,10 +304,9 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 						foreach ( $rows as $r ) {
 				if ( $need_user ) {
 					$site_id = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
-					$is_aff  = $site_id > 0
-					? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
-					: (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
-					$aff     = $is_aff ? 'green' : 'red';
+                                       $is_aff  = $site_id > 0
+                                       ? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
+                                       : (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
 					/* translators: %d: user ID. */
 					$user_label = $r->user_login ? $r->user_login : sprintf( bhg_t( 'label_user_hash', 'user#%d' ), (int) $r->user_id );
 				}
@@ -317,7 +316,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					if ( 'position' === $field ) {
 						echo '<td data-column="position">' . (int) $pos . '</td>';
 					} elseif ( 'user' === $field ) {
-							echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $this->render_affiliate_dot( $aff ) . '</td>';
+                                                   echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $this->render_affiliate_dot( (bool) $is_aff ) . '</td>';
 					} elseif ( 'guess' === $field ) {
 							echo '<td data-column="guess">' . esc_html( number_format_i18n( (float) $r->guess, 2 ) ) . '</td>';
 					}
@@ -460,13 +459,13 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 							echo '<tr>';
 							echo '<td>' . esc_html( $row->title ) . '</td>';
 							$guess_cell = esc_html( number_format_i18n( (float) $row->guess, 2 ) );
-							if ( $show_aff ) {
-								$dot        = $this->render_affiliate_dot(
-									( get_user_meta( (int) $current_user_id, 'bhg_affiliate_website_' . (int) $row->affiliate_site_id, true )
-									|| get_user_meta( (int) $current_user_id, 'bhg_is_affiliate', true ) ) ? 'green' : 'red'
-								);
-								$guess_cell = $dot . $guess_cell;
-							}
+                                                       if ( $show_aff ) {
+                                                                $dot        = $this->render_affiliate_dot(
+                                                                        get_user_meta( (int) $current_user_id, 'bhg_affiliate_website_' . (int) $row->affiliate_site_id, true )
+                                                                        || get_user_meta( (int) $current_user_id, 'bhg_is_affiliate', true )
+                                                                );
+                                                                $guess_cell = $dot . $guess_cell;
+                                                        }
 							echo '<td>' . $guess_cell . '</td>';
 							echo '<td>' . ( isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
 							echo '</tr>';
@@ -757,10 +756,10 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 
 			   $pos = $start;
 			   foreach ( $rows as $row ) {
-				if ( $need_aff ) {
-					$is_aff = (int) get_user_meta( (int) $row->user_id, 'bhg_is_affiliate', true );
-					$aff    = $is_aff ? $this->render_affiliate_dot( 'green' ) : $this->render_affiliate_dot( 'red' );
-				}
+                               if ( $need_aff ) {
+                                       $is_aff = (int) get_user_meta( (int) $row->user_id, 'bhg_is_affiliate', true );
+                                       $aff    = $this->render_affiliate_dot( (bool) $is_aff );
+                               }
 												/* translators: %d: user ID. */
 												$user_label = $row->user_login ? $row->user_login : sprintf( bhg_t( 'label_user_hash', 'user#%d' ), (int) $row->user_id );
 												echo '<tr>';
@@ -1271,12 +1270,12 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 			return ob_get_clean();
 		}
 
-			/** Private: render affiliate dot span */
-		private function render_affiliate_dot( $color ) {
-			$c = ( 'green' === $color ) ? 'green' : 'red';
-			return '<span class="bhg-aff-dot bhg-aff-' . esc_attr( $c ) . '" aria-hidden="true"></span> ';
-		}
-	}
+                       /** Private: render affiliate dot span */
+               private function render_affiliate_dot( $is_affiliate ) {
+                       $c = $is_affiliate ? 'green' : 'red';
+                       return '<span class="bhg-aff-dot bhg-aff-' . esc_attr( $c ) . '" aria-hidden="true"></span> ';
+               }
+       }
 }
 
 // Register once on init even if no other bootstrap instantiates the class


### PR DESCRIPTION
## Summary
- Ensure Tools page reseeds demo hunts and tournaments
- Correct affiliate dot rendering in leaderboards and user lists
- Enable bottom-placement ads and default ads setting to on

## Testing
- `composer run phpcs` *(fails: Use placeholders and other code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0a55a7d48333a978e51ffcb48020