### PR TITLE
Fix PHPCS argument syntax in ruleset

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,7 +18,7 @@
   <config name="php_version" value="70400"/>
 
   <!-- Typical tweaks -->
-  <arg value="--extensions=php" />
-  <arg value="--report=full" />
-  <arg value="--basepath=." />
+  <arg name="extensions" value="php" />
+  <arg name="report" value="full" />
+  <arg name="basepath" value="." />
 </ruleset>


### PR DESCRIPTION
## Summary
- use name/value form for PHPCS arg definitions

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml.dist`


------
https://chatgpt.com/codex/tasks/task_e_68c2247d4ba0833380e2516094faf21c