### PR TITLE
Ensure admin redirects use network-aware URLs

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -233,7 +233,7 @@ class BHG_Admin {
 			$wpdb->delete( $guesses_table, array( 'id' => $guess_id ), array( '%d' ) );
 		}
 				$referer = wp_get_referer();
-				wp_safe_redirect( $referer ? $referer : admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+                               wp_safe_redirect( $referer ? $referer : BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
 	}
 
@@ -363,7 +363,7 @@ class BHG_Admin {
 			}
 		}
 
-		wp_safe_redirect( admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
 	}
 
@@ -380,7 +380,7 @@ class BHG_Admin {
 			$final_balance_raw = isset( $_POST['final_balance'] ) ? sanitize_text_field( wp_unslash( $_POST['final_balance'] ) ) : '';
 
 		if ( '' === $final_balance_raw || ! is_numeric( $final_balance_raw ) || (float) $final_balance_raw < 0 ) {
-				wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
+                               wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
 				exit;
 		}
 
@@ -390,7 +390,7 @@ class BHG_Admin {
 				BHG_Models::close_hunt( $hunt_id, $final_balance );
 		}
 
-		wp_safe_redirect( admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
 	}
 
@@ -413,7 +413,7 @@ class BHG_Admin {
 			$wpdb->delete( $guesses_table, array( 'hunt_id' => $hunt_id ), array( '%d' ) );
 		}
 
-		wp_safe_redirect( admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
 	}
 
@@ -444,7 +444,7 @@ class BHG_Admin {
 			);
 		}
 
-		wp_safe_redirect( admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
 	}
 
@@ -483,7 +483,7 @@ class BHG_Admin {
 		}
 
 			$referer = wp_get_referer();
-			wp_safe_redirect( $referer ? $referer : admin_url( 'admin.php?page=bhg-ads' ) );
+                       wp_safe_redirect( $referer ? $referer : BHG_Utils::admin_url( 'admin.php?page=bhg-ads' ) );
 			exit;
 	}
 
@@ -527,7 +527,7 @@ class BHG_Admin {
 			$wpdb->insert( $table, $data, $format );
 		}
 
-		wp_safe_redirect( admin_url( 'admin.php?page=bhg-ads' ) );
+               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-ads' ) );
 		exit;
 	}
 
@@ -536,11 +536,11 @@ class BHG_Admin {
 	 */
 	public function handle_save_tournament() {
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+                       wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 			exit;
 		}
 		if ( ! check_admin_referer( 'bhg_tournament_save_action', 'bhg_tournament_save_nonce' ) ) {
-			wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+                       wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 			exit;
 		}
 		global $wpdb;
@@ -570,13 +570,13 @@ class BHG_Admin {
 						$format[]           = '%s';
 						$wpdb->insert( $t, $data, $format );
 				}
-					wp_safe_redirect( add_query_arg( 'bhg_msg', 't_saved', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+                                   wp_safe_redirect( add_query_arg( 'bhg_msg', 't_saved', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 					exit;
 			} catch ( Throwable $e ) {
 				if ( function_exists( 'error_log' ) ) {
 					error_log( '[BHG] tournament save error: ' . $e->getMessage() );
 				}
-				wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+                           wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 				exit;
 			}
 	}
@@ -586,11 +586,11 @@ class BHG_Admin {
 		 */
 	public function handle_delete_tournament() {
 		if ( ! current_user_can( 'manage_options' ) ) {
-				wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+                           wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 				exit;
 		}
 		if ( ! isset( $_POST['bhg_tournament_delete_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['bhg_tournament_delete_nonce'] ), 'bhg_tournament_delete_action' ) ) {
-				wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+                           wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 				exit;
 		}
 			global $wpdb;
@@ -598,10 +598,10 @@ class BHG_Admin {
 			$id    = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
 		if ( $id ) {
 				$wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
-				wp_safe_redirect( add_query_arg( 'bhg_msg', 't_deleted', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+                           wp_safe_redirect( add_query_arg( 'bhg_msg', 't_deleted', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 				exit;
 		}
-			wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+                       wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 			exit;
 	}
 
@@ -636,7 +636,7 @@ class BHG_Admin {
 				$format[]           = '%s';
 				$wpdb->insert( $table, $data, $format );
 		}
-			wp_safe_redirect( admin_url( 'admin.php?page=bhg-affiliates' ) );
+                       wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-affiliates' ) );
 			exit;
 	}
 
@@ -654,7 +654,7 @@ class BHG_Admin {
 		if ( $id ) {
 			$wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
 		}
-		wp_safe_redirect( admin_url( 'admin.php?page=bhg-affiliates' ) );
+               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-affiliates' ) );
 		exit;
 	}
 
@@ -673,7 +673,7 @@ class BHG_Admin {
 			update_user_meta( $user_id, 'bhg_real_name', $real_name );
 			update_user_meta( $user_id, 'bhg_is_affiliate', $is_affiliate );
 		}
-		wp_safe_redirect( admin_url( 'admin.php?page=bhg-users' ) );
+               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-users' ) );
 		exit;
 	}
 
@@ -731,7 +731,7 @@ class BHG_Admin {
 			);
 
 			// Redirect back to the tools page with a success message.
-			wp_safe_redirect( admin_url( 'admin.php?page=bhg-tools&bhg_msg=tools_success' ) );
+                       wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-tools&bhg_msg=tools_success' ) );
 			exit;
 	}
 

--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -103,7 +103,7 @@ class BHG_Demo {
 			)
 		);
 
-		wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg_demo&demo_reset=1' ) ) );
+           wp_safe_redirect( esc_url_raw( BHG_Utils::admin_url( 'admin.php?page=bhg_demo&demo_reset=1' ) ) );
 		exit;
 	}
 }

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -413,7 +413,7 @@ function bhg_handle_settings_save() {
 
 				// Verify nonce.
        if ( ! check_admin_referer( 'bhg_settings', 'bhg_settings_nonce' ) ) {
-                                       wp_safe_redirect( admin_url( 'admin.php?page=bhg-settings&error=nonce_failed' ) );
+                                      wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-settings&error=nonce_failed' ) );
                                        exit;
        }
 
@@ -451,7 +451,7 @@ function bhg_handle_settings_save() {
 				// Validate that min is not greater than max.
        if ( isset( $settings['min_guess_amount'] ) && isset( $settings['max_guess_amount'] ) &&
                                                                $settings['min_guess_amount'] > $settings['max_guess_amount'] ) {
-                                       wp_safe_redirect( admin_url( 'admin.php?page=bhg-settings&error=invalid_data' ) );
+                                      wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-settings&error=invalid_data' ) );
                                        exit;
        }
 
@@ -476,7 +476,7 @@ function bhg_handle_settings_save() {
 		update_option( 'bhg_plugin_settings', array_merge( $existing, $settings ) );
 
 				// Redirect back to settings page.
-                               wp_safe_redirect( admin_url( 'admin.php?page=bhg-settings&message=saved' ) );
+                              wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-settings&message=saved' ) );
                                exit;
 }
 

--- a/includes/class-bhg-utils.php
+++ b/includes/class-bhg-utils.php
@@ -86,18 +86,28 @@ class BHG_Utils {
 	 *
 	 * @return void
 	 */
-	public static function require_cap() {
-			   if ( ! current_user_can( 'manage_options' ) ) {
-					   wp_die(
-							   esc_html(
-									   bhg_t(
-											   'you_do_not_have_permission_to_access_this_page',
-											   'You do not have permission to access this page'
-									   )
-							   )
-					   );
-			   }
-	}
+        public static function require_cap() {
+                           if ( ! current_user_can( 'manage_options' ) ) {
+                                           wp_die(
+                                                           esc_html(
+                                                                           bhg_t(
+                                                                                           'you_do_not_have_permission_to_access_this_page',
+                                                                                           'You do not have permission to access this page'
+                                                                           )
+                                                           )
+                                           );
+                           }
+        }
+
+       /**
+        * Retrieve an admin URL, respecting network admin context.
+        *
+        * @param string $path Optional path relative to the admin URL.
+        * @return string Full admin URL for the current context.
+        */
+       public static function admin_url( $path = '' ) {
+               return is_network_admin() ? network_admin_url( $path ) : admin_url( $path );
+       }
 
 	/**
 	 * Output a nonce field for the given action.


### PR DESCRIPTION
## Summary
- Add `BHG_Utils::admin_url()` helper to select `admin_url()` or `network_admin_url()` based on context
- Replace direct `admin_url` redirects in admin handlers and settings with new helper for consistent, network-aware paths

## Testing
- `composer install`
- `composer phpcs` *(warnings: direct database call without caching)*

------
https://chatgpt.com/codex/tasks/task_e_68c18203e108833390ed29d288fe63e1