### PR TITLE
Add currency selection for formatting

### DIFF
--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -57,6 +57,23 @@ foreach ( $periods as $key => $label ) :
 </td>
 </tr>
 <tr>
+<th scope="row"><label for="bhg_currency"><?php echo esc_html( bhg_t( 'currency', 'Currency' ) ); ?></label></th>
+<td>
+<select name="bhg_currency" id="bhg_currency">
+<?php
+$currencies       = array(
+'eur' => bhg_t( 'eur', 'EUR' ),
+'usd' => bhg_t( 'usd', 'USD' ),
+);
+$current_currency = isset( $settings['currency'] ) ? $settings['currency'] : 'eur';
+foreach ( $currencies as $key => $label ) :
+?>
+<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $current_currency, $key ); ?>><?php echo esc_html( $label ); ?></option>
+<?php endforeach; ?>
+</select>
+</td>
+</tr>
+<tr>
 <th scope="row"><label for="bhg_min_guess_amount"><?php echo esc_html( bhg_t( 'min_guess_amount', 'Minimum Guess Amount' ) ); ?></label></th>
 <td><input type="number" class="small-text" id="bhg_min_guess_amount" name="bhg_min_guess_amount" value="<?php echo isset( $settings['min_guess_amount'] ) ? esc_attr( $settings['min_guess_amount'] ) : '0'; ?>" min="0"></td>
 </tr>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -418,12 +418,19 @@ function bhg_handle_settings_save() {
 		}
 	}
 
-	if ( isset( $_POST['bhg_min_guess_amount'] ) ) {
-			$min = floatval( wp_unslash( $_POST['bhg_min_guess_amount'] ) );
-		if ( 0 <= $min ) {
-				$settings['min_guess_amount'] = $min;
-		}
-	}
+        if ( isset( $_POST['bhg_min_guess_amount'] ) ) {
+                        $min = floatval( wp_unslash( $_POST['bhg_min_guess_amount'] ) );
+                if ( 0 <= $min ) {
+                                $settings['min_guess_amount'] = $min;
+                }
+        }
+
+        if ( isset( $_POST['bhg_currency'] ) ) {
+                        $currency = sanitize_text_field( wp_unslash( $_POST['bhg_currency'] ) );
+                if ( in_array( $currency, array( 'eur', 'usd' ), true ) ) {
+                                $settings['currency'] = $currency;
+                }
+        }
 
 				// Validate that min is not greater than max.
 	if ( isset( $settings['min_guess_amount'] ) && isset( $settings['max_guess_amount'] ) &&

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -665,16 +665,31 @@ if ( ! function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
 }
 
 /**
- * Format an amount as currency.
+ * Get the configured currency symbol.
  *
- * Allows the currency symbol to be customized via the `bhg_currency_symbol` filter.
+ * Defaults to the Euro symbol.
+ *
+ * @return string
+ */
+function bhg_currency_symbol() {
+        $settings = get_option( 'bhg_plugin_settings', array() );
+        $currency = isset( $settings['currency'] ) ? $settings['currency'] : 'eur';
+        $map      = array(
+                'usd' => '$',
+                'eur' => '€',
+        );
+        $symbol   = isset( $map[ $currency ] ) ? $map[ $currency ] : '€';
+        return apply_filters( 'bhg_currency_symbol', $symbol, $currency );
+}
+
+/**
+ * Format an amount as currency using the selected symbol.
  *
  * @param float $amount Amount to format.
  * @return string
  */
 function bhg_format_currency( $amount ) {
-	$symbol = apply_filters( 'bhg_currency_symbol', '€' );
-	return sprintf( '%s%s', $symbol, number_format_i18n( (float) $amount, 2 ) );
+        return sprintf( '%s%s', bhg_currency_symbol(), number_format_i18n( (float) $amount, 2 ) );
 }
 
 /**


### PR DESCRIPTION
## Summary
- add currency dropdown in settings
- persist chosen currency and use helper to retrieve symbol
- format currency using the configured symbol

## Testing
- `composer install`
- `./vendor/bin/phpcs admin/views/settings.php bonus-hunt-guesser.php includes/helpers.php` *(fails: Tabs must be used to indent lines; spaces are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f204885c8333aa84f8e1895f38fd