### PR TITLE
Sanitize pagination parameter in users admin view

### DIFF
--- a/admin/views/users.php
+++ b/admin/views/users.php
@@ -5,7 +5,7 @@ if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
 }
 
-$paged    = max( 1, isset( $_GET['paged'] ) ? (int) $_GET['paged'] : 1 );
+$paged    = max( 1, isset( $_GET['paged'] ) ? absint( wp_unslash( $_GET['paged'] ) ) : 1 );
 $per_page = 30;
 $search   = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
 if ( isset( $_GET['s'] ) ) {


### PR DESCRIPTION
## Summary
- sanitize the `paged` query parameter in admin user list with `absint( wp_unslash() )`

## Testing
- `composer run-script phpcs` *(fails: Processing form data without nonce verification and other pre-existing coding standard issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c10e04da6083338bfec975299d1633