### PR TITLE
style: replace leading spaces with tabs

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -564,63 +564,63 @@ class BHG_Admin {
 		exit;
 	}
 
-        /**
-         * Handle submission of the Tools page.
-         */
-        public function handle_tools_action() {
-                if ( ! current_user_can( 'manage_options' ) ) {
-                        wp_die( esc_html( bhg_t( 'no_permission', 'No permission' ) ) );
-                }
+		/**
+		 * Handle submission of the Tools page.
+		 */
+		public function handle_tools_action() {
+				if ( ! current_user_can( 'manage_options' ) ) {
+						wp_die( esc_html( bhg_t( 'no_permission', 'No permission' ) ) );
+				}
 
-                // Verify nonce for tools action submission.
-                check_admin_referer( 'bhg_tools_action', 'bhg_tools_nonce' );
+				// Verify nonce for tools action submission.
+				check_admin_referer( 'bhg_tools_action', 'bhg_tools_nonce' );
 
-                global $wpdb;
+				global $wpdb;
 
-                $hunts_table       = $wpdb->prefix . 'bhg_bonus_hunts';
-                $tournaments_table = $wpdb->prefix . 'bhg_tournaments';
+				$hunts_table       = $wpdb->prefix . 'bhg_bonus_hunts';
+				$tournaments_table = $wpdb->prefix . 'bhg_tournaments';
 
-                // Remove existing demo data.
-                // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names cannot be parameterized.
-                $wpdb->query(
-                        $wpdb->prepare(
-                                "DELETE FROM {$hunts_table} WHERE title LIKE %s",
-                                '%(Demo)%'
-                        )
-                );
+				// Remove existing demo data.
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names cannot be parameterized.
+				$wpdb->query(
+						$wpdb->prepare(
+								"DELETE FROM {$hunts_table} WHERE title LIKE %s",
+								'%(Demo)%'
+						)
+				);
 
-                // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names cannot be parameterized.
-                $wpdb->query(
-                        $wpdb->prepare(
-                                "DELETE FROM {$tournaments_table} WHERE title LIKE %s",
-                                '%(Demo)%'
-                        )
-                );
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names cannot be parameterized.
+				$wpdb->query(
+						$wpdb->prepare(
+								"DELETE FROM {$tournaments_table} WHERE title LIKE %s",
+								'%(Demo)%'
+						)
+				);
 
-                // Seed demo hunt.
-                $wpdb->insert(
-                        $hunts_table,
-                        array(
-                                'title'            => 'Sample Hunt (Demo)',
-                                'starting_balance' => 1000,
-                                'num_bonuses'      => 5,
-                                'status'           => 'open',
-                        )
-                );
+				// Seed demo hunt.
+				$wpdb->insert(
+						$hunts_table,
+						array(
+								'title'            => 'Sample Hunt (Demo)',
+								'starting_balance' => 1000,
+								'num_bonuses'      => 5,
+								'status'           => 'open',
+						)
+				);
 
-                // Seed demo tournament.
-                $wpdb->insert(
-                        $tournaments_table,
-                        array(
-                                'title'  => 'August Tournament (Demo)',
-                                'status' => 'active',
-                        )
-                );
+				// Seed demo tournament.
+				$wpdb->insert(
+						$tournaments_table,
+						array(
+								'title'  => 'August Tournament (Demo)',
+								'status' => 'active',
+						)
+				);
 
-                // Redirect back to the tools page with a success message.
-                wp_safe_redirect( admin_url( 'admin.php?page=bhg-tools&bhg_msg=tools_success' ) );
-                exit;
-        }
+				// Redirect back to the tools page with a success message.
+				wp_safe_redirect( admin_url( 'admin.php?page=bhg-tools&bhg_msg=tools_success' ) );
+				exit;
+		}
 
 	/**
 	 * Display admin notices for tournament actions.

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -726,44 +726,44 @@ function bhg_generate_leaderboard_html( $timeframe, $paged ) {
 				$u = $wpdb->users;
 
 				$total_query  = "SELECT COUNT(*) FROM (
-                SELECT g.user_id
-                FROM %i g
-                INNER JOIN %i h ON h.id = g.hunt_id
-                WHERE h.status='closed' AND h.final_balance IS NOT NULL";
+				SELECT g.user_id
+				FROM %i g
+				INNER JOIN %i h ON h.id = g.hunt_id
+				WHERE h.status='closed' AND h.final_balance IS NOT NULL";
 				$params_total = array( $g, $h );
 	if ( $start_date ) {
 			$total_query   .= ' AND h.updated_at >= %s';
 			$params_total[] = $start_date;
 	}
 				$total_query   .= ' AND NOT EXISTS (
-                SELECT 1 FROM %i g2
-                WHERE g2.hunt_id = g.hunt_id
-                AND ABS(g2.guess - h.final_balance) < ABS(g.guess - h.final_balance)
-                )
-                GROUP BY g.user_id
-                ) t';
+				SELECT 1 FROM %i g2
+				WHERE g2.hunt_id = g.hunt_id
+				AND ABS(g2.guess - h.final_balance) < ABS(g.guess - h.final_balance)
+				)
+				GROUP BY g.user_id
+				) t';
 				$params_total[] = $g;
 				// db call ok; no-cache ok.
 				$total = (int) $wpdb->get_var( $wpdb->prepare( $total_query, $params_total ) );
 
 				$list_query  = "SELECT g.user_id, u.user_login, COUNT(*) AS wins
-                FROM %i g
-                INNER JOIN %i h ON h.id = g.hunt_id
-                INNER JOIN %i u ON u.ID = g.user_id
-                WHERE h.status='closed' AND h.final_balance IS NOT NULL";
+				FROM %i g
+				INNER JOIN %i h ON h.id = g.hunt_id
+				INNER JOIN %i u ON u.ID = g.user_id
+				WHERE h.status='closed' AND h.final_balance IS NOT NULL";
 				$params_list = array( $g, $h, $u );
 	if ( $start_date ) {
 			$list_query   .= ' AND h.updated_at >= %s';
 			$params_list[] = $start_date;
 	}
 				$list_query   .= ' AND NOT EXISTS (
-                SELECT 1 FROM %i g2
-                WHERE g2.hunt_id = g.hunt_id
-                AND ABS(g2.guess - h.final_balance) < ABS(g.guess - h.final_balance)
-                )
-                GROUP BY g.user_id, u.user_login
-                ORDER BY wins DESC, u.user_login ASC
-                LIMIT %d OFFSET %d';
+				SELECT 1 FROM %i g2
+				WHERE g2.hunt_id = g.hunt_id
+				AND ABS(g2.guess - h.final_balance) < ABS(g.guess - h.final_balance)
+				)
+				GROUP BY g.user_id, u.user_login
+				ORDER BY wins DESC, u.user_login ASC
+				LIMIT %d OFFSET %d';
 				$params_list[] = $g;
 				$params_list[] = $per_page;
 				$params_list[] = $offset;

--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -15,26 +15,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 class BHG_Ads {
 
 	/**
-	 * Allowed ad placement values.
-	 *
-	 * @var string[]
-	 */
+	* Allowed ad placement values.
+	*
+	* @var string[]
+	*/
 	private static $allowed_placements = array( 'none', 'footer', 'bottom', 'sidebar', 'shortcode' );
 
 	/**
-	 * Retrieve allowed ad placements.
-	 *
-	 * @return string[]
-	 */
+	* Retrieve allowed ad placements.
+	*
+	* @return string[]
+	*/
 	public static function get_allowed_placements() {
 		return self::$allowed_placements;
 	}
 
 	/**
-	 * Initialize front-end hooks for ads.
-	 *
-	 * @return void
-	 */
+	* Initialize front-end hooks for ads.
+	*
+	* @return void
+	*/
 	public static function init() {
 		add_action( 'wp_footer', array( 'BHG_Ads', 'render_footer' ) );
 		add_shortcode( 'bhg_ad', array( 'BHG_Ads', 'shortcode' ) );
@@ -42,21 +42,21 @@ class BHG_Ads {
 	}
 
 	/**
-	 * Checks if front-end ads are enabled in plugin settings.
-	 *
-	 * @return bool
-	 */
+	* Checks if front-end ads are enabled in plugin settings.
+	*
+	* @return bool
+	*/
 	protected static function ads_enabled() {
-               $settings = get_option( 'bhg_plugin_settings', array() );
-               $enabled  = isset( $settings['ads_enabled'] ) ? (int) $settings['ads_enabled'] : 1;
-               return 1 === $enabled;
-       }
+			$settings = get_option( 'bhg_plugin_settings', array() );
+			$enabled  = isset( $settings['ads_enabled'] ) ? (int) $settings['ads_enabled'] : 1;
+			return 1 === $enabled;
+	}
 
 	/**
-	 * Determine current user's affiliate status (global toggle).
-	 *
-	 * @return bool
-	 */
+	* Determine current user's affiliate status (global toggle).
+	*
+	* @return bool
+	*/
 	protected static function user_is_affiliate() {
 		if ( ! is_user_logged_in() ) {
 			return false;
@@ -66,12 +66,12 @@ class BHG_Ads {
 	}
 
 	/**
-	 * Whether current visitor matches the ad's visibility setting.
-	 *
-	 * @param string $visibility Visibility rule.
-	 *
-	 * @return bool
-	 */
+	* Whether current visitor matches the ad's visibility setting.
+	*
+	* @param string $visibility Visibility rule.
+	*
+	* @return bool
+	*/
 	protected static function visibility_ok( $visibility ) {
 		$visibility = is_string( $visibility ) ? strtolower( $visibility ) : 'all';
 		switch ( $visibility ) {
@@ -90,12 +90,12 @@ class BHG_Ads {
 	}
 
 	/**
-	 * Whether the current page is one of the targeted pages (by slug), if any are set.
-	 *
-	 * @param string $target_pages Comma-separated list of target page slugs.
-	 *
-	 * @return bool
-	 */
+	* Whether the current page is one of the targeted pages (by slug), if any are set.
+	*
+	* @param string $target_pages Comma-separated list of target page slugs.
+	*
+	* @return bool
+	*/
 	protected static function page_target_ok( $target_pages ) {
 		$target_pages = is_string( $target_pages ) ? trim( $target_pages ) : '';
 		if ( '' === $target_pages ) {
@@ -129,12 +129,12 @@ class BHG_Ads {
 	}
 
 	/**
-	 * Render a single ad row to HTML.
-	 *
-	 * @param object $row Database row object.
-	 *
-	 * @return string
-	 */
+	* Render a single ad row to HTML.
+	*
+	* @param object $row Database row object.
+	*
+	* @return string
+	*/
 	protected static function render_ad_row( $row ) {
 		$msg  = isset( $row->content ) ? $row->content : '';
 		$msg  = wp_kses_post( $msg );
@@ -147,12 +147,12 @@ class BHG_Ads {
 	}
 
 	/**
-	 * Fetch active ads for a placement.
-	 *
-	 * @param string $placement Ad placement.
-	 *
-	 * @return array
-	 */
+	* Fetch active ads for a placement.
+	*
+	* @param string $placement Ad placement.
+	*
+	* @return array
+	*/
 	protected static function get_ads_for_placement( $placement = 'footer' ) {
 		global $wpdb;
 		$table          = $wpdb->prefix . 'bhg_ads';
@@ -176,10 +176,10 @@ class BHG_Ads {
 	}
 
 	/**
-	 * Render footer-placed ads.
-	 *
-	 * @return void
-	 */
+	* Render footer-placed ads.
+	*
+	* @return void
+	*/
 	public static function render_footer() {
 		if ( is_admin() ) {
 			return;
@@ -188,45 +188,45 @@ class BHG_Ads {
 			return;
 		}
 
-               $placements = array( 'footer', 'bottom' );
-               foreach ( $placements as $place ) {
-                       $ads = self::get_ads_for_placement( $place );
-                       if ( empty( $ads ) ) {
-                               continue;
-                       }
+			$placements = array( 'footer', 'bottom' );
+			foreach ( $placements as $place ) {
+					$ads = self::get_ads_for_placement( $place );
+					if ( empty( $ads ) ) {
+							continue;
+					}
 
-                       $out = array();
-                       foreach ( $ads as $row ) {
-                               if ( ! self::visibility_ok( $row->visible_to ) ) {
-                                       continue;
-                               }
-                               if ( ! self::page_target_ok( $row->target_pages ) ) {
-                                       continue;
-                               }
-                               $out[] = self::render_ad_row( $row );
-                       }
+					$out = array();
+					foreach ( $ads as $row ) {
+							if ( ! self::visibility_ok( $row->visible_to ) ) {
+									continue;
+							}
+							if ( ! self::page_target_ok( $row->target_pages ) ) {
+									continue;
+							}
+							$out[] = self::render_ad_row( $row );
+					}
 
-                       if ( ! empty( $out ) ) {
-                               echo '<div class="bhg-ads bhg-ads-' . esc_attr( $place ) . '" style="margin:16px 0;text-align:center;">';
-                               echo wp_kses_post( implode( "\n", $out ) );
-                               echo '</div>';
-                       }
-               }
-       }
+					if ( ! empty( $out ) ) {
+							echo '<div class="bhg-ads bhg-ads-' . esc_attr( $place ) . '" style="margin:16px 0;text-align:center;">';
+							echo wp_kses_post( implode( "\n", $out ) );
+							echo '</div>';
+					}
+			}
+	}
 
 	/**
-	 * Shortcode handler for rendering a single ad row regardless of placement.
-	 *
-	 * Usage examples:
-	 * [bhg_ad id="123"]
-	 * [bhg_advertising ad="123" status="inactive"]
-	 *
-	 * @param array  $atts    Shortcode attributes.
-	 * @param string $content Content enclosed by shortcode (unused).
-	 * @param string $tag     Shortcode tag.
-	 *
-	 * @return string
-	 */
+	* Shortcode handler for rendering a single ad row regardless of placement.
+	*
+	* Usage examples:
+	* [bhg_ad id="123"]
+	* [bhg_advertising ad="123" status="inactive"]
+	*
+	* @param array  $atts    Shortcode attributes.
+	* @param string $content Content enclosed by shortcode (unused).
+	* @param string $tag     Shortcode tag.
+	*
+	* @return string
+	*/
 	public static function shortcode( $atts = array(), $content = '', $tag = '' ) {
 		if ( ! self::ads_enabled() ) {
 			return '';

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -304,9 +304,9 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 						foreach ( $rows as $r ) {
 				if ( $need_user ) {
 					$site_id = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
-                                       $is_aff  = $site_id > 0
-                                       ? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
-                                       : (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
+									   $is_aff  = $site_id > 0
+									   ? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
+									   : (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
 					/* translators: %d: user ID. */
 					$user_label = $r->user_login ? $r->user_login : sprintf( bhg_t( 'label_user_hash', 'user#%d' ), (int) $r->user_id );
 				}
@@ -316,7 +316,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					if ( 'position' === $field ) {
 						echo '<td data-column="position">' . (int) $pos . '</td>';
 					} elseif ( 'user' === $field ) {
-                                                   echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $this->render_affiliate_dot( (bool) $is_aff ) . '</td>';
+												   echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $this->render_affiliate_dot( (bool) $is_aff ) . '</td>';
 					} elseif ( 'guess' === $field ) {
 							echo '<td data-column="guess">' . esc_html( number_format_i18n( (float) $r->guess, 2 ) ) . '</td>';
 					}
@@ -459,13 +459,13 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 							echo '<tr>';
 							echo '<td>' . esc_html( $row->title ) . '</td>';
 							$guess_cell = esc_html( number_format_i18n( (float) $row->guess, 2 ) );
-                                                       if ( $show_aff ) {
-                                                                $dot        = $this->render_affiliate_dot(
-                                                                        get_user_meta( (int) $current_user_id, 'bhg_affiliate_website_' . (int) $row->affiliate_site_id, true )
-                                                                        || get_user_meta( (int) $current_user_id, 'bhg_is_affiliate', true )
-                                                                );
-                                                                $guess_cell = $dot . $guess_cell;
-                                                        }
+													   if ( $show_aff ) {
+																$dot        = $this->render_affiliate_dot(
+																		get_user_meta( (int) $current_user_id, 'bhg_affiliate_website_' . (int) $row->affiliate_site_id, true )
+																		|| get_user_meta( (int) $current_user_id, 'bhg_is_affiliate', true )
+																);
+																$guess_cell = $dot . $guess_cell;
+														}
 							echo '<td>' . $guess_cell . '</td>';
 							echo '<td>' . ( isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
 							echo '</tr>';
@@ -756,10 +756,10 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 
 			   $pos = $start;
 			   foreach ( $rows as $row ) {
-                               if ( $need_aff ) {
-                                       $is_aff = (int) get_user_meta( (int) $row->user_id, 'bhg_is_affiliate', true );
-                                       $aff    = $this->render_affiliate_dot( (bool) $is_aff );
-                               }
+							   if ( $need_aff ) {
+									   $is_aff = (int) get_user_meta( (int) $row->user_id, 'bhg_is_affiliate', true );
+									   $aff    = $this->render_affiliate_dot( (bool) $is_aff );
+							   }
 												/* translators: %d: user ID. */
 												$user_label = $row->user_login ? $row->user_login : sprintf( bhg_t( 'label_user_hash', 'user#%d' ), (int) $row->user_id );
 												echo '<tr>';
@@ -1270,12 +1270,12 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 			return ob_get_clean();
 		}
 
-                       /** Private: render affiliate dot span */
-               private function render_affiliate_dot( $is_affiliate ) {
-                       $c = $is_affiliate ? 'green' : 'red';
-                       return '<span class="bhg-aff-dot bhg-aff-' . esc_attr( $c ) . '" aria-hidden="true"></span> ';
-               }
-       }
+					   /** Private: render affiliate dot span */
+			   private function render_affiliate_dot( $is_affiliate ) {
+					   $c = $is_affiliate ? 'green' : 'red';
+					   return '<span class="bhg-aff-dot bhg-aff-' . esc_attr( $c ) . '" aria-hidden="true"></span> ';
+			   }
+	   }
 }
 
 // Register once on init even if no other bootstrap instantiates the class


### PR DESCRIPTION
## Summary
- use WordPress-style tabs for indentation across main files
- remove stray spaces in ad helper

## Testing
- `composer run phpcs` *(fails: Use of a direct database call is discouraged; Use placeholders and $wpdb->prepare(); found $total_query)*

------
https://chatgpt.com/codex/tasks/task_e_68bf159c544c8333be2afdd960ce15ba