### PR TITLE
Sanitize POST data in admin header

### DIFF
--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -14,7 +14,7 @@ $message = '';
 
 // Process form submissions
 if ( isset( $_POST['bhg_action'] ) ) {
-	$action = sanitize_text_field( $_POST['bhg_action'] );
+        $action = sanitize_text_field( wp_unslash( $_POST['bhg_action'] ) );
 
 	// Verify nonce based on action
 	$nonce_action = 'bhg_' . $action;
@@ -23,12 +23,12 @@ if ( isset( $_POST['bhg_action'] ) ) {
 	switch ( $action ) {
 		case 'create_bonus_hunt':
 			// Handle bonus hunt creation with proper sanitization
-			$title             = sanitize_text_field( $_POST['title'] );
-			$starting_balance  = floatval( $_POST['starting_balance'] );
-			$num_bonuses       = intval( $_POST['num_bonuses'] );
-			$prizes            = sanitize_textarea_field( $_POST['prizes'] );
-			$status            = sanitize_text_field( $_POST['status'] );
-			$affiliate_site_id = isset( $_POST['affiliate_site_id'] ) ? intval( $_POST['affiliate_site_id'] ) : 0;
+                        $title             = sanitize_text_field( wp_unslash( $_POST['title'] ) );
+                        $starting_balance  = floatval( wp_unslash( $_POST['starting_balance'] ) );
+                        $num_bonuses       = intval( wp_unslash( $_POST['num_bonuses'] ) );
+                        $prizes            = sanitize_textarea_field( wp_unslash( $_POST['prizes'] ) );
+                        $status            = sanitize_text_field( wp_unslash( $_POST['status'] ) );
+                        $affiliate_site_id = isset( $_POST['affiliate_site_id'] ) ? intval( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
 
 			// Save to database
 			$result = $bhg_db->create_bonus_hunt(
@@ -53,14 +53,14 @@ if ( isset( $_POST['bhg_action'] ) ) {
 
 		case 'update_bonus_hunt':
 			// Handle bonus hunt update
-			$id                = intval( $_POST['id'] );
-			$title             = sanitize_text_field( $_POST['title'] );
-			$starting_balance  = floatval( $_POST['starting_balance'] );
-			$num_bonuses       = intval( $_POST['num_bonuses'] );
-			$prizes            = sanitize_textarea_field( $_POST['prizes'] );
-			$status            = sanitize_text_field( $_POST['status'] );
-			$final_balance     = isset( $_POST['final_balance'] ) ? floatval( $_POST['final_balance'] ) : null;
-			$affiliate_site_id = isset( $_POST['affiliate_site_id'] ) ? intval( $_POST['affiliate_site_id'] ) : 0;
+                        $id                = intval( wp_unslash( $_POST['id'] ) );
+                        $title             = sanitize_text_field( wp_unslash( $_POST['title'] ) );
+                        $starting_balance  = floatval( wp_unslash( $_POST['starting_balance'] ) );
+                        $num_bonuses       = intval( wp_unslash( $_POST['num_bonuses'] ) );
+                        $prizes            = sanitize_textarea_field( wp_unslash( $_POST['prizes'] ) );
+                        $status            = sanitize_text_field( wp_unslash( $_POST['status'] ) );
+                        $final_balance     = isset( $_POST['final_balance'] ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
+                        $affiliate_site_id = isset( $_POST['affiliate_site_id'] ) ? intval( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
 
 			$result = $bhg_db->update_bonus_hunt(
 				$id,
@@ -84,7 +84,7 @@ if ( isset( $_POST['bhg_action'] ) ) {
 
 		case 'delete_bonus_hunt':
 			// Handle bonus hunt deletion
-			$id     = intval( $_POST['id'] );
+                        $id     = intval( wp_unslash( $_POST['id'] ) );
 			$result = $bhg_db->delete_bonus_hunt( $id );
 
 			if ( $result ) {


### PR DESCRIPTION
## Summary
- Sanitize admin POST fields with `wp_unslash()` before processing

## Testing
- `composer install`
- `php -l admin/views/header.php`
- `composer phpcs` *(fails: existing coding standard issues in repository)*


------
https://chatgpt.com/codex/tasks/task_e_68c16b84927c83339e7aedd7d87576df