### PR TITLE
chore: format code per WordPress standards

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -233,7 +233,7 @@ class BHG_Admin {
 			$wpdb->delete( $guesses_table, array( 'id' => $guess_id ), array( '%d' ) );
 		}
 				$referer = wp_get_referer();
-                               wp_safe_redirect( $referer ? $referer : BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+								wp_safe_redirect( $referer ? $referer : BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
 	}
 
@@ -248,54 +248,54 @@ class BHG_Admin {
 		global $wpdb;
 		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
 
-		$id               = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-		$title            = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
-		$starting         = isset( $_POST['starting_balance'] ) ? floatval( wp_unslash( $_POST['starting_balance'] ) ) : 0;
-		$num_bonuses      = isset( $_POST['num_bonuses'] ) ? absint( wp_unslash( $_POST['num_bonuses'] ) ) : 0;
-		$prizes           = isset( $_POST['prizes'] ) ? wp_kses_post( wp_unslash( $_POST['prizes'] ) ) : '';
-		$affiliate_site   = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
-		$tournament_id    = isset( $_POST['tournament_id'] ) ? bhg_sanitize_tournament_id( wp_unslash( $_POST['tournament_id'] ) ) : 0;
-		$winners_count    = isset( $_POST['winners_count'] ) ? max( 1, absint( wp_unslash( $_POST['winners_count'] ) ) ) : 3;
-		$guessing_enabled = isset( $_POST['guessing_enabled'] ) ? 1 : 0;
-               $final_balance    = ( isset( $_POST['final_balance'] ) && '' !== $_POST['final_balance'] ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
-               $status           = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'open';
+		$id                    = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		$title                 = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
+		$starting              = isset( $_POST['starting_balance'] ) ? floatval( wp_unslash( $_POST['starting_balance'] ) ) : 0;
+		$num_bonuses           = isset( $_POST['num_bonuses'] ) ? absint( wp_unslash( $_POST['num_bonuses'] ) ) : 0;
+		$prizes                = isset( $_POST['prizes'] ) ? wp_kses_post( wp_unslash( $_POST['prizes'] ) ) : '';
+		$affiliate_site        = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
+		$tournament_id         = isset( $_POST['tournament_id'] ) ? bhg_sanitize_tournament_id( wp_unslash( $_POST['tournament_id'] ) ) : 0;
+		$winners_count         = isset( $_POST['winners_count'] ) ? max( 1, absint( wp_unslash( $_POST['winners_count'] ) ) ) : 3;
+		$guessing_enabled      = isset( $_POST['guessing_enabled'] ) ? 1 : 0;
+				$final_balance = ( isset( $_POST['final_balance'] ) && '' !== $_POST['final_balance'] ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
+				$status        = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'open';
 
-               $data = array(
-                       'title'             => $title,
-                       'starting_balance'  => $starting,
-                       'num_bonuses'       => $num_bonuses,
-                       'prizes'            => $prizes,
-                       'affiliate_site_id' => $affiliate_site,
-                       'tournament_id'     => $tournament_id,
-                       'winners_count'     => $winners_count,
-                       'guessing_enabled'  => $guessing_enabled,
-               );
+				$data = array(
+					'title'             => $title,
+					'starting_balance'  => $starting,
+					'num_bonuses'       => $num_bonuses,
+					'prizes'            => $prizes,
+					'affiliate_site_id' => $affiliate_site,
+					'tournament_id'     => $tournament_id,
+					'winners_count'     => $winners_count,
+					'guessing_enabled'  => $guessing_enabled,
+				);
 
-               $format = array( '%s', '%f', '%d', '%s', '%d', '%d', '%d', '%d' );
+				$format = array( '%s', '%f', '%d', '%s', '%d', '%d', '%d', '%d' );
 
-               if ( null !== $final_balance ) {
-                       $data['final_balance'] = $final_balance;
-                       $format[]              = '%s';
-               }
+				if ( null !== $final_balance ) {
+						$data['final_balance'] = $final_balance;
+						$format[]              = '%s';
+				}
 
-               $data['status']     = $status;
-               $data['updated_at'] = current_time( 'mysql' );
-               $format[]           = '%s';
-               $format[]           = '%s';
-		if ( $id ) {
-			$wpdb->update( $hunts_table, $data, array( 'id' => $id ), $format, array( '%d' ) );
-		} else {
-			$data['created_at'] = current_time( 'mysql' );
-			$format[]           = '%s';
-			$wpdb->insert( $hunts_table, $data, $format );
-			$id = (int) $wpdb->insert_id;
-		}
+				$data['status']     = $status;
+				$data['updated_at'] = current_time( 'mysql' );
+				$format[]           = '%s';
+				$format[]           = '%s';
+				if ( $id ) {
+					$wpdb->update( $hunts_table, $data, array( 'id' => $id ), $format, array( '%d' ) );
+				} else {
+					$data['created_at'] = current_time( 'mysql' );
+					$format[]           = '%s';
+					$wpdb->insert( $hunts_table, $data, $format );
+					$id = (int) $wpdb->insert_id;
+				}
 
-		if ( 'closed' === $status && null !== $final_balance ) {
-			$winners = BHG_Models::close_hunt( $id, $final_balance );
+				if ( 'closed' === $status && null !== $final_balance ) {
+					$winners = BHG_Models::close_hunt( $id, $final_balance );
 
-			$emails_enabled = (int) get_option( 'bhg_email_enabled', 1 );
-			if ( $emails_enabled ) {
+					$emails_enabled = (int) get_option( 'bhg_email_enabled', 1 );
+					if ( $emails_enabled ) {
 																$guesses_table = $wpdb->prefix . 'bhg_guesses';
 
 																$rows = $wpdb->get_results(
@@ -306,10 +306,10 @@ class BHG_Admin {
 																	)
 																);
 
-				$template = get_option(
-					'bhg_email_template',
-					'Hi {{username}},\nThe Bonus Hunt "{{hunt}}" is closed. Final balance: €{{final}}. Winners: {{winners}}. Thanks for playing!'
-				);
+						$template = get_option(
+							'bhg_email_template',
+							'Hi {{username}},\nThe Bonus Hunt "{{hunt}}" is closed. Final balance: €{{final}}. Winners: {{winners}}. Thanks for playing!'
+						);
 
 																$hunt_title = (string) $wpdb->get_var(
 																	$wpdb->prepare(
@@ -319,21 +319,21 @@ class BHG_Admin {
 																	)
 																);
 
-				$winner_names = array();
-				foreach ( (array) $winners as $winner_id ) {
-					$wu = get_userdata( (int) $winner_id );
-					if ( $wu ) {
-						$winner_names[] = $wu->user_login;
-					}
-				}
+						$winner_names = array();
+						foreach ( (array) $winners as $winner_id ) {
+							$wu = get_userdata( (int) $winner_id );
+							if ( $wu ) {
+								$winner_names[] = $wu->user_login;
+							}
+						}
 								$winner_first = $winner_names ? $winner_names[0] : esc_html( bhg_t( 'label_emdash', '—' ) );
 								$winner_list  = $winner_names ? implode( ', ', $winner_names ) : esc_html( bhg_t( 'label_emdash', '—' ) );
 
-				foreach ( $rows as $r ) {
-					$u = get_userdata( (int) $r->user_id );
-					if ( ! $u ) {
-						continue;
-					}
+						foreach ( $rows as $r ) {
+							$u = get_userdata( (int) $r->user_id );
+							if ( ! $u ) {
+								continue;
+							}
 										$username   = sanitize_text_field( $u->user_login );
 										$hunt_title = sanitize_text_field( $hunt_title );
 
@@ -359,12 +359,12 @@ class BHG_Admin {
 											$body,
 											$headers
 										);
+						}
+					}
 				}
-			}
-		}
 
-               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
-		exit;
+				wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+				exit;
 	}
 
 	/**
@@ -380,7 +380,7 @@ class BHG_Admin {
 			$final_balance_raw = isset( $_POST['final_balance'] ) ? sanitize_text_field( wp_unslash( $_POST['final_balance'] ) ) : '';
 
 		if ( '' === $final_balance_raw || ! is_numeric( $final_balance_raw ) || (float) $final_balance_raw < 0 ) {
-                               wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
+								wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
 				exit;
 		}
 
@@ -390,7 +390,7 @@ class BHG_Admin {
 				BHG_Models::close_hunt( $hunt_id, $final_balance );
 		}
 
-               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+				wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
 	}
 
@@ -413,7 +413,7 @@ class BHG_Admin {
 			$wpdb->delete( $guesses_table, array( 'hunt_id' => $hunt_id ), array( '%d' ) );
 		}
 
-               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+				wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
 	}
 
@@ -444,7 +444,7 @@ class BHG_Admin {
 			);
 		}
 
-               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+				wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
 	}
 
@@ -483,7 +483,7 @@ class BHG_Admin {
 		}
 
 			$referer = wp_get_referer();
-                       wp_safe_redirect( $referer ? $referer : BHG_Utils::admin_url( 'admin.php?page=bhg-ads' ) );
+						wp_safe_redirect( $referer ? $referer : BHG_Utils::admin_url( 'admin.php?page=bhg-ads' ) );
 			exit;
 	}
 
@@ -527,7 +527,7 @@ class BHG_Admin {
 			$wpdb->insert( $table, $data, $format );
 		}
 
-               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-ads' ) );
+				wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-ads' ) );
 		exit;
 	}
 
@@ -536,11 +536,11 @@ class BHG_Admin {
 	 */
 	public function handle_save_tournament() {
 		if ( ! current_user_can( 'manage_options' ) ) {
-                       wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+						wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 			exit;
 		}
 		if ( ! check_admin_referer( 'bhg_tournament_save_action', 'bhg_tournament_save_nonce' ) ) {
-                       wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+						wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 			exit;
 		}
 		global $wpdb;
@@ -570,13 +570,13 @@ class BHG_Admin {
 						$format[]           = '%s';
 						$wpdb->insert( $t, $data, $format );
 				}
-                                   wp_safe_redirect( add_query_arg( 'bhg_msg', 't_saved', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+									wp_safe_redirect( add_query_arg( 'bhg_msg', 't_saved', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 					exit;
 			} catch ( Throwable $e ) {
 				if ( function_exists( 'error_log' ) ) {
 					error_log( '[BHG] tournament save error: ' . $e->getMessage() );
 				}
-                           wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+							wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 				exit;
 			}
 	}
@@ -586,11 +586,11 @@ class BHG_Admin {
 		 */
 	public function handle_delete_tournament() {
 		if ( ! current_user_can( 'manage_options' ) ) {
-                           wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+							wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 				exit;
 		}
 		if ( ! isset( $_POST['bhg_tournament_delete_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['bhg_tournament_delete_nonce'] ), 'bhg_tournament_delete_action' ) ) {
-                           wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+							wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 				exit;
 		}
 			global $wpdb;
@@ -598,10 +598,10 @@ class BHG_Admin {
 			$id    = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
 		if ( $id ) {
 				$wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
-                           wp_safe_redirect( add_query_arg( 'bhg_msg', 't_deleted', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+							wp_safe_redirect( add_query_arg( 'bhg_msg', 't_deleted', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 				exit;
 		}
-                       wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+						wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', BHG_Utils::admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 			exit;
 	}
 
@@ -636,7 +636,7 @@ class BHG_Admin {
 				$format[]           = '%s';
 				$wpdb->insert( $table, $data, $format );
 		}
-                       wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-affiliates' ) );
+						wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-affiliates' ) );
 			exit;
 	}
 
@@ -654,7 +654,7 @@ class BHG_Admin {
 		if ( $id ) {
 			$wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
 		}
-               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-affiliates' ) );
+				wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-affiliates' ) );
 		exit;
 	}
 
@@ -673,7 +673,7 @@ class BHG_Admin {
 			update_user_meta( $user_id, 'bhg_real_name', $real_name );
 			update_user_meta( $user_id, 'bhg_is_affiliate', $is_affiliate );
 		}
-               wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-users' ) );
+				wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-users' ) );
 		exit;
 	}
 
@@ -731,7 +731,7 @@ class BHG_Admin {
 			);
 
 			// Redirect back to the tools page with a success message.
-                       wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-tools&bhg_msg=tools_success' ) );
+						wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-tools&bhg_msg=tools_success' ) );
 			exit;
 	}
 

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -68,19 +68,19 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				. '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html( bhg_t( 'button_log_in', 'Log in' ) ) . '</a></p>';
 		}
 
-/** [bhg_active_hunt] — list all open hunts */
-public function active_hunt_shortcode( $atts ) {
-global $wpdb;
-$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-if ( ! $hunts_table ) {
-return '';
-}
-// db call ok; no-cache ok.
-$sql   = $wpdb->prepare(
-'SELECT * FROM %i WHERE status = %s ORDER BY created_at DESC',
-$hunts_table,
-'open'
-);
+		/** [bhg_active_hunt] — list all open hunts */
+		public function active_hunt_shortcode( $atts ) {
+			global $wpdb;
+			$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			if ( ! $hunts_table ) {
+				return '';
+			}
+			// db call ok; no-cache ok.
+			$sql       = $wpdb->prepare(
+				'SELECT * FROM %i WHERE status = %s ORDER BY created_at DESC',
+				$hunts_table,
+				'open'
+			);
 				$hunts = $wpdb->get_results( $sql );
 
 			if ( ! $hunts ) {
@@ -100,7 +100,7 @@ $hunts_table,
 				echo '<div class="bhg-hunt-card">';
 				echo '<h3>' . esc_html( $hunt->title ) . '</h3>';
 				echo '<ul class="bhg-hunt-meta">';
-                                echo '<li><strong>' . esc_html( bhg_t( 'label_start_balance', 'Starting Balance' ) ) . ':</strong> ' . esc_html( bhg_format_currency( (float) $hunt->starting_balance ) ) . '</li>';
+								echo '<li><strong>' . esc_html( bhg_t( 'label_start_balance', 'Starting Balance' ) ) . ':</strong> ' . esc_html( bhg_format_currency( (float) $hunt->starting_balance ) ) . '</li>';
 				echo '<li><strong>' . esc_html( bhg_t( 'label_number_bonuses', 'Number of Bonuses' ) ) . ':</strong> ' . (int) $hunt->num_bonuses . '</li>';
 				if ( ! empty( $hunt->prizes ) ) {
 					echo '<li><strong>' . esc_html( bhg_t( 'sc_prizes', 'Prizes' ) ) . ':</strong> ' . wp_kses_post( $hunt->prizes ) . '</li>';
@@ -126,12 +126,12 @@ $hunts_table,
 				. '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html( bhg_t( 'button_log_in', 'Log in' ) ) . '</a></p>';
 			}
 
-global $wpdb;
-$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-if ( ! $hunts_table ) {
-return '';
-}
-// db call ok; no-cache ok.
+			global $wpdb;
+			$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			if ( ! $hunts_table ) {
+				return '';
+			}
+			// db call ok; no-cache ok.
 			$sql        = $wpdb->prepare(
 				'SELECT id, title FROM %i WHERE status = %s AND guessing_enabled = 1 ORDER BY created_at DESC',
 				$hunts_table,
@@ -148,20 +148,20 @@ return '';
 				}
 			}
 
-$user_id = get_current_user_id();
-$table   = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
-if ( ! $table ) {
-return '';
-}
-// db call ok; no-cache ok.
-$existing_id = $hunt_id > 0 ? (int) $wpdb->get_var(
-							$wpdb->prepare(
-								'SELECT id FROM %i WHERE user_id = %d AND hunt_id = %d',
-								$table,
-								$user_id,
-								$hunt_id
-							)
-						) : 0;
+			$user_id = get_current_user_id();
+			$table   = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
+			if ( ! $table ) {
+				return '';
+			}
+			// db call ok; no-cache ok.
+			$existing_id = $hunt_id > 0 ? (int) $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT id FROM %i WHERE user_id = %d AND hunt_id = %d',
+					$table,
+					$user_id,
+					$hunt_id
+				)
+			) : 0;
 						// db call ok; no-cache ok.
 						$existing_guess = $existing_id ? (float) $wpdb->get_var(
 							$wpdb->prepare( 'SELECT guess FROM %i WHERE id = %d', $table, $existing_id )
@@ -237,24 +237,24 @@ $existing_id = $hunt_id > 0 ? (int) $wpdb->get_var(
 										);
 
 						global $wpdb;
-$hunt_id = (int) $a['hunt_id'];
-if ( $hunt_id <= 0 ) {
-$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-if ( ! $hunts_table ) {
-return '';
-}
-$sql         = $wpdb->prepare( 'SELECT id FROM %i ORDER BY created_at DESC LIMIT 1', $hunts_table );
-$hunt_id     = (int) $wpdb->get_var( $sql ); // db call ok; no-cache ok.
-if ( $hunt_id <= 0 ) {
-return '<p>' . esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ) . '</p>';
-}
-}
+			$hunt_id = (int) $a['hunt_id'];
+			if ( $hunt_id <= 0 ) {
+				$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+				if ( ! $hunts_table ) {
+					return '';
+				}
+				$sql     = $wpdb->prepare( 'SELECT id FROM %i ORDER BY created_at DESC LIMIT 1', $hunts_table );
+				$hunt_id = (int) $wpdb->get_var( $sql ); // db call ok; no-cache ok.
+				if ( $hunt_id <= 0 ) {
+					return '<p>' . esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ) . '</p>';
+				}
+			}
 
-$g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
-$u = $this->sanitize_table( $wpdb->users );
-if ( ! $g || ! $u ) {
-return '';
-}
+			$g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
+			$u = $this->sanitize_table( $wpdb->users );
+			if ( ! $g || ! $u ) {
+				return '';
+			}
 
 						$allowed_orders = array( 'ASC', 'DESC' );
 						$order          = strtoupper( sanitize_key( $a['order'] ) );
@@ -288,23 +288,23 @@ return '';
 							return '<p>' . esc_html( bhg_t( 'notice_no_guesses_yet', 'No guesses yet.' ) ) . '</p>';
 			}
 
-$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-if ( ! $hunts_table ) {
-return '';
-}
-$query = $wpdb->prepare(
-        sprintf(
-                'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id FROM %%i g LEFT JOIN %%i u ON u.ID = g.user_id LEFT JOIN %%i h ON h.id = g.hunt_id WHERE g.hunt_id = %%d ORDER BY %s %s LIMIT %%d',
-                esc_sql( $orderby ),
-                esc_sql( $order )
-        ),
-        $g,
-        $u,
-        $hunts_table,
-        $hunt_id,
-        $ranking
-);
-                                                $rows = $wpdb->get_results( $query ); // db call ok; no-cache ok.
+			$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			if ( ! $hunts_table ) {
+				return '';
+			}
+			$query                                    = $wpdb->prepare(
+				sprintf(
+					'SELECT g.user_id, g.guess, u.user_login, h.affiliate_site_id FROM %%i g LEFT JOIN %%i u ON u.ID = g.user_id LEFT JOIN %%i h ON h.id = g.hunt_id WHERE g.hunt_id = %%d ORDER BY %s %s LIMIT %%d',
+					esc_sql( $orderby ),
+					esc_sql( $order )
+				),
+				$g,
+				$u,
+				$hunts_table,
+				$hunt_id,
+				$ranking
+			);
+												$rows = $wpdb->get_results( $query ); // db call ok; no-cache ok.
 
 					wp_enqueue_style(
 						'bhg-shortcodes',
@@ -330,22 +330,22 @@ $query = $wpdb->prepare(
 								$pos       = 1;
 								$need_user = in_array( 'user', $fields, true );
 			foreach ( $rows as $r ) {
-                                if ( $need_user ) {
-                                        $site_id   = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
-                                        $aff_dot   = bhg_render_affiliate_dot( (int) $r->user_id, $site_id );
-                                        /* translators: %d: user ID. */
-                                        $user_label = $r->user_login ? $r->user_login : sprintf( bhg_t( 'label_user_hash', 'user#%d' ), (int) $r->user_id );
-                                }
+				if ( $need_user ) {
+						$site_id = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
+						$aff_dot = bhg_render_affiliate_dot( (int) $r->user_id, $site_id );
+						/* translators: %d: user ID. */
+						$user_label = $r->user_login ? $r->user_login : sprintf( bhg_t( 'label_user_hash', 'user#%d' ), (int) $r->user_id );
+				}
 
 				echo '<tr>';
 				foreach ( $fields as $field ) {
 					if ( 'position' === $field ) {
 						echo '<td data-column="position">' . (int) $pos . '</td>';
-                                        } elseif ( 'user' === $field ) {
-                                                                                                        echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $aff_dot . '</td>';
-                                        } elseif ( 'guess' === $field ) {
-                                                        echo '<td data-column="guess">' . esc_html( bhg_format_currency( (float) $r->guess ) ) . '</td>';
-                                        }
+					} elseif ( 'user' === $field ) {
+																					echo '<td data-column="user">' . esc_html( $user_label ) . ' ' . $aff_dot . '</td>';
+					} elseif ( 'guess' === $field ) {
+									echo '<td data-column="guess">' . esc_html( bhg_format_currency( (float) $r->guess ) ) . '</td>';
+					}
 				}
 				echo '</tr>';
 									++$pos;
@@ -402,11 +402,11 @@ $query = $wpdb->prepare(
 				return '<p>' . esc_html( bhg_t( 'notice_no_user_specified', 'No user specified.' ) ) . '</p>';
 			}
 
-$g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
-$h = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-if ( ! $g || ! $h ) {
-return '';
-}
+			$g = $this->sanitize_table( $wpdb->prefix . 'bhg_guesses' );
+			$h = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			if ( ! $g || ! $h ) {
+				return '';
+			}
 
 				// Ensure hunts table has created_at column. If missing, attempt migration and fall back.
 				$has_created_at = $wpdb->get_var( $wpdb->prepare( 'SHOW COLUMNS FROM %i LIKE %s', $h, 'created_at' ) );
@@ -443,42 +443,42 @@ return '';
 				$params[] = $since;
 			}
 
-                        $allowed_orders = array( 'ASC', 'DESC' );
-                        $order          = strtoupper( sanitize_key( $a['order'] ) );
-                        if ( ! in_array( $order, $allowed_orders, true ) ) {
-                                $order = 'DESC';
-                        }
-                        $orderby_map = array(
-                                'guess' => 'g.guess',
-                                'hunt'  => $has_created_at ? 'h.created_at' : 'h.id',
-                        );
-                        $orderby_key = sanitize_key( $a['orderby'] );
-                        if ( ! isset( $orderby_map[ $orderby_key ] ) ) {
-                                $orderby_key = 'hunt';
-                        }
-                        $orderby = $orderby_map[ $orderby_key ];
+						$allowed_orders = array( 'ASC', 'DESC' );
+						$order          = strtoupper( sanitize_key( $a['order'] ) );
+			if ( ! in_array( $order, $allowed_orders, true ) ) {
+					$order = 'DESC';
+			}
+						$orderby_map = array(
+							'guess' => 'g.guess',
+							'hunt'  => $has_created_at ? 'h.created_at' : 'h.id',
+						);
+						$orderby_key = sanitize_key( $a['orderby'] );
+						if ( ! isset( $orderby_map[ $orderby_key ] ) ) {
+								$orderby_key = 'hunt';
+						}
+						$orderby = $orderby_map[ $orderby_key ];
 
-                        $order_sql = sprintf( ' ORDER BY %s %s', esc_sql( $orderby ), esc_sql( $order ) );
-                        $limit_sql = '';
-                        $limit_val = 0;
-                        if ( 'recent' === strtolower( $a['timeline'] ) ) {
-                                $limit_sql = ' LIMIT %d';
-                                $limit_val = 10;
-                        }
+						$order_sql = sprintf( ' ORDER BY %s %s', esc_sql( $orderby ), esc_sql( $order ) );
+						$limit_sql = '';
+						$limit_val = 0;
+						if ( 'recent' === strtolower( $a['timeline'] ) ) {
+								$limit_sql = ' LIMIT %d';
+								$limit_val = 10;
+						}
 
-                        $sql    = 'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id FROM %i g INNER JOIN %i h ON h.id = g.hunt_id WHERE ' . implode( ' AND ', $where ) . $order_sql . $limit_sql;
-                        $params = array_merge( array( $g, $h ), $params );
-                        if ( $limit_val ) {
-                                $params[] = $limit_val;
-                        }
+						$sql    = 'SELECT g.guess, h.title, h.final_balance, h.affiliate_site_id FROM %i g INNER JOIN %i h ON h.id = g.hunt_id WHERE ' . implode( ' AND ', $where ) . $order_sql . $limit_sql;
+						$params = array_merge( array( $g, $h ), $params );
+						if ( $limit_val ) {
+								$params[] = $limit_val;
+						}
                         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- query built with placeholders and sanitized identifiers.
-                        $query = $wpdb->prepare( $sql, ...$params );
+						$query = $wpdb->prepare( $sql, ...$params );
 
 						// db call ok; no-cache ok.
 						$rows = $wpdb->get_results( $query );
-			if ( ! $rows ) {
-					return '<p>' . esc_html( bhg_t( 'notice_no_guesses_found', 'No guesses found.' ) ) . '</p>';
-			}
+						if ( ! $rows ) {
+								return '<p>' . esc_html( bhg_t( 'notice_no_guesses_found', 'No guesses found.' ) ) . '</p>';
+						}
 
 						$show_aff = in_array( 'user', $fields_arr, true ) && in_array( strtolower( (string) $a['aff'] ), array( 'yes', '1', 'true' ), true );
 
@@ -490,18 +490,18 @@ return '';
 						echo '</tr></thead><tbody>';
 
 						$current_user_id = $user_id; // for aff dot.
-			foreach ( $rows as $row ) {
-				echo '<tr>';
-				echo '<td>' . esc_html( $row->title ) . '</td>';
-                                $guess_cell = esc_html( bhg_format_currency( (float) $row->guess ) );
-                                if ( $show_aff ) {
-                                        $dot        = bhg_render_affiliate_dot( (int) $current_user_id, (int) $row->affiliate_site_id );
-                                        $guess_cell = $dot . $guess_cell;
-                                }
+						foreach ( $rows as $row ) {
+							echo '<tr>';
+							echo '<td>' . esc_html( $row->title ) . '</td>';
+								$guess_cell = esc_html( bhg_format_currency( (float) $row->guess ) );
+							if ( $show_aff ) {
+									$dot        = bhg_render_affiliate_dot( (int) $current_user_id, (int) $row->affiliate_site_id );
+									$guess_cell = $dot . $guess_cell;
+							}
 							echo '<td>' . $guess_cell . '</td>';
-                                                        echo '<td>' . ( isset( $row->final_balance ) ? esc_html( bhg_format_currency( (float) $row->final_balance ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
+														echo '<td>' . ( isset( $row->final_balance ) ? esc_html( bhg_format_currency( (float) $row->final_balance ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
 							echo '</tr>';
-			}
+						}
 						echo '</tbody></table>';
 						return ob_get_clean();
 		}
@@ -542,11 +542,11 @@ return '';
 			}
 
 			global $wpdb;
-$h                     = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-$aff_table = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliate_websites' );
-if ( ! $h || ! $aff_table ) {
-return '';
-}
+			$h         = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			$aff_table = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliate_websites' );
+			if ( ! $h || ! $aff_table ) {
+				return '';
+			}
 
 			$where  = array();
 			$params = array();
@@ -616,8 +616,8 @@ return '';
 			foreach ( $rows as $row ) {
 				echo '<tr>';
 				echo '<td>' . esc_html( $row->title ) . '</td>';
-                                echo '<td>' . esc_html( bhg_format_currency( (float) $row->starting_balance ) ) . '</td>';
-                                echo '<td>' . ( isset( $row->final_balance ) ? esc_html( bhg_format_currency( (float) $row->final_balance ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
+								echo '<td>' . esc_html( bhg_format_currency( (float) $row->starting_balance ) ) . '</td>';
+								echo '<td>' . ( isset( $row->final_balance ) ? esc_html( bhg_format_currency( (float) $row->final_balance ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ) ) . '</td>';
 								$status_key = strtolower( (string) $row->status );
 								echo '<td>' . esc_html( bhg_t( $status_key, ucfirst( $status_key ) ) ) . '</td>';
 				if ( $show_aff ) {
@@ -690,15 +690,15 @@ return '';
 			$need_hunt       = in_array( 'hunt', $fields_arr, true );
 			$need_aff        = in_array( 'aff', $fields_arr, true );
 
-$r  = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
-$u  = $this->sanitize_table( $wpdb->users );
-$t  = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
-$w  = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliate_websites' );
-$hw = $this->sanitize_table( $wpdb->prefix . 'bhg_hunt_winners' );
-$h  = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-if ( ! $r || ! $u || ! $t || ! $w || ! $hw || ! $h ) {
-return '';
-}
+			$r  = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
+			$u  = $this->sanitize_table( $wpdb->users );
+			$t  = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
+			$w  = $this->sanitize_table( $wpdb->prefix . 'bhg_affiliate_websites' );
+			$hw = $this->sanitize_table( $wpdb->prefix . 'bhg_hunt_winners' );
+			$h  = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			if ( ! $r || ! $u || ! $t || ! $w || ! $hw || ! $h ) {
+				return '';
+			}
 
 				// db call ok; no-cache ok.
 				$sql         = 'SELECT r.user_id, u.user_login, SUM(r.wins) AS total_wins';
@@ -794,9 +794,9 @@ return '';
 
 				$pos = $start;
 			foreach ( $rows as $row ) {
-                                if ( $need_aff ) {
-                                        $aff = bhg_render_affiliate_dot( (int) $row->user_id );
-                                }
+				if ( $need_aff ) {
+						$aff = bhg_render_affiliate_dot( (int) $row->user_id );
+				}
 											/* translators: %d: user ID. */
 											$user_label = $row->user_login ? $row->user_login : sprintf( bhg_t( 'label_user_hash', 'user#%d' ), (int) $row->user_id );
 											echo '<tr>';
@@ -848,12 +848,12 @@ return '';
 			// Details screen
 			$details_id = isset( $_GET['bhg_tournament_id'] ) ? absint( wp_unslash( $_GET['bhg_tournament_id'] ) ) : 0;
 			if ( $details_id > 0 ) {
-$t = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
-$r = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
-$u = $this->sanitize_table( $wpdb->users );
-if ( ! $t || ! $r || ! $u ) {
-return '';
-}
+				$t = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
+				$r = $this->sanitize_table( $wpdb->prefix . 'bhg_tournament_results' );
+				$u = $this->sanitize_table( $wpdb->users );
+				if ( ! $t || ! $r || ! $u ) {
+					return '';
+				}
 
 						// db call ok; no-cache ok.
 						$tournament = $wpdb->get_row(
@@ -964,12 +964,12 @@ return '';
 				'bhg_tournaments'
 			);
 
-$t     = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
-if ( ! $t ) {
-return '';
-}
-$where = array();
-$args  = array();
+			$t = $this->sanitize_table( $wpdb->prefix . 'bhg_tournaments' );
+			if ( ! $t ) {
+				return '';
+			}
+			$where = array();
+			$args  = array();
 
 			$status     = isset( $_GET['bhg_status'] ) ? sanitize_key( wp_unslash( $_GET['bhg_status'] ) ) : sanitize_key( $a['status'] );
 			$timeline   = isset( $_GET['bhg_timeline'] ) ? sanitize_key( wp_unslash( $_GET['bhg_timeline'] ) ) : sanitize_key( $a['timeline'] );
@@ -1105,17 +1105,17 @@ $args  = array();
 				'bhg_winner_notifications'
 			);
 
-$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-if ( ! $hunts_table ) {
-return '';
-}
-// db call ok; no-cache ok.
-$sql   = $wpdb->prepare(
-'SELECT id, title, final_balance, winners_count, closed_at FROM %i WHERE status = %s ORDER BY closed_at DESC LIMIT %d',
-$hunts_table,
-'closed',
-					(int) $a['limit']
-				);
+			$hunts_table = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			if ( ! $hunts_table ) {
+				return '';
+			}
+			// db call ok; no-cache ok.
+			$sql       = $wpdb->prepare(
+				'SELECT id, title, final_balance, winners_count, closed_at FROM %i WHERE status = %s ORDER BY closed_at DESC LIMIT %d',
+				$hunts_table,
+				'closed',
+				(int) $a['limit']
+			);
 				$hunts = $wpdb->get_results( $sql );
 
 			if ( ! $hunts ) {
@@ -1138,16 +1138,16 @@ $hunts_table,
 
 				echo '<div class="bhg-winner">';
 				echo '<p><strong>' . esc_html( $hunt->title ) . '</strong></p>';
-                                if ( null !== $hunt->final_balance ) {
-                                        echo '<p><em>' . esc_html( bhg_t( 'sc_final', 'Final' ) ) . ':</em> ' . esc_html( bhg_format_currency( (float) $hunt->final_balance ) ) . '</p>';
-                                }
+				if ( null !== $hunt->final_balance ) {
+						echo '<p><em>' . esc_html( bhg_t( 'sc_final', 'Final' ) ) . ':</em> ' . esc_html( bhg_format_currency( (float) $hunt->final_balance ) ) . '</p>';
+				}
 
 				if ( $winners ) {
 					echo '<ul class="bhg-winner-list">';
 					foreach ( $winners as $w ) {
 						$u  = get_userdata( (int) $w->user_id );
 						$nm = $u ? $u->user_login : sprintf( bhg_t( 'label_user_number', 'User #%d' ), (int) $w->user_id );
-                                                echo '<li>' . esc_html( $nm ) . ' ' . esc_html( bhg_t( 'label_emdash', '—' ) ) . ' ' . esc_html( bhg_format_currency( (float) $w->guess ) ) . ' (' . esc_html( bhg_format_currency( (float) $w->diff ) ) . ')</li>';
+												echo '<li>' . esc_html( $nm ) . ' ' . esc_html( bhg_t( 'label_emdash', '—' ) ) . ' ' . esc_html( bhg_format_currency( (float) $w->guess ) ) . ' (' . esc_html( bhg_format_currency( (float) $w->diff ) ) . ')</li>';
 					}
 					echo '</ul>';
 				}
@@ -1244,16 +1244,16 @@ $hunts_table,
 				}
 			}
 
-$hunts_tbl = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
-if ( ! $hunts_tbl ) {
-return '';
-}
-$hunts_sql = $wpdb->prepare(
-'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC LIMIT 50',
-$hunts_tbl,
-'closed'
-);
-					$hunts     = $wpdb->get_results( $hunts_sql );
+			$hunts_tbl = $this->sanitize_table( $wpdb->prefix . 'bhg_bonus_hunts' );
+			if ( ! $hunts_tbl ) {
+				return '';
+			}
+			$hunts_sql     = $wpdb->prepare(
+				'SELECT id, title FROM %i WHERE status = %s ORDER BY created_at DESC LIMIT 50',
+				$hunts_tbl,
+				'closed'
+			);
+					$hunts = $wpdb->get_results( $hunts_sql );
 
 						wp_enqueue_style(
 							'bhg-shortcodes',
@@ -1318,7 +1318,6 @@ $hunts_tbl,
 
 			return ob_get_clean();
 		}
-
 	}
 }
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -700,7 +700,7 @@ function bhg_format_currency( $amount ) {
  * Validate a guess amount against settings.
  *
  * @param mixed $guess Guess value.
- *  void
+ * @return bool True if the guess is within the allowed range.
  */
 function bhg_validate_guess( $guess ) {
 	$settings  = get_option( 'bhg_plugin_settings', array() );


### PR DESCRIPTION
## Summary
- format admin constructor and handlers with tabs
- document guess validation return type
- reflow shortcode class to conform to WordPress standards

## Testing
- `vendor/bin/phpcs --standard=WordPress admin/class-bhg-admin.php includes/helpers.php includes/class-bhg-shortcodes.php` *(fails: warnings/errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68c185f69d9483338f8749141ec8d9f0