### PR TITLE
Sanitize affiliate website edit parameter

### DIFF
--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -19,7 +19,7 @@ if ( ! in_array( $table, $allowed_tables, true ) ) {
 $table = esc_sql( $table );
 
 // Load for edit.
-$edit_id = isset( $_GET['edit'] ) ? (int) $_GET['edit'] : 0;
+$edit_id = isset( $_GET['edit'] ) ? absint( wp_unslash( $_GET['edit'] ) ) : 0;
 $row     = $edit_id ? $wpdb->get_row(
 	$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $edit_id )
 ) : null;


### PR DESCRIPTION
## Summary
- Sanitize affiliate website edit parameter using `absint` and `wp_unslash`

## Testing
- `composer phpcs` *(fails: existing coding standard issues in repo)*
- `./vendor/bin/phpcs --standard=phpcs.xml admin/views/affiliate-websites.php`

------
https://chatgpt.com/codex/tasks/task_e_68c10e7c1a3c833384a28e7db0d6d024