### PR TITLE
Add leaderboard pagination controls

### DIFF
--- a/assets/css/bhg-shortcodes.css
+++ b/assets/css/bhg-shortcodes.css
@@ -126,6 +126,15 @@
     filter: brightness(0.9);
 }
 
+.bhg-pagination {
+    margin-top: 15px;
+    text-align: center;
+}
+
+.bhg-pagination a {
+    margin: 0 4px;
+}
+
 .bhg-pagination .bhg-current-page {
     font-weight: 700;
 }

--- a/assets/js/public.js
+++ b/assets/js/public.js
@@ -20,7 +20,10 @@ jQuery(document).ready(function($) {
         
         // Tab switching for leaderboard views
         initLeaderboardTabs();
-        
+
+        // Leaderboard pagination
+        initLeaderboardPagination();
+
         // Login redirect handling
         handleLoginRedirects();
         
@@ -193,6 +196,27 @@ jQuery(document).ready(function($) {
             complete: function() {
                 $('#bhg-leaderboard-' + timeframe).removeClass('loading');
             }
+        });
+    }
+
+    // Handle pagination for leaderboard tables
+    function initLeaderboardPagination() {
+        $('.bhg-pagination').on('click', 'a', function(e) {
+            e.preventDefault();
+
+            var url = $(this).attr('href');
+            var container = $(this).closest('.bhg-leaderboard-wrapper');
+
+            $.get(url, function(response) {
+                var newHtml = $(response).find('.bhg-leaderboard-wrapper').html();
+                container.html(newHtml);
+
+                // Reinitialize sorting and pagination on new content
+                initLeaderboardSorting();
+                initLeaderboardPagination();
+            }).fail(function() {
+                window.location.href = url;
+            });
         });
     }
 


### PR DESCRIPTION
## Summary
- support paged/per_page attributes for leaderboard shortcode and output pagination links
- fetch leaderboard pages via JS pagination links
- style pagination block

## Testing
- `composer phpcs` *(fails: existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c22dfb40188333a15ed3ff4d9c382e