### PR TITLE
Sanitize item ID retrieval in results view

### DIFF
--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -15,7 +15,7 @@ global $wpdb;
 
 $view_type = isset( $_GET['type'] ) ? sanitize_key( wp_unslash( $_GET['type'] ) ) : 'hunt';
 $view_type = ( 'tournament' === $view_type ) ? 'tournament' : 'hunt';
-$item_id   = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
+$item_id   = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
 
 $hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
 $guess_table = $wpdb->prefix . 'bhg_guesses';


### PR DESCRIPTION
## Summary
- Sanitize `id` query parameter with `absint( wp_unslash() )` in results view to ensure safe integer handling

## Testing
- `./vendor/bin/phpcs admin/views/bonus-hunts-results.php`


------
https://chatgpt.com/codex/tasks/task_e_68c10fca04f48333968a9578482cfdcb