### PR TITLE
Use placeholders for tournament query

### DIFF
--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -29,13 +29,20 @@ if ( empty( $order_by_clause ) ) {
         $order_by_clause = 'id DESC';
 }
 
-$sql = $wpdb->prepare( 'SELECT * FROM %i', $table );
+$sql    = 'SELECT * FROM %i';
+$params = array( $table );
+
 if ( $search ) {
-        $like = '%' . $wpdb->esc_like( $search ) . '%';
-        $sql .= $wpdb->prepare( ' WHERE title LIKE %s', $like );
+        $sql    .= ' WHERE title LIKE %s';
+        $params[] = '%' . $wpdb->esc_like( $search ) . '%';
 }
 
-$sql .= " ORDER BY {$order_by_clause}";
+$sql    .= ' ORDER BY %i %s';
+$params[] = $orderby;
+$params[] = $order;
+
+$sql  = $wpdb->prepare( $sql, $params );
+$sql  = str_replace( array( "'ASC'", "'DESC'" ), array( 'ASC', 'DESC' ), $sql );
 $rows = $wpdb->get_results( $sql );
 
 $labels = array(


### PR DESCRIPTION
## Summary
- build tournament query using `$wpdb->prepare()` with placeholders for search and ordering clauses

## Testing
- `composer phpcs admin/views/tournaments.php` *(fails: Tabs must be used to indent lines; spaces are not allowed, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c2176654108333abf45157e8f38e69