### PR TITLE
Sanitize pagination query param

### DIFF
--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -16,7 +16,7 @@ if ( ! current_user_can( 'manage_options' ) ) {
 global $wpdb;
 $t = $wpdb->prefix . 'bhg_bonus_hunts';
 
-$paged    = max( 1, isset( $_GET['paged'] ) ? (int) $_GET['paged'] : 1 );
+$paged = max( 1, isset( $_GET['paged'] ) ? absint( wp_unslash( $_GET['paged'] ) ) : 1 );
 $per_page = 20;
 $offset   = ( $paged - 1 ) * $per_page;
 


### PR DESCRIPTION
## Summary
- sanitize pagination query param

## Testing
- `composer phpcs admin/views/hunts-list.php` *(fails: Overriding WordPress globals is prohibited; other coding standards issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c16c422580833385ec7a41def24b97