### PR TITLE
Use float format for final balance

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -273,10 +273,11 @@ class BHG_Admin {
 
 				$format = array( '%s', '%f', '%d', '%s', '%d', '%d', '%d', '%d' );
 
-				if ( null !== $final_balance ) {
-						$data['final_balance'] = $final_balance;
-						$format[]              = '%s';
-				}
+                                if ( null !== $final_balance ) {
+                                                $data['final_balance'] = $final_balance;
+                                                // Use a float format to match the stored value.
+                                                $format[]              = '%f';
+                                }
 
 				$data['status']     = $status;
 				$data['updated_at'] = current_time( 'mysql' );


### PR DESCRIPTION
## Summary
- store `final_balance` with float format specifier when present
- avoid adding empty `final_balance` so column stays NULL

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68c18cc59d50833397749837602e8ba2