### PR TITLE
Sanitize guess ID input in bonus hunts controller

### DIFF
--- a/admin/class-bhg-bonus-hunts-controller.php
+++ b/admin/class-bhg-bonus-hunts-controller.php
@@ -169,7 +169,7 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 
 																check_admin_referer( 'bhg_delete_guess', 'bhg_delete_guess_nonce' );
 
-				$guess_id = isset( $_GET['guess_id'] ) ? absint( $_GET['guess_id'] ) : 0;
+				$guess_id = isset( $_GET['guess_id'] ) ? absint( wp_unslash( $_GET['guess_id'] ) ) : 0;
 
 				global $wpdb;
 				$table   = $wpdb->prefix . 'bhg_guesses';


### PR DESCRIPTION
## Summary
- Sanitize `guess_id` retrieval in bonus hunt deletion to safely handle user input

## Testing
- `composer phpcs` *(fails: 4 errors, 41 warnings)*
- `vendor/bin/phpcs admin/class-bhg-bonus-hunts-controller.php`


------
https://chatgpt.com/codex/tasks/task_e_68c16d2db2ec8333a63c77b04e3a91db