### PR TITLE
Sanitize hunt results ID

### DIFF
--- a/admin/views/hunt-results.php
+++ b/admin/views/hunt-results.php
@@ -15,7 +15,7 @@ if ( ! current_user_can( 'manage_options' ) ) {
 	);
 }
 
-$hunt_id = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
+$hunt_id = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
 if ( ! $hunt_id ) {
 	wp_die( esc_html( bhg_t( 'missing_hunt_id', 'Missing hunt id' ) ) );
 }


### PR DESCRIPTION
## Summary
- sanitize `$_GET['id']` in hunt results view with `absint( wp_unslash() )`
- ensure nonce check uses sanitized hunt ID

## Testing
- ⚠️ `composer phpcs` *(fails: existing coding standard violations in unrelated files)*
- ✅ `vendor/bin/phpcs -p admin/views/hunt-results.php`


------
https://chatgpt.com/codex/tasks/task_e_68c10f271d848333b026990bd8fe3b5e