### PR TITLE
Use absint to sanitize tournament edit ID

### DIFF
--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -12,7 +12,7 @@ if ( ! in_array( $table, $allowed_tables, true ) ) {
 }
 $table = esc_sql( $table );
 
-$edit_id = isset( $_GET['edit'] ) ? (int) wp_unslash( $_GET['edit'] ) : 0;
+$edit_id = isset( $_GET['edit'] ) ? absint( wp_unslash( $_GET['edit'] ) ) : 0;
 $row     = $edit_id
 	? $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $edit_id ) )
 	: null;


### PR DESCRIPTION
## Summary
- Harden tournament edit ID handling with `absint`

## Testing
- `composer install`
- `composer phpcs` *(fails: Processing form data without nonce verification, direct database calls, missing doc comments, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c1704d286c8333a7cbefefc68627b8