### PR TITLE
Move results script to external file

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -95,15 +95,32 @@ class BHG_Admin {
 				array(),
 				defined( 'BHG_VERSION' ) ? BHG_VERSION : null
 			);
-			$script_path = BHG_PLUGIN_DIR . 'assets/js/admin.js';
+						$script_path = BHG_PLUGIN_DIR . 'assets/js/admin.js';
 			if ( file_exists( $script_path ) && filesize( $script_path ) > 0 ) {
-				wp_enqueue_script(
-					'bhg-admin',
-					BHG_PLUGIN_URL . 'assets/js/admin.js',
-					array( 'jquery' ),
-					defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
-					true
-				);
+					wp_enqueue_script(
+						'bhg-admin',
+						BHG_PLUGIN_URL . 'assets/js/admin.js',
+						array( 'jquery' ),
+						defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
+						true
+					);
+			}
+
+			if ( 'bhg_page_bhg-bonus-hunts-results' === $hook ) {
+					wp_enqueue_script(
+						'bhg-admin-results',
+						BHG_PLUGIN_URL . 'assets/js/admin-results.js',
+						array(),
+						defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
+						true
+					);
+					wp_localize_script(
+						'bhg-admin-results',
+						'bhgResults',
+						array(
+							'base_url' => esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results' ) ),
+						)
+					);
 			}
 		}
 	}

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -99,7 +99,6 @@ $all_tours = $wpdb->get_results(
 	$wpdb->prepare( 'SELECT id, title FROM %i ORDER BY id DESC', $tour_table )
 );
 $current   = $view_type . '-' . $item_id;
-$base_url  = esc_url( admin_url( 'admin.php?page=bhg-hunt-results' ) );
 ?>
 <div class="wrap">
 <h1><?php echo esc_html( sprintf( bhg_t( 'title_results_s', 'Results — %s' ), $result_title ) ); ?></h1>
@@ -135,8 +134,8 @@ $base_url  = esc_url( admin_url( 'admin.php?page=bhg-hunt-results' ) );
 								<?php if ( 'tournament' === $view_type ) : ?>
 										<td><?php echo (int) $r->wins; ?></td>
 								<?php else : ?>
-                                                                        <td><?php echo esc_html( bhg_format_currency( (float) $r->guess ) ); ?></td>
-                                                                        <td><?php echo esc_html( bhg_format_currency( (float) $r->diff ) ); ?></td>
+																		<td><?php echo esc_html( bhg_format_currency( (float) $r->guess ) ); ?></td>
+																		<td><?php echo esc_html( bhg_format_currency( (float) $r->diff ) ); ?></td>
 							<?php endif; ?>
 					</tr>
 					<?php
@@ -146,14 +145,4 @@ $base_url  = esc_url( admin_url( 'admin.php?page=bhg-hunt-results' ) );
 			</tbody>
 	</table>
 </div>
-<script>
-document.getElementById('bhg-results-select').addEventListener('change', function () {
-	var val = this.value.split('-');
-	if ( val.length < 2 ) {
-			return;
-	}
-	var type = val[0];
-	var id   = val[1];
-		window.location = '<?php echo esc_url_raw( $base_url ); ?>' + '&type=' + type + '&id=' + id;
-});
-</script>
+

--- a/assets/js/admin-results.js
+++ b/assets/js/admin-results.js
@@ -1,0 +1,15 @@
+(function(){
+    var select = document.getElementById('bhg-results-select');
+    if (!select || typeof bhgResults === 'undefined') {
+        return;
+    }
+    select.addEventListener('change', function(){
+        var val = this.value.split('-');
+        if (val.length < 2) {
+            return;
+        }
+        var type = val[0];
+        var id = val[1];
+        window.location = bhgResults.base_url + '&type=' + type + '&id=' + id;
+    });
+})();


### PR DESCRIPTION
## Summary
- extract inline results JS to `assets/js/admin-results.js`
- enqueue `bhg-admin-results` script on Bonus Hunt results page with localized base URL
- clean up results view by removing embedded script

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml admin/class-bhg-admin.php admin/views/bonus-hunts-results.php` *(errors: Detected usage of a non-sanitized input variable; warnings about direct database calls)*

------
https://chatgpt.com/codex/tasks/task_e_68c10261bc3483338e2dc71c05e84e17