### PR TITLE
Add search, sorting, and guessing controls for hunts

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -13,16 +13,17 @@ if ( ! current_user_can( 'manage_options' ) ) {
 }
 
 global $wpdb;
-$hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
-$guesses_table = $wpdb->prefix . 'bhg_guesses';
-$tours_table   = $wpdb->prefix . 'bhg_tournaments';
-$users_table   = $wpdb->users;
+$hunts_table    = $wpdb->prefix . 'bhg_bonus_hunts';
+$guesses_table  = $wpdb->prefix . 'bhg_guesses';
+$tours_table    = $wpdb->prefix . 'bhg_tournaments';
+$users_table    = $wpdb->users;
+$aff_table      = $wpdb->prefix . 'bhg_affiliate_websites';
 $allowed_tables = array(
-		$wpdb->prefix . 'bhg_bonus_hunts',
-		$wpdb->prefix . 'bhg_guesses',
-		$wpdb->prefix . 'bhg_affiliate_websites',
-		$wpdb->prefix . 'bhg_tournaments',
-		$wpdb->users,
+	$wpdb->prefix . 'bhg_bonus_hunts',
+	$wpdb->prefix . 'bhg_guesses',
+	$wpdb->prefix . 'bhg_affiliate_websites',
+	$wpdb->prefix . 'bhg_tournaments',
+	$wpdb->users,
 );
 if (
 				! in_array( $hunts_table, $allowed_tables, true ) ||
@@ -37,52 +38,169 @@ $hunts_table   = esc_sql( $hunts_table );
 $guesses_table = esc_sql( $guesses_table );
 $users_table   = esc_sql( $users_table );
 $tours_table   = esc_sql( $tours_table );
+$aff_table     = esc_sql( $aff_table );
 
 $view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'list';
 
 /** LIST VIEW */
 if ( 'list' === $view ) :
-		$current_page = max( 1, isset( $_GET['paged'] ) ? (int) wp_unslash( $_GET['paged'] ) : 1 );
-		$per_page     = 30;
-		$offset       = ( $current_page - 1 ) * $per_page;
+	$current_page = max( 1, isset( $_GET['paged'] ) ? (int) wp_unslash( $_GET['paged'] ) : 1 );
+	$per_page     = 30;
+	$offset       = ( $current_page - 1 ) * $per_page;
+	$search       = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+	$orderby      = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'id';
+	$order        = ( isset( $_GET['order'] ) && 'asc' === strtolower( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 
-				// db call ok; no-cache ok.
-				$hunts = $wpdb->get_results(
-					$wpdb->prepare(
-						'SELECT * FROM %i ORDER BY id DESC LIMIT %d OFFSET %d',
-						$hunts_table,
-						$per_page,
-						$offset
-					)
-				);
+	$allowed_orderby = array(
+		'id'               => 'h.id',
+		'title'            => 'h.title',
+		'starting_balance' => 'h.starting_balance',
+		'final_balance'    => 'h.final_balance',
+		'affiliate'        => 'a.name',
+		'winners'          => 'h.winners_count',
+		'status'           => 'h.status',
+	);
+	$order_by_sql    = isset( $allowed_orderby[ $orderby ] ) ? $allowed_orderby[ $orderby ] : 'h.id';
 
-				// db call ok; no-cache ok.
-				$total = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $hunts_table ) );
-		$base_url      = remove_query_arg( array( 'paged' ) );
+	$sql  = "SELECT h.*, a.name AS affiliate_name FROM {$hunts_table} h LEFT JOIN {$aff_table} a ON a.id = h.affiliate_site_id";
+	$like = '';
+	if ( $search ) {
+		$like = '%' . $wpdb->esc_like( $search ) . '%';
+		$sql .= $wpdb->prepare( ' WHERE h.title LIKE %s', $like );
+	}
+	$sql  .= " ORDER BY {$order_by_sql} {$order}";
+	$hunts = $wpdb->get_results( $wpdb->prepare( $sql . ' LIMIT %d OFFSET %d', $per_page, $offset ) );
+
+	$count_sql = "SELECT COUNT(*) FROM {$hunts_table} h";
+	if ( $search ) {
+		$count_sql .= $wpdb->prepare( ' WHERE h.title LIKE %s', $like );
+	}
+	$total     = (int) $wpdb->get_var( $count_sql );
+	$base_url  = remove_query_arg( array( 'paged' ) );
+	$sort_base = remove_query_arg( array( 'paged', 'orderby', 'order' ) );
 	?>
 <div class="wrap">
-	<h1 class="wp-heading-inline"><?php echo esc_html( bhg_t( 'label_bonus_hunts', 'Bonus Hunts' ) ); ?></h1>
-	<a href="<?php echo esc_url( add_query_arg( array( 'view' => 'add' ) ) ); ?>" class="page-title-action"><?php echo esc_html( bhg_t( 'add_new', 'Add New' ) ); ?></a>
+<h1 class="wp-heading-inline"><?php echo esc_html( bhg_t( 'label_bonus_hunts', 'Bonus Hunts' ) ); ?></h1>
+<a href="<?php echo esc_url( add_query_arg( array( 'view' => 'add' ) ) ); ?>" class="page-title-action"><?php echo esc_html( bhg_t( 'add_new', 'Add New' ) ); ?></a>
+
+<form method="get" class="search-form">
+<input type="hidden" name="page" value="bhg-bonus-hunts" />
+<p class="search-box">
+<input type="search" name="s" value="<?php echo esc_attr( $search ); ?>" />
+	<?php if ( $orderby ) : ?>
+<input type="hidden" name="orderby" value="<?php echo esc_attr( $orderby ); ?>" />
+	<?php endif; ?>
+	<?php if ( $order ) : ?>
+<input type="hidden" name="order" value="<?php echo esc_attr( strtolower( $order ) ); ?>" />
+	<?php endif; ?>
+<input type="submit" class="button" value="<?php echo esc_attr( bhg_t( 'search_hunts', 'Search Hunts' ) ); ?>" />
+</p>
+</form>
 
 	<?php if ( isset( $_GET['closed'] ) && '1' === sanitize_text_field( wp_unslash( $_GET['closed'] ) ) ) : ?>
 	<div class="notice notice-success is-dismissible"><p><?php echo esc_html( bhg_t( 'hunt_closed_successfully', 'Hunt closed successfully.' ) ); ?></p></div>
 	<?php endif; ?>
 
-	<table class="widefat striped bhg-margin-top-small">
-	<thead>
-		<tr>
-		<th><?php echo esc_html( bhg_t( 'id', 'ID' ) ); ?></th>
-		<th><?php echo esc_html( bhg_t( 'sc_title', 'Title' ) ); ?></th>
-		<th><?php echo esc_html( bhg_t( 'sc_start_balance', 'Start Balance' ) ); ?></th>
-		<th><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></th>
-		<th><?php echo esc_html( bhg_t( 'winners', 'Winners' ) ); ?></th>
-		<th><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) ); ?></th>
-		<th><?php echo esc_html( bhg_t( 'label_actions', 'Actions' ) ); ?></th>
-		</tr>
-	</thead>
+<table class="widefat striped bhg-margin-top-small">
+<thead>
+<tr>
+<th><a href="
+	<?php
+	echo esc_url(
+		add_query_arg(
+			array(
+				'orderby' => 'id',
+				'order'   => ( 'id' === $orderby && 'ASC' === $order ? 'desc' : 'asc' ),
+			),
+			$sort_base
+		)
+	);
+	?>
+				"><?php echo esc_html( bhg_t( 'id', 'ID' ) ); ?></a></th>
+<th><a href="
+	<?php
+	echo esc_url(
+		add_query_arg(
+			array(
+				'orderby' => 'title',
+				'order'   => ( 'title' === $orderby && 'ASC' === $order ? 'desc' : 'asc' ),
+			),
+			$sort_base
+		)
+	);
+	?>
+				"><?php echo esc_html( bhg_t( 'sc_title', 'Title' ) ); ?></a></th>
+<th><a href="
+	<?php
+	echo esc_url(
+		add_query_arg(
+			array(
+				'orderby' => 'starting_balance',
+				'order'   => ( 'starting_balance' === $orderby && 'ASC' === $order ? 'desc' : 'asc' ),
+			),
+			$sort_base
+		)
+	);
+	?>
+				"><?php echo esc_html( bhg_t( 'sc_start_balance', 'Start Balance' ) ); ?></a></th>
+<th><a href="
+	<?php
+	echo esc_url(
+		add_query_arg(
+			array(
+				'orderby' => 'final_balance',
+				'order'   => ( 'final_balance' === $orderby && 'ASC' === $order ? 'desc' : 'asc' ),
+			),
+			$sort_base
+		)
+	);
+	?>
+				"><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></a></th>
+<th><a href="
+	<?php
+	echo esc_url(
+		add_query_arg(
+			array(
+				'orderby' => 'affiliate',
+				'order'   => ( 'affiliate' === $orderby && 'ASC' === $order ? 'desc' : 'asc' ),
+			),
+			$sort_base
+		)
+	);
+	?>
+				"><?php echo esc_html( bhg_t( 'affiliate', 'Affiliate' ) ); ?></a></th>
+<th><a href="
+	<?php
+	echo esc_url(
+		add_query_arg(
+			array(
+				'orderby' => 'winners',
+				'order'   => ( 'winners' === $orderby && 'ASC' === $order ? 'desc' : 'asc' ),
+			),
+			$sort_base
+		)
+	);
+	?>
+				"><?php echo esc_html( bhg_t( 'winners', 'Winners' ) ); ?></a></th>
+<th><a href="
+	<?php
+	echo esc_url(
+		add_query_arg(
+			array(
+				'orderby' => 'status',
+				'order'   => ( 'status' === $orderby && 'ASC' === $order ? 'desc' : 'asc' ),
+			),
+			$sort_base
+		)
+	);
+	?>
+				"><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) ); ?></a></th>
+<th><?php echo esc_html( bhg_t( 'label_actions', 'Actions' ) ); ?></th>
+</tr>
+</thead>
 	<tbody>
 		<?php if ( empty( $hunts ) ) : ?>
-		<tr><td colspan="7"><?php echo esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ); ?></td></tr>
+<tr><td colspan="8"><?php echo esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ); ?></td></tr>
 			<?php
 		else :
 			foreach ( $hunts as $h ) :
@@ -101,12 +219,13 @@ if ( 'list' === $view ) :
 				);
 				?>
 							"><?php echo esc_html( $h->title ); ?></a></td>
-			<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-					<td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
-			<td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
-					   <td><?php echo esc_html( bhg_t( $h->status, ucfirst( $h->status ) ) ); ?></td>
-			<td>
-			<a class="button" href="
+<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
+<td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
+<td><?php echo $h->affiliate_name ? esc_html( $h->affiliate_name ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
+<td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
+<td><?php echo esc_html( bhg_t( $h->status, ucfirst( $h->status ) ) ); ?></td>
+<td>
+<a class="button" href="
 				<?php
 				echo esc_url(
 					add_query_arg(
@@ -117,9 +236,9 @@ if ( 'list' === $view ) :
 					)
 				);
 				?>
-									"><?php echo esc_html( bhg_t( 'button_edit', 'Edit' ) ); ?></a>
+"><?php echo esc_html( bhg_t( 'button_edit', 'Edit' ) ); ?></a>
 				<?php if ( 'open' === $h->status ) : ?>
-				<a class="button" href="
+<a class="button" href="
 					<?php
 					echo esc_url(
 						add_query_arg(
@@ -130,11 +249,24 @@ if ( 'list' === $view ) :
 						)
 					);
 					?>
-										"><?php echo esc_html( bhg_t( 'close_hunt', 'Close Hunt' ) ); ?></a>
-			<?php elseif ( $h->final_balance !== null ) : ?>
-				<a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html( bhg_t( 'button_results', 'Results' ) ); ?></a>
-			<?php endif; ?>
-			</td>
+"><?php echo esc_html( bhg_t( 'close_hunt', 'Close Hunt' ) ); ?></a>
+<?php elseif ( $h->final_balance !== null ) : ?>
+<a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html( bhg_t( 'button_results', 'Results' ) ); ?></a>
+<?php endif; ?>
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( bhg_t( 'delete_this_hunt', 'Delete this hunt?' ) ); ?>');" class="bhg-inline-form">
+				<?php wp_nonce_field( 'bhg_delete_hunt', 'bhg_delete_hunt_nonce' ); ?>
+<input type="hidden" name="action" value="bhg_delete_hunt" />
+<input type="hidden" name="hunt_id" value="<?php echo (int) $h->id; ?>" />
+<button type="submit" class="button-link-delete"><?php echo esc_html( bhg_t( 'delete', 'Delete' ) ); ?></button>
+</form>
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-inline-form">
+				<?php wp_nonce_field( 'bhg_toggle_guessing', 'bhg_toggle_guessing_nonce' ); ?>
+<input type="hidden" name="action" value="bhg_toggle_guessing" />
+<input type="hidden" name="hunt_id" value="<?php echo (int) $h->id; ?>" />
+<input type="hidden" name="guessing_enabled" value="<?php echo $h->guessing_enabled ? 0 : 1; ?>" />
+<button type="submit" class="button"><?php echo esc_html( $h->guessing_enabled ? bhg_t( 'disable_guessing', 'Disable Guessing' ) : bhg_t( 'enable_guessing', 'Enable Guessing' ) ); ?></button>
+</form>
+</td>
 		</tr>
 				<?php
 			endforeach;
@@ -166,16 +298,16 @@ endif;
 <?php
 /** CLOSE VIEW */
 if ( 'close' === $view ) :
-			   $id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
-			   // db call ok; no-cache ok.
-			   $hunt = $wpdb->get_row(
-					   $wpdb->prepare(
-							   'SELECT * FROM %i WHERE id = %d',
-							   $hunts_table,
-							   $id
-					   )
-			   );
-		if ( ! $hunt || 'open' !== $hunt->status ) :
+				$id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
+				// db call ok; no-cache ok.
+				$hunt = $wpdb->get_row(
+					$wpdb->prepare(
+						'SELECT * FROM %i WHERE id = %d',
+						$hunts_table,
+						$id
+					)
+				);
+	if ( ! $hunt || 'open' !== $hunt->status ) :
 		echo '<div class="notice notice-error"><p>' . esc_html( bhg_t( 'invalid_hunt_2', 'Invalid hunt.' ) ) . '</p></div>';
 	else :
 		?>
@@ -268,9 +400,9 @@ if ( $view === 'add' ) :
 												$t_table = esc_sql( $t_table );
 												// db call ok; no-cache ok.
 												$tours = $wpdb->get_results(
-														$wpdb->prepare( 'SELECT id, title FROM %i ORDER BY title ASC', $t_table )
+													$wpdb->prepare( 'SELECT id, title FROM %i ORDER BY title ASC', $t_table )
 												);
-												$tsel = isset( $hunt->tournament_id ) ? (int) $hunt->tournament_id : 0;
+												$tsel  = isset( $hunt->tournament_id ) ? (int) $hunt->tournament_id : 0;
 												?>
 						<select id="bhg_tournament" name="tournament_id">
 								<option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
@@ -286,12 +418,16 @@ if ( $view === 'add' ) :
 						</select>
 						</td>
 				</tr>
-				<tr>
-						<th scope="row"><label for="bhg_winners"><?php echo esc_html( bhg_t( 'number_of_winners', 'Number of Winners' ) ); ?></label></th>
-						<td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="3"></td>
-				</tr>
-				<tr>
-			<th scope="row"><label for="bhg_status"><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) ); ?></label></th>
+<tr>
+<th scope="row"><label for="bhg_winners"><?php echo esc_html( bhg_t( 'number_of_winners', 'Number of Winners' ) ); ?></label></th>
+<td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="3"></td>
+</tr>
+<tr>
+<th scope="row"><label for="bhg_guessing_enabled"><?php echo esc_html( bhg_t( 'guessing_enabled', 'Guessing Enabled' ) ); ?></label></th>
+<td><input type="checkbox" id="bhg_guessing_enabled" name="guessing_enabled" value="1" checked></td>
+</tr>
+<tr>
+<th scope="row"><label for="bhg_status"><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) ); ?></label></th>
 			<td>
 			<select id="bhg_status" name="status">
 				<option value="open"><?php echo esc_html( bhg_t( 'open', 'Open' ) ); ?></option>
@@ -315,14 +451,14 @@ if ( $view === 'add' ) :
 if ( $view === 'edit' ) :
 		$id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
 		// db call ok; no-cache ok.
-			   $hunt = $wpdb->get_row(
-					   $wpdb->prepare(
-							   'SELECT * FROM %i WHERE id = %d',
-							   $hunts_table,
-							   $id
-					   )
-			   );
-		if ( ! $hunt ) {
+				$hunt = $wpdb->get_row(
+					$wpdb->prepare(
+						'SELECT * FROM %i WHERE id = %d',
+						$hunts_table,
+						$id
+					)
+				);
+	if ( ! $hunt ) {
 		echo '<div class="notice notice-error"><p>' . esc_html( bhg_t( 'invalid_hunt', 'Invalid hunt' ) ) . '</p></div>';
 		return;
 	}
@@ -330,15 +466,15 @@ if ( $view === 'edit' ) :
 	if ( ! in_array( $users_table_local, $allowed_tables, true ) ) {
 			wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
 	}
-	   $users_table_local = esc_sql( $users_table_local );
+		$users_table_local = esc_sql( $users_table_local );
 								// db call ok; no-cache ok.
 														$guesses = $wpdb->get_results(
-																$wpdb->prepare(
-																		'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
-																		$guesses_table,
-																		$users_table_local,
-																		$id
-																				)
+															$wpdb->prepare(
+																'SELECT g.*, u.display_name FROM %i g LEFT JOIN %i u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC',
+																$guesses_table,
+																$users_table_local,
+																$id
+															)
 														);
 	?>
 <div class="wrap">
@@ -406,9 +542,9 @@ if ( $view === 'edit' ) :
 												$t_table = esc_sql( $t_table );
 												// db call ok; no-cache ok.
 												$tours = $wpdb->get_results(
-														$wpdb->prepare( 'SELECT id, title FROM %i ORDER BY title ASC', $t_table )
+													$wpdb->prepare( 'SELECT id, title FROM %i ORDER BY title ASC', $t_table )
 												);
-												$tsel = isset( $hunt->tournament_id ) ? (int) $hunt->tournament_id : 0;
+												$tsel  = isset( $hunt->tournament_id ) ? (int) $hunt->tournament_id : 0;
 												?>
 						<select id="bhg_tournament" name="tournament_id">
 								<option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
@@ -424,14 +560,18 @@ if ( $view === 'edit' ) :
 						</select>
 						</td>
 				</tr>
-				<tr>
-						<th scope="row"><label for="bhg_winners"><?php echo esc_html( bhg_t( 'number_of_winners', 'Number of Winners' ) ); ?></label></th>
-						<td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ?: 3 ); ?>"></td>
-				</tr>
-				<tr>
-			<th scope="row"><label for="bhg_final"><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></label></th>
-					<td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html( bhg_t( 'label_emdash', '—' ) ) ); ?>"></td>
-		</tr>
+<tr>
+<th scope="row"><label for="bhg_winners"><?php echo esc_html( bhg_t( 'number_of_winners', 'Number of Winners' ) ); ?></label></th>
+<td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ?: 3 ); ?>"></td>
+</tr>
+<tr>
+<th scope="row"><label for="bhg_guessing_enabled"><?php echo esc_html( bhg_t( 'guessing_enabled', 'Guessing Enabled' ) ); ?></label></th>
+<td><input type="checkbox" id="bhg_guessing_enabled" name="guessing_enabled" value="1" <?php checked( $hunt->guessing_enabled, 1 ); ?>></td>
+</tr>
+<tr>
+<th scope="row"><label for="bhg_final"><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></label></th>
+<td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html( bhg_t( 'label_emdash', '—' ) ) ); ?>"></td>
+</tr>
 		<tr>
 			<th scope="row"><label for="bhg_status"><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) ); ?></label></th>
 			<td>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -418,19 +418,19 @@ function bhg_handle_settings_save() {
 		}
 	}
 
-        if ( isset( $_POST['bhg_min_guess_amount'] ) ) {
-                        $min = floatval( wp_unslash( $_POST['bhg_min_guess_amount'] ) );
-                if ( 0 <= $min ) {
-                                $settings['min_guess_amount'] = $min;
-                }
-        }
+	if ( isset( $_POST['bhg_min_guess_amount'] ) ) {
+					$min = floatval( wp_unslash( $_POST['bhg_min_guess_amount'] ) );
+		if ( 0 <= $min ) {
+						$settings['min_guess_amount'] = $min;
+		}
+	}
 
-        if ( isset( $_POST['bhg_currency'] ) ) {
-                        $currency = sanitize_text_field( wp_unslash( $_POST['bhg_currency'] ) );
-                if ( in_array( $currency, array( 'eur', 'usd' ), true ) ) {
-                                $settings['currency'] = $currency;
-                }
-        }
+	if ( isset( $_POST['bhg_currency'] ) ) {
+					$currency = sanitize_text_field( wp_unslash( $_POST['bhg_currency'] ) );
+		if ( in_array( $currency, array( 'eur', 'usd' ), true ) ) {
+						$settings['currency'] = $currency;
+		}
+	}
 
 				// Validate that min is not greater than max.
 	if ( isset( $settings['min_guess_amount'] ) && isset( $settings['max_guess_amount'] ) &&
@@ -530,7 +530,7 @@ function bhg_handle_submit_guess() {
 	$hunt_cache_key = 'bhg_hunt_' . $hunt_id;
 	$hunt           = wp_cache_get( $hunt_cache_key );
 	if ( false === $hunt ) {
-		$hunt = $wpdb->get_row( $wpdb->prepare( 'SELECT id, status FROM %i WHERE id = %d', $hunts, $hunt_id ) );
+		$hunt = $wpdb->get_row( $wpdb->prepare( 'SELECT id, status, guessing_enabled FROM %i WHERE id = %d', $hunts, $hunt_id ) );
 		wp_cache_set( $hunt_cache_key, $hunt );
 	}
 	if ( ! $hunt ) {
@@ -539,11 +539,12 @@ function bhg_handle_submit_guess() {
 		}
 			wp_die( esc_html( bhg_t( 'notice_hunt_not_found', 'Hunt not found.' ) ) );
 	}
-	if ( 'open' !== $hunt->status ) {
+	if ( 'open' !== $hunt->status || ! $hunt->guessing_enabled ) {
+		$msg = ! $hunt->guessing_enabled ? bhg_t( 'guessing_disabled_for_this_hunt', 'Guessing is disabled for this hunt.' ) : bhg_t( 'this_hunt_is_closed_you_cannot_submit_or_change_a_guess', 'This hunt is closed. You cannot submit or change a guess.' );
 		if ( wp_doing_ajax() ) {
-				wp_send_json_error( bhg_t( 'this_hunt_is_closed_you_cannot_submit_or_change_a_guess', 'This hunt is closed. You cannot submit or change a guess.' ) );
+			wp_send_json_error( $msg );
 		}
-			wp_die( esc_html( bhg_t( 'this_hunt_is_closed_you_cannot_submit_or_change_a_guess', 'This hunt is closed. You cannot submit or change a guess.' ) ) );
+		wp_die( esc_html( $msg ) );
 	}
 
 		// Insert or update last guess per settings.

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -42,23 +42,24 @@ class BHG_DB {
 
 		// Bonus Hunts
 		$sql[] = "CREATE TABLE {$hunts_table} (
-			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-			title VARCHAR(190) NOT NULL,
-			starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
-			num_bonuses INT UNSIGNED NOT NULL DEFAULT 0,
-			prizes TEXT NULL,
-						affiliate_site_id BIGINT UNSIGNED NULL,
-						tournament_id BIGINT UNSIGNED NULL,
-						winners_count INT UNSIGNED NOT NULL DEFAULT 3,
-						final_balance DECIMAL(12,2) NULL,
-						status VARCHAR(20) NOT NULL DEFAULT 'open',
-						created_at DATETIME NULL,
-						updated_at DATETIME NULL,
-						closed_at DATETIME NULL,
-						PRIMARY KEY  (id),
-						KEY status (status),
-						KEY tournament_id (tournament_id)
-				) {$charset_collate};";
+id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+title VARCHAR(190) NOT NULL,
+starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+num_bonuses INT UNSIGNED NOT NULL DEFAULT 0,
+prizes TEXT NULL,
+affiliate_site_id BIGINT UNSIGNED NULL,
+tournament_id BIGINT UNSIGNED NULL,
+winners_count INT UNSIGNED NOT NULL DEFAULT 3,
+guessing_enabled TINYINT(1) NOT NULL DEFAULT 1,
+final_balance DECIMAL(12,2) NULL,
+status VARCHAR(20) NOT NULL DEFAULT 'open',
+created_at DATETIME NULL,
+updated_at DATETIME NULL,
+closed_at DATETIME NULL,
+PRIMARY KEY  (id),
+KEY status (status),
+KEY tournament_id (tournament_id)
+) {$charset_collate};";
 
 		// Guesses
 		$sql[] = "CREATE TABLE {$guesses_table} (
@@ -144,31 +145,32 @@ class BHG_DB {
 					   KEY user_id (user_id)
 			   ) {$charset_collate};";
 
-			   foreach ( $sql as $statement ) {
-					   dbDelta( $statement );
-			   }
+		foreach ( $sql as $statement ) {
+				dbDelta( $statement );
+		}
 
-			   // Translations table handled separately.
-			   $this->create_table_translations();
+				// Translations table handled separately.
+				$this->create_table_translations();
 
 		// Idempotent ensure for columns/indexes
 		try {
-						// Hunts: winners_count, affiliate_site_id, tournament_id
-						$need = array(
-								'winners_count'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN winners_count INT UNSIGNED NOT NULL DEFAULT 3",
-								'affiliate_site_id' => "ALTER TABLE `{$hunts_table}` ADD COLUMN affiliate_site_id BIGINT UNSIGNED NULL",
-								'tournament_id'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN tournament_id BIGINT UNSIGNED NULL",
-								'final_balance'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN final_balance DECIMAL(12,2) NULL",
-								'status'            => "ALTER TABLE `{$hunts_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'",
-						);
-						foreach ( $need as $c => $alter ) {
-								if ( ! $this->column_exists( $hunts_table, $c ) ) {
-										$wpdb->query( $alter );
-								}
-						}
-						if ( ! $this->index_exists( $hunts_table, 'tournament_id' ) ) {
-								$wpdb->query( "ALTER TABLE `{$hunts_table}` ADD KEY tournament_id (tournament_id)" );
-						}
+			// Hunts: winners_count, affiliate_site_id, tournament_id
+			$need = array(
+				'winners_count'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN winners_count INT UNSIGNED NOT NULL DEFAULT 3",
+				'affiliate_site_id' => "ALTER TABLE `{$hunts_table}` ADD COLUMN affiliate_site_id BIGINT UNSIGNED NULL",
+				'tournament_id'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN tournament_id BIGINT UNSIGNED NULL",
+				'guessing_enabled'  => "ALTER TABLE `{$hunts_table}` ADD COLUMN guessing_enabled TINYINT(1) NOT NULL DEFAULT 1",
+				'final_balance'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN final_balance DECIMAL(12,2) NULL",
+				'status'            => "ALTER TABLE `{$hunts_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'",
+			);
+			foreach ( $need as $c => $alter ) {
+				if ( ! $this->column_exists( $hunts_table, $c ) ) {
+									$wpdb->query( $alter );
+				}
+			}
+			if ( ! $this->index_exists( $hunts_table, 'tournament_id' ) ) {
+					$wpdb->query( "ALTER TABLE `{$hunts_table}` ADD KEY tournament_id (tournament_id)" );
+			}
 
 			// Tournaments: make sure common columns exist
 			$tneed = array(
@@ -222,34 +224,34 @@ class BHG_DB {
 							}
 						}
 
-											   // Translations columns
-											   $trneed = array(
-													   'slug'         => "ALTER TABLE `{$trans_table}` ADD COLUMN slug VARCHAR(191) NOT NULL",
-													   'default_text' => "ALTER TABLE `{$trans_table}` ADD COLUMN default_text LONGTEXT NOT NULL",
-													   'text'         => "ALTER TABLE `{$trans_table}` ADD COLUMN `text` LONGTEXT NULL",
-													   'locale'       => "ALTER TABLE `{$trans_table}` ADD COLUMN locale VARCHAR(20) NOT NULL",
-													   'created_at'   => "ALTER TABLE `{$trans_table}` ADD COLUMN created_at DATETIME NULL",
-													   'updated_at'   => "ALTER TABLE `{$trans_table}` ADD COLUMN updated_at DATETIME NULL",
-											   );
-											   foreach ( $trneed as $c => $alter ) {
-													   if ( ! $this->column_exists( $trans_table, $c ) ) {
-															   $wpdb->query( $alter );
-													   }
-											   }
-											   // Ensure composite unique index on (slug, locale).
-											   // Drop legacy single-column indexes if present first.
-											  if ( $this->index_exists( $trans_table, 'slug' ) ) {
-													  $wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX slug" );
-											  }
-											  if ( $this->index_exists( $trans_table, 'slug_unique' ) ) {
-													  $wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX slug_unique" );
-											  }
-											  if ( $this->index_exists( $trans_table, 'tkey_locale' ) ) {
-													  $wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX tkey_locale" );
-											  }
-											  if ( ! $this->index_exists( $trans_table, 'slug_locale' ) ) {
-													  $wpdb->query( "ALTER TABLE `{$trans_table}` ADD UNIQUE KEY slug_locale (slug, locale)" );
-											  }
+												// Translations columns
+												$trneed = array(
+													'slug' => "ALTER TABLE `{$trans_table}` ADD COLUMN slug VARCHAR(191) NOT NULL",
+													'default_text' => "ALTER TABLE `{$trans_table}` ADD COLUMN default_text LONGTEXT NOT NULL",
+													'text' => "ALTER TABLE `{$trans_table}` ADD COLUMN `text` LONGTEXT NULL",
+													'locale' => "ALTER TABLE `{$trans_table}` ADD COLUMN locale VARCHAR(20) NOT NULL",
+													'created_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN created_at DATETIME NULL",
+													'updated_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN updated_at DATETIME NULL",
+												);
+												foreach ( $trneed as $c => $alter ) {
+													if ( ! $this->column_exists( $trans_table, $c ) ) {
+															$wpdb->query( $alter );
+													}
+												}
+												// Ensure composite unique index on (slug, locale).
+												// Drop legacy single-column indexes if present first.
+												if ( $this->index_exists( $trans_table, 'slug' ) ) {
+														$wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX slug" );
+												}
+												if ( $this->index_exists( $trans_table, 'slug_unique' ) ) {
+														$wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX slug_unique" );
+												}
+												if ( $this->index_exists( $trans_table, 'tkey_locale' ) ) {
+														$wpdb->query( "ALTER TABLE `{$trans_table}` DROP INDEX tkey_locale" );
+												}
+												if ( ! $this->index_exists( $trans_table, 'slug_locale' ) ) {
+														$wpdb->query( "ALTER TABLE `{$trans_table}` ADD UNIQUE KEY slug_locale (slug, locale)" );
+												}
 
 												// Affiliate websites columns / unique index
 												$afw_need = array(
@@ -289,25 +291,25 @@ class BHG_DB {
 												if ( ! $this->index_exists( $winners_table, 'user_id' ) ) {
 														$wpdb->query( "ALTER TABLE `{$winners_table}` ADD KEY user_id (user_id)" );
 												}
-			   } catch ( Throwable $e ) {
-					   if ( function_exists( 'error_log' ) ) {
-											   error_log( '[BHG] Schema ensure error: ' . $e->getMessage() );
-					   }
-			   }
-	   }
+		} catch ( Throwable $e ) {
+			if ( function_exists( 'error_log' ) ) {
+										error_log( '[BHG] Schema ensure error: ' . $e->getMessage() );
+			}
+		}
+	}
 
-	   /**
-		* Create or update the translations table.
-		*
-		* @return void
-		*/
-	   private function create_table_translations() {
-			   global $wpdb;
+		/**
+		 * Create or update the translations table.
+		 *
+		 * @return void
+		 */
+	private function create_table_translations() {
+			global $wpdb;
 
-			   $table           = $wpdb->prefix . 'bhg_translations';
-			   $charset_collate = $wpdb->get_charset_collate();
+			$table           = $wpdb->prefix . 'bhg_translations';
+			$charset_collate = $wpdb->get_charset_collate();
 
-			   $sql = "CREATE TABLE {$table} (
+			$sql = "CREATE TABLE {$table} (
 					   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 					   slug VARCHAR(191) NOT NULL,
 					   default_text LONGTEXT NOT NULL,
@@ -319,8 +321,8 @@ class BHG_DB {
 					   UNIQUE KEY slug_locale (slug, locale)
 			   ) {$charset_collate};";
 
-			   dbDelta( $sql );
-	   }
+			dbDelta( $sql );
+	}
 
 		/**
 		 * Retrieve all affiliate websites.

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -63,15 +63,15 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 
 			/** [bhg_active_hunt] — list all open hunts */
 		public function active_hunt_shortcode( $atts ) {
-			   global $wpdb;
-			   $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-			   // db call ok; no-cache ok.
-			   $sql         = $wpdb->prepare(
-				   'SELECT * FROM %i WHERE status = %s ORDER BY created_at DESC',
-				   $hunts_table,
-				   'open'
-			   );
-			   $hunts       = $wpdb->get_results( $sql );
+				global $wpdb;
+				$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+				// db call ok; no-cache ok.
+				$sql   = $wpdb->prepare(
+					'SELECT * FROM %i WHERE status = %s ORDER BY created_at DESC',
+					$hunts_table,
+					'open'
+				);
+				$hunts = $wpdb->get_results( $sql );
 
 			if ( ! $hunts ) {
 				return '<div class="bhg-active-hunt"><p>' . esc_html( bhg_t( 'notice_no_active_hunts', 'No active bonus hunts at the moment.' ) ) . '</p></div>';
@@ -116,15 +116,15 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				. '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html( bhg_t( 'button_log_in', 'Log in' ) ) . '</a></p>';
 			}
 
-					   global $wpdb;
-					   $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-					   // db call ok; no-cache ok.
-					   $sql         = $wpdb->prepare(
-						   'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC',
-						   $hunts_table,
-						   'open'
-					   );
-					   $open_hunts  = $wpdb->get_results( $sql );
+						global $wpdb;
+						$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+						// db call ok; no-cache ok.
+			$sql        = $wpdb->prepare(
+				'SELECT id, title FROM %i WHERE status = %s AND guessing_enabled = 1 ORDER BY created_at DESC',
+				$hunts_table,
+				'open'
+			);
+			$open_hunts = $wpdb->get_results( $sql );
 
 			if ( $hunt_id <= 0 ) {
 				if ( ! $open_hunts ) {
@@ -135,21 +135,21 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				}
 			}
 
-					   $user_id = get_current_user_id();
-					   $table   = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
-					   // db call ok; no-cache ok.
-					   $existing_id = $hunt_id > 0 ? (int) $wpdb->get_var(
-						   $wpdb->prepare(
-							   'SELECT id FROM %i WHERE user_id = %d AND hunt_id = %d',
-							   $table,
-							   $user_id,
-							   $hunt_id
-						   )
-					   ) : 0;
-					   // db call ok; no-cache ok.
-					   $existing_guess = $existing_id ? (float) $wpdb->get_var(
-						   $wpdb->prepare( 'SELECT guess FROM %i WHERE id = %d', $table, $existing_id )
-					   ) : '';
+						$user_id = get_current_user_id();
+						$table   = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
+						// db call ok; no-cache ok.
+						$existing_id = $hunt_id > 0 ? (int) $wpdb->get_var(
+							$wpdb->prepare(
+								'SELECT id FROM %i WHERE user_id = %d AND hunt_id = %d',
+								$table,
+								$user_id,
+								$hunt_id
+							)
+						) : 0;
+						// db call ok; no-cache ok.
+						$existing_guess = $existing_id ? (float) $wpdb->get_var(
+							$wpdb->prepare( 'SELECT guess FROM %i WHERE id = %d', $table, $existing_id )
+						) : '';
 
 			$settings = get_option( 'bhg_plugin_settings' );
 			$min      = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
@@ -209,42 +209,42 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			 */
 		public function leaderboard_shortcode( $atts ) {
 										$a = shortcode_atts(
-												array(
-														'hunt_id' => 0,
-														'orderby' => 'guess', // guess|user|position
-														'order'   => 'ASC',
-														'ranking' => 10, // top N results (1–10)
-														'fields'  => 'position,user,guess',
-												),
-												$atts,
-												'bhg_leaderboard'
+											array(
+												'hunt_id' => 0,
+												'orderby' => 'guess', // guess|user|position
+												'order'   => 'ASC',
+												'ranking' => 10, // top N results (1–10)
+												'fields'  => 'position,user,guess',
+											),
+											$atts,
+											'bhg_leaderboard'
 										);
 
-					   global $wpdb;
-					   $hunt_id = (int) $a['hunt_id'];
-			   if ( $hunt_id <= 0 ) {
-					   $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-					   $sql         = $wpdb->prepare( 'SELECT id FROM %i ORDER BY created_at DESC LIMIT 1', $hunts_table );
-					   $hunt_id     = (int) $wpdb->get_var( $sql ); // db call ok; no-cache ok.
-				   if ( $hunt_id <= 0 ) {
-					   return '<p>' . esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ) . '</p>';
-				   }
-			   }
+						global $wpdb;
+						$hunt_id = (int) $a['hunt_id'];
+			if ( $hunt_id <= 0 ) {
+					$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+					$sql         = $wpdb->prepare( 'SELECT id FROM %i ORDER BY created_at DESC LIMIT 1', $hunts_table );
+					$hunt_id     = (int) $wpdb->get_var( $sql ); // db call ok; no-cache ok.
+				if ( $hunt_id <= 0 ) {
+					return '<p>' . esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ) . '</p>';
+				}
+			}
 
 			$g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
 			$u = $this->sanitize_table( $wpdb->users );
 
 						$allowed_orders = array( 'ASC', 'DESC' );
 						$order          = strtoupper( sanitize_key( $a['order'] ) );
-						if ( ! in_array( $order, $allowed_orders, true ) ) {
-								$order = 'ASC';
-						}
+			if ( ! in_array( $order, $allowed_orders, true ) ) {
+					$order = 'ASC';
+			}
 						$allowed_orderby = array(
-								'guess'    => 'g.guess',
-								'user'     => 'u.user_login',
-								'position' => 'g.id', // stable proxy
+							'guess'    => 'g.guess',
+							'user'     => 'u.user_login',
+							'position' => 'g.id', // stable proxy
 						);
-						$orderby_key = sanitize_key( $a['orderby'] );
+						$orderby_key     = sanitize_key( $a['orderby'] );
 						if ( ! isset( $allowed_orderby[ $orderby_key ] ) ) {
 								$orderby_key = 'guess';
 						}
@@ -255,28 +255,28 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 										$fields_raw    = explode( ',', (string) $a['fields'] );
 										$allowed_field = array( 'position', 'user', 'guess' );
 										$fields        = array_values( array_intersect( $allowed_field, array_map( 'sanitize_key', array_map( 'trim', $fields_raw ) ) ) );
-										if ( empty( $fields ) ) {
-														$fields = $allowed_field;
-										}
-
-									   $total = (int) $wpdb->get_var(
-											   $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE hunt_id = %d', $g, $hunt_id )
-									   ); // db call ok; no-cache ok.
-						if ( $total < 1 ) {
-										return '<p>' . esc_html( bhg_t( 'notice_no_guesses_yet', 'No guesses yet.' ) ) . '</p>';
+						if ( empty( $fields ) ) {
+										$fields = $allowed_field;
 						}
 
-										$hunts_table     = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-										$query = $wpdb->prepare(
-							   'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id FROM %i g LEFT JOIN %i u ON u.ID = g.user_id LEFT JOIN %i h ON h.id = g.hunt_id WHERE g.hunt_id = %d',
-							   $g,
-							   $u,
-							   $hunts_table,
-							   $hunt_id
-					   );
-					   $query .= ' ORDER BY ' . $orderby . ' ' . $order; 
-					   $query .= $wpdb->prepare( ' LIMIT %d', $ranking );
-																															   $rows   = $wpdb->get_results( $query ); // db call ok; no-cache ok.
+										$total = (int) $wpdb->get_var(
+											$wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE hunt_id = %d', $g, $hunt_id )
+										); // db call ok; no-cache ok.
+			if ( $total < 1 ) {
+							return '<p>' . esc_html( bhg_t( 'notice_no_guesses_yet', 'No guesses yet.' ) ) . '</p>';
+			}
+
+										$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+										$query       = $wpdb->prepare(
+											'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id FROM %i g LEFT JOIN %i u ON u.ID = g.user_id LEFT JOIN %i h ON h.id = g.hunt_id WHERE g.hunt_id = %d',
+											$g,
+											$u,
+											$hunts_table,
+											$hunt_id
+										);
+						$query                      .= ' ORDER BY ' . $orderby . ' ' . $order;
+						$query                      .= $wpdb->prepare( ' LIMIT %d', $ranking );
+																																$rows = $wpdb->get_results( $query ); // db call ok; no-cache ok.
 
 					wp_enqueue_style(
 						'bhg-shortcodes',
@@ -301,33 +301,33 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 
 								$pos       = 1;
 								$need_user = in_array( 'user', $fields, true );
-						foreach ( $rows as $r ) {
+			foreach ( $rows as $r ) {
 				if ( $need_user ) {
-					$site_id = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
-									   $is_aff  = $site_id > 0
-									   ? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
-									   : (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
+					$site_id                    = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
+										$is_aff = $site_id > 0
+										? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
+										: (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
 					/* translators: %d: user ID. */
 					$user_label = $r->user_login ? $r->user_login : sprintf( bhg_t( 'label_user_hash', 'user#%d' ), (int) $r->user_id );
 				}
 
-					echo '<tr>';
+				echo '<tr>';
 				foreach ( $fields as $field ) {
 					if ( 'position' === $field ) {
 						echo '<td data-column="position">' . (int) $pos . '</td>';
 					} elseif ( 'user' === $field ) {
-												   echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $this->render_affiliate_dot( (bool) $is_aff ) . '</td>';
+													echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $this->render_affiliate_dot( (bool) $is_aff ) . '</td>';
 					} elseif ( 'guess' === $field ) {
 							echo '<td data-column="guess">' . esc_html( number_format_i18n( (float) $r->guess, 2 ) ) . '</td>';
 					}
 				}
-						echo '</tr>';
-												++$pos;
-						}
+				echo '</tr>';
+									++$pos;
+			}
 								echo '</tbody></table>';
 
 								return ob_get_clean();
-				}
+		}
 
 			/**
 			 * [bhg_user_guesses]
@@ -379,12 +379,12 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 						$g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
 						$h = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
 
-			   // Ensure hunts table has created_at column. If missing, attempt migration and fall back.
-			   $has_created_at = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $h, 'created_at' ) );
-			   if ( empty( $has_created_at ) && class_exists( 'BHG_DB' ) ) {
-				   BHG_DB::migrate();
-				   $has_created_at = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $h, 'created_at' ) );
-			   }
+				// Ensure hunts table has created_at column. If missing, attempt migration and fall back.
+				$has_created_at = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $h, 'created_at' ) );
+			if ( empty( $has_created_at ) && class_exists( 'BHG_DB' ) ) {
+				BHG_DB::migrate();
+				$has_created_at = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $h, 'created_at' ) );
+			}
 
 			$where  = array( 'g.user_id = %d' );
 			$params = array( $user_id );
@@ -413,37 +413,37 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				$where[]  = 'g.created_at >= %s';
 				$params[] = $since;
 			}
-					
+
 						$allowed_orders = array( 'ASC', 'DESC' );
 						$order          = strtoupper( sanitize_key( $a['order'] ) );
-						if ( ! in_array( $order, $allowed_orders, true ) ) {
-								$order = 'DESC';
-						}
+			if ( ! in_array( $order, $allowed_orders, true ) ) {
+					$order = 'DESC';
+			}
 						$orderby_map = array(
-								'guess' => 'g.guess',
-								'hunt'  => $has_created_at ? 'h.created_at' : 'h.id',
+							'guess' => 'g.guess',
+							'hunt'  => $has_created_at ? 'h.created_at' : 'h.id',
 						);
 						$orderby_key = sanitize_key( $a['orderby'] );
 						if ( ! isset( $orderby_map[ $orderby_key ] ) ) {
 								$orderby_key = 'hunt';
 						}
-$orderby = $orderby_map[ $orderby_key ];
+						$orderby = $orderby_map[ $orderby_key ];
 
-$params = array_merge( array( $g, $h ), $params );
-$query  = $wpdb->prepare(
-'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id FROM %i g INNER JOIN %i h ON h.id = g.hunt_id WHERE ' . implode( ' AND ', $where ),
-...$params
-);
-$query .= ' ORDER BY ' . $orderby . ' ' . $order;
-						if ( 'recent' === strtolower( $a['timeline'] ) ) {
-								$query .= ' LIMIT 10';
-						}
+						$params = array_merge( array( $g, $h ), $params );
+						$query  = $wpdb->prepare(
+							'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id FROM %i g INNER JOIN %i h ON h.id = g.hunt_id WHERE ' . implode( ' AND ', $where ),
+							...$params
+						);
+			$query             .= ' ORDER BY ' . $orderby . ' ' . $order;
+			if ( 'recent' === strtolower( $a['timeline'] ) ) {
+					$query .= ' LIMIT 10';
+			}
 
 						// db call ok; no-cache ok.
 						$rows = $wpdb->get_results( $query );
-						if ( ! $rows ) {
-								return '<p>' . esc_html( bhg_t( 'notice_no_guesses_found', 'No guesses found.' ) ) . '</p>';
-						}
+			if ( ! $rows ) {
+					return '<p>' . esc_html( bhg_t( 'notice_no_guesses_found', 'No guesses found.' ) ) . '</p>';
+			}
 
 						$show_aff = in_array( 'user', $fields_arr, true ) && in_array( strtolower( (string) $a['aff'] ), array( 'yes', '1', 'true' ), true );
 
@@ -455,21 +455,21 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 						echo '</tr></thead><tbody>';
 
 						$current_user_id = $user_id; // for aff dot.
-						foreach ( $rows as $row ) {
-							echo '<tr>';
-							echo '<td>' . esc_html( $row->title ) . '</td>';
-							$guess_cell = esc_html( number_format_i18n( (float) $row->guess, 2 ) );
-													   if ( $show_aff ) {
-																$dot        = $this->render_affiliate_dot(
-																		get_user_meta( (int) $current_user_id, 'bhg_affiliate_website_' . (int) $row->affiliate_site_id, true )
-																		|| get_user_meta( (int) $current_user_id, 'bhg_is_affiliate', true )
-																);
-																$guess_cell = $dot . $guess_cell;
-														}
+			foreach ( $rows as $row ) {
+				echo '<tr>';
+				echo '<td>' . esc_html( $row->title ) . '</td>';
+				$guess_cell = esc_html( number_format_i18n( (float) $row->guess, 2 ) );
+				if ( $show_aff ) {
+					$dot        = $this->render_affiliate_dot(
+						get_user_meta( (int) $current_user_id, 'bhg_affiliate_website_' . (int) $row->affiliate_site_id, true )
+						|| get_user_meta( (int) $current_user_id, 'bhg_is_affiliate', true )
+					);
+					$guess_cell = $dot . $guess_cell;
+				}
 							echo '<td>' . $guess_cell . '</td>';
 							echo '<td>' . ( isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
 							echo '</tr>';
-						}
+			}
 						echo '</tbody></table>';
 						return ob_get_clean();
 		}
@@ -547,20 +547,20 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 				$params[] = $since;
 			}
 
-			   $sql = 'SELECT h.id, h.title, h.starting_balance, h.final_balance, h.status, h.created_at, h.closed_at, a.name AS aff_name FROM %i h LEFT JOIN %i a ON a.id = h.affiliate_site_id';
-			   if ( $where ) {
-				   $sql .= ' WHERE ' . implode( ' AND ', $where );
-			   }
-			   $order_clause = ' ORDER BY h.created_at DESC';
-			   if ( 'recent' === strtolower( $a['timeline'] ) ) {
-				   $order_clause .= ' LIMIT 10';
-			   }
+				$sql = 'SELECT h.id, h.title, h.starting_balance, h.final_balance, h.status, h.created_at, h.closed_at, a.name AS aff_name FROM %i h LEFT JOIN %i a ON a.id = h.affiliate_site_id';
+			if ( $where ) {
+				$sql .= ' WHERE ' . implode( ' AND ', $where );
+			}
+				$order_clause = ' ORDER BY h.created_at DESC';
+			if ( 'recent' === strtolower( $a['timeline'] ) ) {
+				$order_clause .= ' LIMIT 10';
+			}
 
-			   // db call ok; no-cache ok.
-			   $prep_args = array_merge( array( $h, $aff_table ), $params );
-			   $sql       = $wpdb->prepare( $sql, ...$prep_args );
-			   $sql      .= $order_clause;
-			   $rows      = $wpdb->get_results( $sql );
+				// db call ok; no-cache ok.
+				$prep_args = array_merge( array( $h, $aff_table ), $params );
+				$sql       = $wpdb->prepare( $sql, ...$prep_args );
+				$sql      .= $order_clause;
+				$rows      = $wpdb->get_results( $sql );
 			if ( ! $rows ) {
 				return '<p>' . esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ) . '</p>';
 			}
@@ -598,10 +598,10 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 						 * [bhg_leaderboards] — overall wins leaderboard.
 						 *
 						 * Attributes:
-						   * - fields: comma-separated list of columns to display.
-						   *   Allowed: pos,user,wins,avg,aff,site,hunt,tournament.
-						   * - ranking: range of positions to display (e.g. 1-10 or 5).
-						   * - timeline: optional window (day|week|month|year).
+						 * - fields: comma-separated list of columns to display.
+						 *   Allowed: pos,user,wins,avg,aff,site,hunt,tournament.
+						 * - ranking: range of positions to display (e.g. 1-10 or 5).
+						 * - timeline: optional window (day|week|month|year).
 						 */
 		public function leaderboards_shortcode( $atts ) {
 			$a = shortcode_atts(
@@ -614,24 +614,24 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 				'bhg_leaderboards'
 			);
 
-			   $raw_fields                = array_map( 'trim', explode( ',', (string) $a['fields'] ) );
-			   $allowed_field             = array( 'pos', 'user', 'wins', 'avg', 'aff', 'site', 'hunt', 'tournament' );
-			   $fields_arr                = array_values( array_unique( array_intersect( $allowed_field, array_map( 'sanitize_key', $raw_fields ) ) ) );
-			   if ( empty( $fields_arr ) ) {
-				   $fields_arr = array( 'pos', 'user', 'wins' );
-			   }
+				$raw_fields    = array_map( 'trim', explode( ',', (string) $a['fields'] ) );
+				$allowed_field = array( 'pos', 'user', 'wins', 'avg', 'aff', 'site', 'hunt', 'tournament' );
+				$fields_arr    = array_values( array_unique( array_intersect( $allowed_field, array_map( 'sanitize_key', $raw_fields ) ) ) );
+			if ( empty( $fields_arr ) ) {
+				$fields_arr = array( 'pos', 'user', 'wins' );
+			}
 
-			   global $wpdb;
+				global $wpdb;
 
-			   $ranking_raw = trim( (string) $a['ranking'] );
-			   if ( preg_match( '/^(\d+)-(\d+)$/', $ranking_raw, $m ) ) {
-				   $start = max( 1, min( 10, (int) $m[1] ) );
-				   $end   = max( $start, min( 10, (int) $m[2] ) );
-			   } else {
-				   $start = 1;
-				   $end   = max( 1, min( 10, (int) $ranking_raw ) );
-			   }
-			   $count = $end - $start + 1;
+				$ranking_raw = trim( (string) $a['ranking'] );
+			if ( preg_match( '/^(\d+)-(\d+)$/', $ranking_raw, $m ) ) {
+				$start = max( 1, min( 10, (int) $m[1] ) );
+				$end   = max( $start, min( 10, (int) $m[2] ) );
+			} else {
+				$start = 1;
+				$end   = max( 1, min( 10, (int) $ranking_raw ) );
+			}
+				$count = $end - $start + 1;
 
 			// Optional timeline filter.
 			$where      = '';
@@ -644,8 +644,8 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 				'year'  => '-1 year',
 			);
 			if ( isset( $intervals[ $timeline ] ) ) {
-				$since       = wp_date( 'Y-m-d H:i:s', strtotime( $intervals[ $timeline ], current_time( 'timestamp' ) ) );
-				$where       = ' WHERE r.last_win_date >= %s';
+				$since        = wp_date( 'Y-m-d H:i:s', strtotime( $intervals[ $timeline ], current_time( 'timestamp' ) ) );
+				$where        = ' WHERE r.last_win_date >= %s';
 				$prep_where[] = $since;
 			}
 
@@ -655,35 +655,35 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 			$need_hunt       = in_array( 'hunt', $fields_arr, true );
 			$need_aff        = in_array( 'aff', $fields_arr, true );
 
-			   $r  = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
-			   $u  = $this->sanitize_table( $wpdb->users );
-			   $t  = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
-			   $w  = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliate_websites' );
-			   $hw = $this->sanitize_table( $wpdb->prefix . 'bhg_hunt_winners' );
-			   $h  = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+				$r  = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
+				$u  = $this->sanitize_table( $wpdb->users );
+				$t  = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
+				$w  = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliate_websites' );
+				$hw = $this->sanitize_table( $wpdb->prefix . 'bhg_hunt_winners' );
+				$h  = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
 
-			   // db call ok; no-cache ok.
-			   $sql         = 'SELECT r.user_id, u.user_login, SUM(r.wins) AS total_wins';
-			   $prep_tables = array();
-			   if ( $need_avg ) {
-				   $sql          .= ', (SELECT AVG(hw.position) FROM %i hw WHERE hw.user_id = r.user_id) AS avg_rank';
-				   $prep_tables[] = $hw;
-			   }
-			   $sql          .= ' FROM %i r INNER JOIN %i u ON u.ID = r.user_id';
-			   $prep_tables[] = $r;
-			   $prep_tables[] = $u;
-			   if ( $where ) {
-				   $sql         .= $where;
-				   $prep_tables = array_merge( $prep_tables, $prep_where );
-			   }
-			   $sql  .= ' GROUP BY r.user_id, u.user_login';
-			   $sql   = $wpdb->prepare( $sql, ...$prep_tables );
-			   $sql  .= ' ORDER BY total_wins DESC, u.user_login ASC';
-			   $sql  .= $wpdb->prepare( ' LIMIT %d', $end );
-			   $rows  = $wpdb->get_results( $sql );
-			   if ( $start > 1 ) {
-				   $rows = array_slice( $rows, $start - 1, $count );
-			   }
+				// db call ok; no-cache ok.
+				$sql         = 'SELECT r.user_id, u.user_login, SUM(r.wins) AS total_wins';
+				$prep_tables = array();
+			if ( $need_avg ) {
+				$sql          .= ', (SELECT AVG(hw.position) FROM %i hw WHERE hw.user_id = r.user_id) AS avg_rank';
+				$prep_tables[] = $hw;
+			}
+				$sql          .= ' FROM %i r INNER JOIN %i u ON u.ID = r.user_id';
+				$prep_tables[] = $r;
+				$prep_tables[] = $u;
+			if ( $where ) {
+				$sql        .= $where;
+				$prep_tables = array_merge( $prep_tables, $prep_where );
+			}
+				$sql .= ' GROUP BY r.user_id, u.user_login';
+				$sql  = $wpdb->prepare( $sql, ...$prep_tables );
+				$sql .= ' ORDER BY total_wins DESC, u.user_login ASC';
+				$sql .= $wpdb->prepare( ' LIMIT %d', $end );
+				$rows = $wpdb->get_results( $sql );
+			if ( $start > 1 ) {
+				$rows = array_slice( $rows, $start - 1, $count );
+			}
 
 			if ( ! $rows ) {
 				return '<p>' . esc_html( bhg_t( 'notice_no_data_available', 'No data available.' ) ) . '</p>';
@@ -691,16 +691,16 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 
 			foreach ( $rows as $row ) {
 				if ( $need_site || $need_tournament ) {
-							   // Last tournament and site.
-							   $last_sql = $wpdb->prepare(
-								   'SELECT t.title AS tournament_title, w.name AS site_name FROM %i r INNER JOIN %i t ON t.id = r.tournament_id LEFT JOIN %i w ON w.id = t.affiliate_site_id WHERE r.user_id = %d',
-								   $r,
-								   $t,
-								   $w,
-								   $row->user_id
-							   );
-							   $last_sql .= ' ORDER BY r.last_win_date DESC LIMIT 1';
-							   $last      = $wpdb->get_row( $last_sql );
+								// Last tournament and site.
+								$last_sql  = $wpdb->prepare(
+									'SELECT t.title AS tournament_title, w.name AS site_name FROM %i r INNER JOIN %i t ON t.id = r.tournament_id LEFT JOIN %i w ON w.id = t.affiliate_site_id WHERE r.user_id = %d',
+									$r,
+									$t,
+									$w,
+									$row->user_id
+								);
+								$last_sql .= ' ORDER BY r.last_win_date DESC LIMIT 1';
+								$last      = $wpdb->get_row( $last_sql );
 					if ( $need_tournament ) {
 						$row->tournament_title = $last && isset( $last->tournament_title ) ? $last->tournament_title : '';
 					}
@@ -710,14 +710,14 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 				}
 
 				if ( $need_hunt ) {
-								   // Last hunt won.
-								   $hunt_sql = $wpdb->prepare(
-									   'SELECT h.title FROM %i hw INNER JOIN %i h ON h.id = hw.hunt_id WHERE hw.user_id = %d',
-									   $hw,
-									   $h,
-									   $row->user_id
-								   );
-								   $hunt_sql .= ' ORDER BY hw.created_at DESC LIMIT 1';
+									// Last hunt won.
+									$hunt_sql    = $wpdb->prepare(
+										'SELECT h.title FROM %i hw INNER JOIN %i h ON h.id = hw.hunt_id WHERE hw.user_id = %d',
+										$hw,
+										$h,
+										$row->user_id
+									);
+									$hunt_sql   .= ' ORDER BY hw.created_at DESC LIMIT 1';
 								$hunt_title      = $wpdb->get_var( $hunt_sql );
 								$row->hunt_title = $hunt_title ? $hunt_title : '';
 				}
@@ -754,24 +754,24 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 			}
 			echo '</tr></thead><tbody>';
 
-			   $pos = $start;
-			   foreach ( $rows as $row ) {
-							   if ( $need_aff ) {
-									   $is_aff = (int) get_user_meta( (int) $row->user_id, 'bhg_is_affiliate', true );
-									   $aff    = $this->render_affiliate_dot( (bool) $is_aff );
-							   }
-												/* translators: %d: user ID. */
-												$user_label = $row->user_login ? $row->user_login : sprintf( bhg_t( 'label_user_hash', 'user#%d' ), (int) $row->user_id );
-												echo '<tr>';
+				$pos = $start;
+			foreach ( $rows as $row ) {
+				if ( $need_aff ) {
+					$is_aff = (int) get_user_meta( (int) $row->user_id, 'bhg_is_affiliate', true );
+					$aff    = $this->render_affiliate_dot( (bool) $is_aff );
+				}
+											/* translators: %d: user ID. */
+											$user_label = $row->user_login ? $row->user_login : sprintf( bhg_t( 'label_user_hash', 'user#%d' ), (int) $row->user_id );
+											echo '<tr>';
 				foreach ( $fields_arr as $field ) {
 					if ( 'pos' === $field ) {
-							echo '<td>' . (int) $pos . '</td>';
+						echo '<td>' . (int) $pos . '</td>';
 					} elseif ( 'user' === $field ) {
-								echo '<td>' . esc_html( $user_label ) . '</td>';
+							echo '<td>' . esc_html( $user_label ) . '</td>';
 					} elseif ( 'wins' === $field ) {
 						echo '<td>' . (int) $row->total_wins . '</td>';
 					} elseif ( 'avg' === $field ) {
-							echo '<td>' . ( isset( $row->avg_rank ) ? esc_html( number_format_i18n( (float) $row->avg_rank, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
+						echo '<td>' . ( isset( $row->avg_rank ) ? esc_html( number_format_i18n( (float) $row->avg_rank, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
 					} elseif ( 'aff' === $field ) {
 						echo '<td>' . $aff . '</td>';
 					} elseif ( 'site' === $field ) {
@@ -782,8 +782,8 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 						echo '<td>' . esc_html( $row->tournament_title ?: bhg_t( 'label_emdash', '—' ) ) . '</td>';
 					}
 				}
-							echo '</tr>';
-							++$pos;
+						echo '</tr>';
+						++$pos;
 			}
 					echo '</tbody></table>';
 					return ob_get_clean();
@@ -811,18 +811,18 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 			// Details screen
 			$details_id = isset( $_GET['bhg_tournament_id'] ) ? absint( wp_unslash( $_GET['bhg_tournament_id'] ) ) : 0;
 			if ( $details_id > 0 ) {
-					   $t = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
-					   $r = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
-					   $u = $this->sanitize_table( $wpdb->users );
+						$t = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
+						$r = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
+						$u = $this->sanitize_table( $wpdb->users );
 
-					   // db call ok; no-cache ok.
-					   $tournament = $wpdb->get_row(
-						   $wpdb->prepare(
-							   'SELECT id, type, start_date, end_date, status FROM %i WHERE id = %d',
-							   $t,
-							   $details_id
-						   )
-					   );
+						// db call ok; no-cache ok.
+						$tournament = $wpdb->get_row(
+							$wpdb->prepare(
+								'SELECT id, type, start_date, end_date, status FROM %i WHERE id = %d',
+								$t,
+								$details_id
+							)
+						);
 				if ( ! $tournament ) {
 					return '<p>' . esc_html( bhg_t( 'notice_tournament_not_found', 'Tournament not found.' ) ) . '</p>';
 				}
@@ -832,9 +832,9 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 						$order          = isset( $_GET['order'] ) ? strtolower( sanitize_key( wp_unslash( $_GET['order'] ) ) ) : 'desc';
 
 						$allowed = array(
-								'wins'        => 'r.wins',
-								'username'    => 'u.user_login',
-								'last_win_at' => 'r.last_win_date',
+							'wins'        => 'r.wins',
+							'username'    => 'u.user_login',
+							'last_win_at' => 'r.last_win_date',
 						);
 						if ( ! isset( $allowed[ $orderby ] ) ) {
 								$orderby = 'wins';
@@ -845,14 +845,14 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 						$orderby_column = $allowed[ $orderby ];
 						$order          = strtoupper( $order );
 
-								   $query = $wpdb->prepare(
-									   'SELECT r.user_id, r.wins, r.last_win_date, u.user_login FROM %i r INNER JOIN %i u ON u.ID = r.user_id WHERE r.tournament_id = %d',
-									   $r,
-									   $u,
-									   $tournament->id
-								   );
-								$query                                .= ' ORDER BY ' . $orderby_column . ' ' . $order . ', r.user_id ASC';
-								$rows                                  = $wpdb->get_results( $query ); // db call ok; no-cache ok.
+									$query = $wpdb->prepare(
+										'SELECT r.user_id, r.wins, r.last_win_date, u.user_login FROM %i r INNER JOIN %i u ON u.ID = r.user_id WHERE r.tournament_id = %d',
+										$r,
+										$u,
+										$tournament->id
+									);
+								$query    .= ' ORDER BY ' . $orderby_column . ' ' . $order . ', r.user_id ASC';
+								$rows      = $wpdb->get_results( $query ); // db call ok; no-cache ok.
 
 				$base   = remove_query_arg( array( 'orderby', 'order' ) );
 				$toggle = function ( $key ) use ( $orderby, $order, $base ) {
@@ -963,15 +963,15 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 				$args[]  = $website;
 			}
 
-			   $query = 'SELECT * FROM %i';
-			   if ( $where ) {
-				   $query .= ' WHERE ' . implode( ' AND ', $where );
-			   }
-			   $query .= ' ORDER BY start_date DESC, id DESC';
+				$query = 'SELECT * FROM %i';
+			if ( $where ) {
+				$query .= ' WHERE ' . implode( ' AND ', $where );
+			}
+				$query .= ' ORDER BY start_date DESC, id DESC';
 
-			   $prep_args = array_merge( array( $t ), $args );
-			   $query     = $wpdb->prepare( $query, ...$prep_args );
-			   $rows      = $wpdb->get_results( $query ); // db call ok; no-cache ok.
+				$prep_args = array_merge( array( $t ), $args );
+				$query     = $wpdb->prepare( $query, ...$prep_args );
+				$rows      = $wpdb->get_results( $query ); // db call ok; no-cache ok.
 			if ( ! $rows ) {
 				return '<p>' . esc_html( bhg_t( 'notice_no_tournaments_found', 'No tournaments found.' ) ) . '</p>';
 			}
@@ -1062,15 +1062,15 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 				'bhg_winner_notifications'
 			);
 
-			   $hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-			   // db call ok; no-cache ok.
-			   $sql         = $wpdb->prepare(
-				   'SELECT id, title, final_balance, winners_count, closed_at FROM %i WHERE status = %s ORDER BY closed_at DESC LIMIT %d',
-				   $hunts_table,
-				   'closed',
-				   (int) $a['limit']
-			   );
-			   $hunts       = $wpdb->get_results( $sql );
+				$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+				// db call ok; no-cache ok.
+				$sql   = $wpdb->prepare(
+					'SELECT id, title, final_balance, winners_count, closed_at FROM %i WHERE status = %s ORDER BY closed_at DESC LIMIT %d',
+					$hunts_table,
+					'closed',
+					(int) $a['limit']
+				);
+				$hunts = $wpdb->get_results( $sql );
 
 			if ( ! $hunts ) {
 				return '<p>' . esc_html( bhg_t( 'notice_no_closed_hunts', 'No closed hunts yet.' ) ) . '</p>';
@@ -1133,9 +1133,9 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 		public function best_guessers_shortcode( $atts ) {
 			global $wpdb;
 
-			   $wins_tbl  = $wpdb->prefix . 'bhg_tournament_results';
-			   $tours_tbl = $wpdb->prefix . 'bhg_tournaments';
-			   $users_tbl = $wpdb->users;
+				$wins_tbl  = $wpdb->prefix . 'bhg_tournament_results';
+				$tours_tbl = $wpdb->prefix . 'bhg_tournaments';
+				$users_tbl = $wpdb->users;
 
 			$now_ts        = current_time( 'timestamp' );
 			$current_month = wp_date( 'Y-m', $now_ts );
@@ -1170,41 +1170,41 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 
 			$results = array();
 			foreach ( $periods as $key => $info ) {
-				   if ( $info['type'] ) {
-					   $where  = 't.type = %s';
-					   $params = array( $info['type'] );
-					   if ( ! empty( $info['start'] ) && ! empty( $info['end'] ) ) {
-						   $where   .= ' AND t.start_date >= %s AND t.end_date <= %s';
-						   $params[] = $info['start'];
-						   $params[] = $info['end'];
-					   }
-					   $sql = 'SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins'
-						   . ' FROM %i r'
-						   . ' INNER JOIN %i u ON u.ID = r.user_id'
-						   . ' INNER JOIN %i t ON t.id = r.tournament_id'
-						   . ' WHERE ' . $where . "\n                                                       GROUP BY u.ID, u.user_login";
-					   // db call ok; no-cache ok.
-					   $sql      = $wpdb->prepare( $sql, $wins_tbl, $users_tbl, $tours_tbl, ...$params );
-					   $sql     .= ' ORDER BY total_wins DESC, u.user_login ASC LIMIT 50';
-					   $results[ $key ] = $wpdb->get_results( $sql );
-				   } else {
-					   $sql = 'SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins'
-						   . ' FROM %i r'
-						   . ' INNER JOIN %i u ON u.ID = r.user_id'
-						   . ' GROUP BY u.ID, u.user_login';
-					   // db call ok; no-cache ok.
-					   $sql     .= ' ORDER BY total_wins DESC, u.user_login ASC LIMIT 50';
-					   $results[ $key ] = $wpdb->get_results( $wpdb->prepare( $sql, $wins_tbl, $users_tbl ) );
-				   }
+				if ( $info['type'] ) {
+					$where  = 't.type = %s';
+					$params = array( $info['type'] );
+					if ( ! empty( $info['start'] ) && ! empty( $info['end'] ) ) {
+						$where   .= ' AND t.start_date >= %s AND t.end_date <= %s';
+						$params[] = $info['start'];
+						$params[] = $info['end'];
+					}
+					$sql = 'SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins'
+						. ' FROM %i r'
+						. ' INNER JOIN %i u ON u.ID = r.user_id'
+						. ' INNER JOIN %i t ON t.id = r.tournament_id'
+						. ' WHERE ' . $where . "\n                                                       GROUP BY u.ID, u.user_login";
+					// db call ok; no-cache ok.
+					$sql             = $wpdb->prepare( $sql, $wins_tbl, $users_tbl, $tours_tbl, ...$params );
+					$sql            .= ' ORDER BY total_wins DESC, u.user_login ASC LIMIT 50';
+					$results[ $key ] = $wpdb->get_results( $sql );
+				} else {
+					$sql = 'SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins'
+						. ' FROM %i r'
+						. ' INNER JOIN %i u ON u.ID = r.user_id'
+						. ' GROUP BY u.ID, u.user_login';
+					// db call ok; no-cache ok.
+					$sql            .= ' ORDER BY total_wins DESC, u.user_login ASC LIMIT 50';
+					$results[ $key ] = $wpdb->get_results( $wpdb->prepare( $sql, $wins_tbl, $users_tbl ) );
+				}
 			}
 
-				   $hunts_tbl = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-				   $hunts_sql = $wpdb->prepare(
-					   'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC LIMIT 50',
-					   $hunts_tbl,
-					   'closed'
-				   );
-				   $hunts     = $wpdb->get_results( $hunts_sql );
+					$hunts_tbl = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+					$hunts_sql = $wpdb->prepare(
+						'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC LIMIT 50',
+						$hunts_tbl,
+						'closed'
+					);
+					$hunts     = $wpdb->get_results( $hunts_sql );
 
 						wp_enqueue_style(
 							'bhg-shortcodes',
@@ -1270,12 +1270,12 @@ $query .= ' ORDER BY ' . $orderby . ' ' . $order;
 			return ob_get_clean();
 		}
 
-					   /** Private: render affiliate dot span */
-			   private function render_affiliate_dot( $is_affiliate ) {
-					   $c = $is_affiliate ? 'green' : 'red';
-					   return '<span class="bhg-aff-dot bhg-aff-' . esc_attr( $c ) . '" aria-hidden="true"></span> ';
-			   }
-	   }
+						/** Private: render affiliate dot span */
+		private function render_affiliate_dot( $is_affiliate ) {
+				$c = $is_affiliate ? 'green' : 'red';
+				return '<span class="bhg-aff-dot bhg-aff-' . esc_attr( $c ) . '" aria-hidden="true"></span> ';
+		}
+	}
 }
 
 // Register once on init even if no other bootstrap instantiates the class


### PR DESCRIPTION
## Summary
- Support searching and sortable columns on Bonus Hunts admin table
- Show affiliate column and allow deleting hunts or toggling guessing
- Store and enforce guessing_enabled flag for hunts

## Testing
- `php -l admin/class-bhg-admin.php`
- `php -l admin/views/bonus-hunts.php`
- `php -l includes/class-bhg-db.php`
- `php -l bonus-hunt-guesser.php`
- `php -l includes/class-bhg-shortcodes.php`
- `vendor/bin/phpcs --standard=phpcs.xml admin/class-bhg-admin.php admin/views/bonus-hunts.php includes/class-bhg-db.php bonus-hunt-guesser.php includes/class-bhg-shortcodes.php` (fails: numerous warnings/errors)


------
https://chatgpt.com/codex/tasks/task_e_68c0f333a4c08333b34c7f3bc7ad86bf