### PR TITLE
Secure advertising edit link with nonce

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -18,7 +18,14 @@ if ( ! in_array( $ads_table, $allowed_tables, true ) ) {
 	wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
 }
 
-$edit_id = isset( $_GET['edit'] ) ? absint( wp_unslash( $_GET['edit'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$edit_id = 0;
+if ( isset( $_GET['edit'] ) ) {
+        $nonce = isset( $_GET['bhg_edit_ad_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['bhg_edit_ad_nonce'] ) ) : '';
+        if ( ! $nonce || ! wp_verify_nonce( $nonce, 'bhg_edit_ad' ) ) {
+                wp_die( esc_html( bhg_t( 'notice_invalid_nonce', 'Invalid nonce.' ) ) );
+        }
+        $edit_id = absint( wp_unslash( $_GET['edit'] ) );
+}
 
 // Fetch ads.
 // db call ok; no-cache ok.
@@ -88,7 +95,14 @@ $ads = $wpdb->get_results(
 																<td><?php echo esc_html( $visible_labels[ $visible_to ] ?? $visible_to ); ?></td>
 																<td><?php echo 1 === (int) $ad->active ? esc_html( bhg_t( 'yes', 'Yes' ) ) : esc_html( bhg_t( 'no', 'No' ) ); ?></td>
 																<td>
-																<a class="button" href="<?php echo esc_url( add_query_arg( array( 'edit' => (int) $ad->id ) ) ); ?>"><?php echo esc_html( bhg_t( 'button_edit', 'Edit' ) ); ?></a>
+<?php
+$edit_url = wp_nonce_url(
+        add_query_arg( array( 'edit' => (int) $ad->id ) ),
+        'bhg_edit_ad',
+        'bhg_edit_ad_nonce'
+);
+?>
+<a class="button" href="<?php echo esc_url( $edit_url ); ?>"><?php echo esc_html( bhg_t( 'button_edit', 'Edit' ) ); ?></a>
 																<button type="submit" name="ad_id" value="<?php echo esc_attr( (int) $ad->id ); ?>" class="button-link-delete" onclick="return confirm('<?php echo esc_js( bhg_t( 'delete_this_ad', 'Delete this ad?' ) ); ?>');"><?php echo esc_html( bhg_t( 'remove', 'Remove' ) ); ?></button>
 																</td>
 				</tr>


### PR DESCRIPTION
## Summary
- add `wp_nonce_url` to advertisement edit links
- verify nonce before loading ad data

## Testing
- `composer install`
- `composer phpcs` *(fails: missing file doc comments and direct DB access warnings in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68c232e282148333b250be380b28b6d9