### PR TITLE
Refactor hunts list query to use prepared statement

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -64,17 +64,21 @@ if ( 'list' === $view ) :
 		$order_by_clause = 'h.id DESC';
 		}
 
-		$search_like = '%' . $wpdb->esc_like( $search ) . '%';
+               $search_like = '%' . $wpdb->esc_like( $search ) . '%';
 
-		$hunts_query = $wpdb->prepare(
-"SELECT h.*, a.name AS affiliate_name FROM %i h LEFT JOIN %i a ON a.id = h.affiliate_site_id WHERE h.title LIKE %s ORDER BY {$order_by_clause} LIMIT %d OFFSET %d",
-			$hunts_table,
-			$aff_table,
-			$search_like,
-			$per_page,
-			$offset
-); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- ORDER BY clause sanitized.
-	$hunts       = $wpdb->get_results( $hunts_query );
+               $base_query  = $wpdb->prepare(
+                       'SELECT h.*, a.name AS affiliate_name FROM %i h LEFT JOIN %i a ON a.id = h.affiliate_site_id WHERE h.title LIKE %s',
+                       $hunts_table,
+                       $aff_table,
+                       $search_like
+               );
+
+               $hunts_query = $wpdb->prepare(
+                       "$base_query ORDER BY {$order_by_clause} LIMIT %d OFFSET %d",
+                       $per_page,
+                       $offset
+               ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- ORDER BY clause sanitized.
+       $hunts       = $wpdb->get_results( $hunts_query );
 
 	$count_query = $wpdb->prepare(
 		'SELECT COUNT(*) FROM %i h WHERE h.title LIKE %s',


### PR DESCRIPTION
## Summary
- build bonus hunt query using `$wpdb->prepare` with table name placeholders
- sanitize and append `ORDER BY` clause separately before limiting/paginating results

## Testing
- `composer phpcs admin/views/bonus-hunts.php` *(fails: 52 errors, 53 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c192fb90ec83338150f9b798b630b5