### PR TITLE
Document sanitize_table parameter and return

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -42,12 +42,12 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				add_shortcode( 'bonus_hunt_login', array( $this, 'login_hint_shortcode' ) );
 				add_shortcode( 'bhg_active', array( $this, 'active_hunt_shortcode' ) );
 		}
-			/**
-			 * Validates a database table name against known tables.
-			 *
-			 * @param string $table Table name to validate.
-			 * @return string Sanitized table name or empty string if invalid.
-			 */
+		/**
+		 * Validates a database table name against known tables.
+		 *
+		 * @param string $table Database table name to validate.
+		 * @return string Sanitized table name or empty string if invalid.
+		 */
 		private function sanitize_table( $table ) {
 			global $wpdb;
 


### PR DESCRIPTION
## Summary
- add PHPDoc for the `$table` parameter and return value in `sanitize_table`
- normalize indentation to tabs per WordPress standards

## Testing
- `./vendor/bin/phpcs includes/class-bhg-shortcodes.php` *(fails: existing coding standards warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c2283a7ad483338e174a925eed9c11