### PR TITLE
Use bhg_format_currency for monetary values

### DIFF
--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -135,8 +135,8 @@ $base_url  = esc_url( admin_url( 'admin.php?page=bhg-hunt-results' ) );
 								<?php if ( 'tournament' === $view_type ) : ?>
 										<td><?php echo (int) $r->wins; ?></td>
 								<?php else : ?>
-									<td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>
-									<td><?php echo esc_html( number_format_i18n( (float) $r->diff, 2 ) ); ?></td>
+                                                                        <td><?php echo esc_html( bhg_format_currency( (float) $r->guess ) ); ?></td>
+                                                                        <td><?php echo esc_html( bhg_format_currency( (float) $r->diff ) ); ?></td>
 							<?php endif; ?>
 					</tr>
 					<?php

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -219,8 +219,8 @@ if ( 'list' === $view ) :
 				);
 				?>
 							"><?php echo esc_html( $h->title ); ?></a></td>
-<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-<td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
+<td><?php echo esc_html( bhg_format_currency( (float) $h->starting_balance ) ); ?></td>
+<td><?php echo null !== $h->final_balance ? esc_html( bhg_format_currency( (float) $h->final_balance ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
 <td><?php echo $h->affiliate_name ? esc_html( $h->affiliate_name ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
 <td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
 <td><?php echo esc_html( bhg_t( $h->status, ucfirst( $h->status ) ) ); ?></td>
@@ -611,7 +611,7 @@ if ( $view === 'edit' ) :
 							echo '<a href="' . esc_url( $url ) . '">' . esc_html( $name ) . '</a>';
 							?>
 			</td>
-			<td><?php echo esc_html( number_format_i18n( (float) ( $g->guess ?? 0 ), 2 ) ); ?></td>
+                        <td><?php echo esc_html( bhg_format_currency( (float) ( $g->guess ?? 0 ) ) ); ?></td>
 			<td>
 						<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( bhg_t( 'delete_this_guess', 'Delete this guess?' ) ); ?>');" class="bhg-inline-form">
 																<?php wp_nonce_field( 'bhg_delete_guess', 'bhg_delete_guess_nonce' ); ?>

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -114,9 +114,9 @@ $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect: id, title, starting_balanc
 																						'%1$s %2$s %3$s (%4$s %5$s)',
 																						esc_html( $nm ),
 																						esc_html_x( '—', 'name/guess separator', 'bonus-hunt-guesser' ),
-																						esc_html( number_format_i18n( $guess, 2 ) ),
+                                                                                                                               esc_html( bhg_format_currency( $guess ) ),
 																						esc_html( bhg_t( 'label_diff', 'diff' ) ),
-																						esc_html( number_format_i18n( $diff, 2 ) )
+                                                                                                                               esc_html( bhg_format_currency( $diff ) )
 																					);
 																				}
 																				$winners_out = implode( ' • ', $out );
@@ -128,11 +128,11 @@ $hunts = bhg_get_latest_closed_hunts( 3 ); // Expect: id, title, starting_balanc
 																				<tr>
 																						<td><?php echo '' !== $hunt_title ? esc_html( $hunt_title ) : esc_html( bhg_t( 'label_untitled', '(untitled)' ) ); ?></td>
 																						<td><?php echo esc_html( $winners_out ); ?></td>
-																						<td><?php echo esc_html( number_format_i18n( $start, 2 ) ); ?></td>
+                                                                                                                               <td><?php echo esc_html( bhg_format_currency( $start ) ); ?></td>
 																						<td>
 																						<?php
 																						if ( isset( $h->final_balance ) && null !== $h->final_balance ) {
-																								echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
+                                                                                                                               echo esc_html( bhg_format_currency( (float) $h->final_balance ) );
 																						} else {
 																								echo esc_html( bhg_t( 'label_emdash', '—' ) );
 																						}

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -90,7 +90,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				echo '<div class="bhg-hunt-card">';
 				echo '<h3>' . esc_html( $hunt->title ) . '</h3>';
 				echo '<ul class="bhg-hunt-meta">';
-				echo '<li><strong>' . esc_html( bhg_t( 'label_start_balance', 'Starting Balance' ) ) . ':</strong> ' . esc_html( number_format_i18n( (float) $hunt->starting_balance, 2 ) ) . '</li>';
+                                echo '<li><strong>' . esc_html( bhg_t( 'label_start_balance', 'Starting Balance' ) ) . ':</strong> ' . esc_html( bhg_format_currency( (float) $hunt->starting_balance ) ) . '</li>';
 				echo '<li><strong>' . esc_html( bhg_t( 'label_number_bonuses', 'Number of Bonuses' ) ) . ':</strong> ' . (int) $hunt->num_bonuses . '</li>';
 				if ( ! empty( $hunt->prizes ) ) {
 					echo '<li><strong>' . esc_html( bhg_t( 'sc_prizes', 'Prizes' ) ) . ':</strong> ' . wp_kses_post( $hunt->prizes ) . '</li>';
@@ -317,9 +317,9 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 						echo '<td data-column="position">' . (int) $pos . '</td>';
 					} elseif ( 'user' === $field ) {
 													echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $this->render_affiliate_dot( (bool) $is_aff ) . '</td>';
-					} elseif ( 'guess' === $field ) {
-							echo '<td data-column="guess">' . esc_html( number_format_i18n( (float) $r->guess, 2 ) ) . '</td>';
-					}
+                                        } elseif ( 'guess' === $field ) {
+                                                        echo '<td data-column="guess">' . esc_html( bhg_format_currency( (float) $r->guess ) ) . '</td>';
+                                        }
 				}
 				echo '</tr>';
 									++$pos;
@@ -458,7 +458,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			foreach ( $rows as $row ) {
 				echo '<tr>';
 				echo '<td>' . esc_html( $row->title ) . '</td>';
-				$guess_cell = esc_html( number_format_i18n( (float) $row->guess, 2 ) );
+                                $guess_cell = esc_html( bhg_format_currency( (float) $row->guess ) );
 				if ( $show_aff ) {
 					$dot        = $this->render_affiliate_dot(
 						get_user_meta( (int) $current_user_id, 'bhg_affiliate_website_' . (int) $row->affiliate_site_id, true )
@@ -467,7 +467,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					$guess_cell = $dot . $guess_cell;
 				}
 							echo '<td>' . $guess_cell . '</td>';
-							echo '<td>' . ( isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
+                                                        echo '<td>' . ( isset( $row->final_balance ) ? esc_html( bhg_format_currency( (float) $row->final_balance ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
 							echo '</tr>';
 			}
 						echo '</tbody></table>';
@@ -581,8 +581,8 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			foreach ( $rows as $row ) {
 				echo '<tr>';
 				echo '<td>' . esc_html( $row->title ) . '</td>';
-				echo '<td>' . esc_html( number_format_i18n( (float) $row->starting_balance, 2 ) ) . '</td>';
-				echo '<td>' . ( isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
+                                echo '<td>' . esc_html( bhg_format_currency( (float) $row->starting_balance ) ) . '</td>';
+                                echo '<td>' . ( isset( $row->final_balance ) ? esc_html( bhg_format_currency( (float) $row->final_balance ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
 								$status_key = strtolower( (string) $row->status );
 								echo '<td>' . esc_html( bhg_t( $status_key, ucfirst( $status_key ) ) ) . '</td>';
 				if ( $show_aff ) {
@@ -1092,16 +1092,16 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 
 				echo '<div class="bhg-winner">';
 				echo '<p><strong>' . esc_html( $hunt->title ) . '</strong></p>';
-				if ( null !== $hunt->final_balance ) {
-					echo '<p><em>' . esc_html( bhg_t( 'sc_final', 'Final' ) ) . ':</em> ' . esc_html( number_format_i18n( (float) $hunt->final_balance, 2 ) ) . '</p>';
-				}
+                                if ( null !== $hunt->final_balance ) {
+                                        echo '<p><em>' . esc_html( bhg_t( 'sc_final', 'Final' ) ) . ':</em> ' . esc_html( bhg_format_currency( (float) $hunt->final_balance ) ) . '</p>';
+                                }
 
 				if ( $winners ) {
 					echo '<ul class="bhg-winner-list">';
 					foreach ( $winners as $w ) {
 						$u  = get_userdata( (int) $w->user_id );
 						$nm = $u ? $u->user_login : sprintf( bhg_t( 'label_user_number', 'User #%d' ), (int) $w->user_id );
-						echo '<li>' . esc_html( $nm ) . ' ' . esc_html( bhg_t( 'label_emdash', '—' ) ) . ' ' . esc_html( number_format_i18n( (float) $w->guess, 2 ) ) . ' (' . esc_html( number_format_i18n( (float) $w->diff, 2 ) ) . ')</li>';
+                                                echo '<li>' . esc_html( $nm ) . ' ' . esc_html( bhg_t( 'label_emdash', '—' ) ) . ' ' . esc_html( bhg_format_currency( (float) $w->guess ) ) . ' (' . esc_html( bhg_format_currency( (float) $w->diff ) ) . ')</li>';
 					}
 					echo '</ul>';
 				}


### PR DESCRIPTION
## Summary
- Replace direct `number_format_i18n()` usage with `bhg_format_currency()` in admin bonus hunt lists and results screens
- Update dashboard and shortcode templates to output currency with the configured symbol

## Testing
- `composer install`
- `composer run phpcs` *(fails: Missing file doc comment, line indented incorrectly, use placeholders and `$wpdb->prepare()`)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f92d428083338749ba6dcdab6265