### PR TITLE
Sanitize tournaments ordering parameters

### DIFF
--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -37,13 +37,9 @@ if ( $search ) {
         $params[] = '%' . $wpdb->esc_like( $search ) . '%';
 }
 
-$sql    .= ' ORDER BY %i %s';
-$params[] = $orderby;
-$params[] = $order;
-
-$sql  = $wpdb->prepare( $sql, $params );
-$sql  = str_replace( array( "'ASC'", "'DESC'" ), array( 'ASC', 'DESC' ), $sql );
-$rows = $wpdb->get_results( $sql );
+$sql  .= ' ORDER BY ' . $order_by_clause;
+$sql   = $wpdb->prepare( $sql, $params );
+$rows  = $wpdb->get_results( $sql );
 
 $labels = array(
 	'weekly'    => bhg_t( 'label_weekly', 'Weekly' ),


### PR DESCRIPTION
## Summary
- sanitize and validate `orderby` and `order` inputs for tournaments view
- append validated `ORDER BY` clause to SQL before preparing remaining placeholders

## Testing
- `composer phpcs admin/views/tournaments.php` *(fails: multiple pre-existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c227701eb483338335a5d3086afbf4