### PR TITLE
Add participants mode and admin improvements for tournaments

### DIFF
--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -17,7 +17,21 @@ $row     = $edit_id
 	? $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $edit_id ) )
 	: null;
 
-$rows = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY id DESC" );
+$search          = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+$orderby         = isset( $_GET['orderby'] ) ? sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) : 'id';
+$order           = isset( $_GET['order'] ) ? strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) : 'DESC';
+$allowed_orderby = array( 'id', 'title', 'type', 'start_date', 'end_date', 'status' );
+if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
+		$orderby = 'id';
+}
+$order = ( 'ASC' === $order ) ? 'ASC' : 'DESC';
+$sql   = "SELECT * FROM {$table}";
+if ( $search ) {
+		$like = '%' . $wpdb->esc_like( $search ) . '%';
+		$sql .= $wpdb->prepare( ' WHERE title LIKE %s', $like );
+}
+$sql .= " ORDER BY {$orderby} {$order}";
+$rows = $wpdb->get_results( $sql );
 
 $labels = array(
 	'weekly'    => bhg_t( 'label_weekly', 'Weekly' ),
@@ -39,39 +53,95 @@ $labels = array(
 	echo esc_html( bhg_t( 'all_tournaments', 'All Tournaments' ) );
 	?>
 </h2>
-	<table class="widefat striped">
-	<thead>
+		<form method="get" class="search-form">
+				<input type="hidden" name="page" value="bhg-tournaments" />
+				<p class="search-box">
+						<label class="screen-reader-text" for="bhg-search-input"><?php echo esc_html( bhg_t( 'search_tournaments', 'Search Tournaments' ) ); ?></label>
+						<input type="search" id="bhg-search-input" name="s" value="<?php echo esc_attr( $search ); ?>" />
+						<?php submit_button( bhg_t( 'search', 'Search' ), 'button', false, false, array( 'id' => 'search-submit' ) ); ?>
+				</p>
+		</form>
+		<table class="widefat striped">
+		<thead>
 		<tr>
-		<th>
-		<?php
-		echo esc_html( bhg_t( 'id', 'ID' ) );
-		?>
-</th>
-		<th>
-		<?php
-		echo esc_html( bhg_t( 'sc_title', 'Title' ) );
-		?>
-</th>
-		<th>
-		<?php
-		echo esc_html( bhg_t( 'label_type', 'Type' ) );
-		?>
-</th>
-		<th>
-		<?php
-		echo esc_html( bhg_t( 'sc_start', 'Start' ) );
-		?>
-</th>
-		<th>
-		<?php
-		echo esc_html( bhg_t( 'sc_end', 'End' ) );
-		?>
-</th>
-		<th>
-		<?php
-		echo esc_html( bhg_t( 'sc_status', 'Status' ) );
-		?>
-</th>
+				<th>
+				<?php
+				$n = ( 'id' === $orderby && 'ASC' === $order ) ? 'desc' : 'asc';
+				echo '<a href="' . esc_url(
+					add_query_arg(
+						array(
+							'orderby' => 'id',
+							'order'   => $n,
+						)
+					)
+				) . '">' . esc_html( bhg_t( 'id', 'ID' ) ) . '</a>';
+				?>
+				</th>
+				<th>
+				<?php
+				$n = ( 'title' === $orderby && 'ASC' === $order ) ? 'desc' : 'asc';
+				echo '<a href="' . esc_url(
+					add_query_arg(
+						array(
+							'orderby' => 'title',
+							'order'   => $n,
+						)
+					)
+				) . '">' . esc_html( bhg_t( 'sc_title', 'Title' ) ) . '</a>';
+				?>
+				</th>
+				<th>
+				<?php
+				$n = ( 'type' === $orderby && 'ASC' === $order ) ? 'desc' : 'asc';
+				echo '<a href="' . esc_url(
+					add_query_arg(
+						array(
+							'orderby' => 'type',
+							'order'   => $n,
+						)
+					)
+				) . '">' . esc_html( bhg_t( 'label_type', 'Type' ) ) . '</a>';
+				?>
+				</th>
+				<th>
+				<?php
+				$n = ( 'start_date' === $orderby && 'ASC' === $order ) ? 'desc' : 'asc';
+				echo '<a href="' . esc_url(
+					add_query_arg(
+						array(
+							'orderby' => 'start_date',
+							'order'   => $n,
+						)
+					)
+				) . '">' . esc_html( bhg_t( 'sc_start', 'Start' ) ) . '</a>';
+				?>
+				</th>
+				<th>
+				<?php
+				$n = ( 'end_date' === $orderby && 'ASC' === $order ) ? 'desc' : 'asc';
+				echo '<a href="' . esc_url(
+					add_query_arg(
+						array(
+							'orderby' => 'end_date',
+							'order'   => $n,
+						)
+					)
+				) . '">' . esc_html( bhg_t( 'sc_end', 'End' ) ) . '</a>';
+				?>
+				</th>
+				<th>
+				<?php
+				$n = ( 'status' === $orderby && 'ASC' === $order ) ? 'desc' : 'asc';
+				echo '<a href="' . esc_url(
+					add_query_arg(
+						array(
+							'orderby' => 'status',
+							'order'   => $n,
+						)
+					)
+				) . '">' . esc_html( bhg_t( 'sc_status', 'Status' ) ) . '</a>';
+				?>
+				</th>
 		<th>
 		<?php
 		echo esc_html( bhg_t( 'label_actions', 'Actions' ) );
@@ -96,14 +166,18 @@ $labels = array(
 			<td><?php echo esc_html( $labels[ $r->type ] ?? $r->type ); ?></td>
 			<td><?php echo esc_html( $r->start_date ); ?></td>
 			<td><?php echo esc_html( $r->end_date ); ?></td>
-					   <td><?php echo esc_html( bhg_t( $r->status, ucfirst( $r->status ) ) ); ?></td>
-			<td>
-			<a class="button" href="<?php echo esc_url( add_query_arg( array( 'edit' => (int) $r->id ) ) ); ?>">
-				<?php
-				echo esc_html( bhg_t( 'button_edit', 'Edit' ) );
-				?>
-</a>
-			</td>
+						<td><?php echo esc_html( bhg_t( $r->status, ucfirst( $r->status ) ) ); ?></td>
+						<td>
+						<a class="button" href="<?php echo esc_url( add_query_arg( array( 'edit' => (int) $r->id ) ) ); ?>">
+								<?php echo esc_html( bhg_t( 'button_edit', 'Edit' ) ); ?>
+						</a>
+						<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline;">
+								<?php wp_nonce_field( 'bhg_tournament_delete_action', 'bhg_tournament_delete_nonce' ); ?>
+								<input type="hidden" name="action" value="bhg_tournament_delete" />
+								<input type="hidden" name="id" value="<?php echo (int) $r->id; ?>" />
+								<button type="submit" class="button button-link-delete" onclick="return confirm('<?php echo esc_js( bhg_t( 'are_you_sure', 'Are you sure?' ) ); ?>');"><?php echo esc_html( bhg_t( 'button_delete', 'Delete' ) ); ?></button>
+						</form>
+						</td>
 		</tr>
 					<?php
 		endforeach;
@@ -153,10 +227,24 @@ endif;
 				<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $cur, $t ); ?>><?php echo esc_html( $labels[ $t ] ); ?></option>
 			<?php endforeach; ?>
 			</select>
-		</td>
-		</tr>
-		<tr>
-		<th><label for="bhg_t_start">
+				</td>
+				</tr>
+				<tr>
+				<th><label for="bhg_t_pmode">
+				<?php
+				echo esc_html( bhg_t( 'participants_mode', 'Participants Mode' ) );
+				?>
+				</label></th>
+				<td>
+						<?php $pmode = $row->participants_mode ?? 'winners'; ?>
+						<select id="bhg_t_pmode" name="participants_mode">
+								<option value="winners" <?php selected( $pmode, 'winners' ); ?>><?php echo esc_html( bhg_t( 'winners', 'Winners' ) ); ?></option>
+								<option value="all" <?php selected( $pmode, 'all' ); ?>><?php echo esc_html( bhg_t( 'all', 'All' ) ); ?></option>
+						</select>
+				</td>
+				</tr>
+				<tr>
+				<th><label for="bhg_t_start">
 		<?php
 		echo esc_html( bhg_t( 'label_start_date', 'Start Date' ) );
 		?>

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -74,20 +74,21 @@ KEY tournament_id (tournament_id)
 		) {$charset_collate};";
 
 				// Tournaments
-				$sql[] = "CREATE TABLE {$tours_table} (
-						id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-						title VARCHAR(190) NOT NULL,
-						description TEXT NULL,
-						type VARCHAR(20) NOT NULL,
-						start_date DATE NULL,
-						end_date DATE NULL,
-						status VARCHAR(20) NOT NULL DEFAULT 'active',
-						created_at DATETIME NULL,
-						updated_at DATETIME NULL,
-						PRIMARY KEY  (id),
-						KEY type (type),
-						KEY status (status)
-				) {$charset_collate};";
+								$sql[] = "CREATE TABLE {$tours_table} (
+                                                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                                                title VARCHAR(190) NOT NULL,
+                                                description TEXT NULL,
+                                                type VARCHAR(20) NOT NULL,
+                                                participants_mode VARCHAR(20) NOT NULL DEFAULT 'winners',
+                                                start_date DATE NULL,
+                                                end_date DATE NULL,
+                                                status VARCHAR(20) NOT NULL DEFAULT 'active',
+                                                created_at DATETIME NULL,
+                                                updated_at DATETIME NULL,
+                                                PRIMARY KEY  (id),
+                                                KEY type (type),
+                                                KEY status (status)
+                                ) {$charset_collate};";
 
 				// Tournament Results
 				$sql[] = "CREATE TABLE {$tres_table} (
@@ -173,19 +174,20 @@ KEY tournament_id (tournament_id)
 			}
 
 			// Tournaments: make sure common columns exist
-			$tneed = array(
-				'title'       => "ALTER TABLE `{$tours_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
-				'description' => "ALTER TABLE `{$tours_table}` ADD COLUMN description TEXT NULL",
-				'type'        => "ALTER TABLE `{$tours_table}` ADD COLUMN type VARCHAR(20) NOT NULL",
-				'start_date'  => "ALTER TABLE `{$tours_table}` ADD COLUMN start_date DATE NULL",
-				'end_date'    => "ALTER TABLE `{$tours_table}` ADD COLUMN end_date DATE NULL",
-				'status'      => "ALTER TABLE `{$tours_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
-			);
-			foreach ( $tneed as $c => $alter ) {
-				if ( ! $this->column_exists( $tours_table, $c ) ) {
+						$tneed = array(
+							'title'             => "ALTER TABLE `{$tours_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
+							'description'       => "ALTER TABLE `{$tours_table}` ADD COLUMN description TEXT NULL",
+							'type'              => "ALTER TABLE `{$tours_table}` ADD COLUMN type VARCHAR(20) NOT NULL",
+							'participants_mode' => "ALTER TABLE `{$tours_table}` ADD COLUMN participants_mode VARCHAR(20) NOT NULL DEFAULT 'winners'",
+							'start_date'        => "ALTER TABLE `{$tours_table}` ADD COLUMN start_date DATE NULL",
+							'end_date'          => "ALTER TABLE `{$tours_table}` ADD COLUMN end_date DATE NULL",
+							'status'            => "ALTER TABLE `{$tours_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
+						);
+						foreach ( $tneed as $c => $alter ) {
+							if ( ! $this->column_exists( $tours_table, $c ) ) {
 								$wpdb->query( $alter );
-				}
-			}
+							}
+						}
 
 						// Tournament results columns
 						$trrneed = array(

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -220,7 +220,6 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'label_status_colon'                           => 'Status:',
 			'label_wins'                                   => 'Wins',
 			'label_last_win'                               => 'Last win',
-			'label_period'                                 => 'Period',
 			'label_all'                                    => 'All',
 			'label_weekly'                                 => 'Weekly',
 			'label_monthly'                                => 'Monthly',
@@ -524,7 +523,6 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'inactive'                                     => 'Inactive',
 			'optimize_database_tables'                     => 'Optimize Database Tables',
 			'participants'                                 => 'Participants',
-			'period'                                       => 'Period:',
 			'placement'                                    => 'Placement',
 			'play_responsibly'                             => 'Play responsibly.',
 			'please_enter_a_guess'                         => 'Please enter a guess.',
@@ -562,6 +560,7 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'settings_currently_unavailable'               => 'Settings management is currently unavailable.',
 			'show_ads_block_on_selected_pages'             => 'Show ads block on selected pages.',
 			'status'                                       => 'Status:',
+			'participants_mode'                            => 'Participants Mode',
 			'tshirt'                                       => 'T-shirt',
 			'table_name'                                   => 'Table Name',
 			'tables_are_automatically_created_on_activation_if_you_need_to_reinstall_them_deactivate_and_activate_the_plugin_again' => 'Tables are automatically created on activation. If you need to reinstall them, deactivate and activate the plugin again.',
@@ -570,6 +569,7 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'this_will_delete_all_demo_data_and_pages_then_recreate_fresh_demo_content' => 'This will delete all demo data and pages, then recreate fresh demo content.',
 			'titlecontent'                                 => 'Title/Content',
 			'tournament_saved'                             => 'Tournament saved.',
+			'tournament_deleted'                           => 'Tournament deleted.',
 			'tournaments'                                  => 'Tournaments:',
 			'translation_saved'                            => 'Translation saved.',
 			'tools_action_completed'                       => 'Tools action completed.',
@@ -587,6 +587,10 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'view_not_found'                               => 'View Not Found',
 			'requested_view_not_found'                     => 'The requested view "%s" was not found.',
 			'winners'                                      => 'Winners',
+			'all'                                          => 'All',
+			'search'                                       => 'Search',
+			'search_tournaments'                           => 'Search Tournaments',
+			'are_you_sure'                                 => 'Are you sure?',
 			'yes'                                          => 'Yes',
 			'you_do_not_have_permission_to_access_this_page' => 'You do not have permission to access this page',
 			'you_do_not_have_permission_to_do_that'        => 'You do not have permission to do that.',
@@ -672,14 +676,14 @@ if ( ! function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
  * @return string
  */
 function bhg_currency_symbol() {
-        $settings = get_option( 'bhg_plugin_settings', array() );
-        $currency = isset( $settings['currency'] ) ? $settings['currency'] : 'eur';
-        $map      = array(
-                'usd' => '$',
-                'eur' => '€',
-        );
-        $symbol   = isset( $map[ $currency ] ) ? $map[ $currency ] : '€';
-        return apply_filters( 'bhg_currency_symbol', $symbol, $currency );
+		$settings = get_option( 'bhg_plugin_settings', array() );
+		$currency = isset( $settings['currency'] ) ? $settings['currency'] : 'eur';
+		$map      = array(
+			'usd' => '$',
+			'eur' => '€',
+		);
+		$symbol   = isset( $map[ $currency ] ) ? $map[ $currency ] : '€';
+		return apply_filters( 'bhg_currency_symbol', $symbol, $currency );
 }
 
 /**
@@ -689,7 +693,7 @@ function bhg_currency_symbol() {
  * @return string
  */
 function bhg_format_currency( $amount ) {
-        return sprintf( '%s%s', bhg_currency_symbol(), number_format_i18n( (float) $amount, 2 ) );
+		return sprintf( '%s%s', bhg_currency_symbol(), number_format_i18n( (float) $amount, 2 ) );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add search, sorting, and delete controls to tournament admin list
- Support choosing participants mode (winners or all) when creating tournaments
- Persist participants mode in database and remove old period references

## Testing
- `composer install`
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f6316cc88333afc4e860685b613f