### PR TITLE
Normalize indentation to WordPress coding standards

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -20,11 +20,11 @@ if ( ! in_array( $ads_table, $allowed_tables, true ) ) {
 
 $edit_id = 0;
 if ( isset( $_GET['edit'] ) ) {
-        $nonce = isset( $_GET['bhg_edit_ad_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['bhg_edit_ad_nonce'] ) ) : '';
-        if ( ! $nonce || ! wp_verify_nonce( $nonce, 'bhg_edit_ad' ) ) {
-                wp_die( esc_html( bhg_t( 'notice_invalid_nonce', 'Invalid nonce.' ) ) );
-        }
-        $edit_id = absint( wp_unslash( $_GET['edit'] ) );
+		$nonce = isset( $_GET['bhg_edit_ad_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['bhg_edit_ad_nonce'] ) ) : '';
+	if ( ! $nonce || ! wp_verify_nonce( $nonce, 'bhg_edit_ad' ) ) {
+			wp_die( esc_html( bhg_t( 'notice_invalid_nonce', 'Invalid nonce.' ) ) );
+	}
+		$edit_id = absint( wp_unslash( $_GET['edit'] ) );
 }
 
 // Fetch ads.
@@ -95,13 +95,13 @@ $ads = $wpdb->get_results(
 																<td><?php echo esc_html( $visible_labels[ $visible_to ] ?? $visible_to ); ?></td>
 																<td><?php echo 1 === (int) $ad->active ? esc_html( bhg_t( 'yes', 'Yes' ) ) : esc_html( bhg_t( 'no', 'No' ) ); ?></td>
 																<td>
-<?php
-$edit_url = wp_nonce_url(
-        add_query_arg( array( 'edit' => (int) $ad->id ) ),
-        'bhg_edit_ad',
-        'bhg_edit_ad_nonce'
-);
-?>
+															<?php
+															$edit_url = wp_nonce_url(
+																add_query_arg( array( 'edit' => (int) $ad->id ) ),
+																'bhg_edit_ad',
+																'bhg_edit_ad_nonce'
+															);
+															?>
 <a class="button" href="<?php echo esc_url( $edit_url ); ?>"><?php echo esc_html( bhg_t( 'button_edit', 'Edit' ) ); ?></a>
 																<button type="submit" name="ad_id" value="<?php echo esc_attr( (int) $ad->id ); ?>" class="button-link-delete" onclick="return confirm('<?php echo esc_js( bhg_t( 'delete_this_ad', 'Delete this ad?' ) ); ?>');"><?php echo esc_html( bhg_t( 'remove', 'Remove' ) ); ?></button>
 																</td>
@@ -118,8 +118,8 @@ $edit_url = wp_nonce_url(
 	<?php
 		$ad = null;
 	if ( $edit_id ) {
-									// db call ok; no-cache ok.
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// db call ok; no-cache ok.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$ad = $wpdb->get_row(
 			$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $ads_table, $edit_id )
 		);

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -41,14 +41,14 @@ $view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] 
 if ( 'list' === $view ) :
 	$current_page = max( 1, isset( $_GET['paged'] ) ? (int) wp_unslash( $_GET['paged'] ) : 1 );
 	$per_page     = 30;
-        $offset       = ( $current_page - 1 ) * $per_page;
-        $search       = '';
-        if ( isset( $_GET['s'] ) ) {
-                check_admin_referer( 'bhg_hunts_search', 'bhg_hunts_search_nonce' );
-                $search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
-        }
-                $orderby  = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'id';
-		$order    = ( isset( $_GET['order'] ) && 'asc' === strtolower( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+		$offset   = ( $current_page - 1 ) * $per_page;
+		$search   = '';
+	if ( isset( $_GET['s'] ) ) {
+			check_admin_referer( 'bhg_hunts_search', 'bhg_hunts_search_nonce' );
+			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
+	}
+				$orderby = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'id';
+		$order           = ( isset( $_GET['order'] ) && 'asc' === strtolower( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
 
 		$allowed_orderby = array(
 			'id'               => 'h.id',
@@ -95,7 +95,7 @@ if ( 'list' === $view ) :
 
 <form method="get" class="search-form">
 <input type="hidden" name="page" value="bhg-bonus-hunts" />
-<?php wp_nonce_field( 'bhg_hunts_search', 'bhg_hunts_search_nonce' ); ?>
+	<?php wp_nonce_field( 'bhg_hunts_search', 'bhg_hunts_search_nonce' ); ?>
 <p class="search-box">
 <input type="search" name="s" value="<?php echo esc_attr( $search ); ?>" />
 	<?php if ( $orderby ) : ?>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -570,7 +570,7 @@ function bhg_handle_submit_guess() {
 	$count_cache_key = 'bhg_guess_count_' . $hunt_id . '_' . $user_id;
 	$count           = wp_cache_get( $count_cache_key );
 	if ( false === $count ) {
-                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 				$count = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE hunt_id = %d AND user_id = %d', $g_tbl, $hunt_id, $user_id ) );
 		wp_cache_set( $count_cache_key, $count );
 	}
@@ -580,13 +580,13 @@ function bhg_handle_submit_guess() {
 			$last_guess_key = 'bhg_last_guess_' . $hunt_id . '_' . $user_id;
 			$gid            = wp_cache_get( $last_guess_key );
 			if ( false === $gid ) {
-                                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 								$gid = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT id FROM %i WHERE hunt_id = %d AND user_id = %d ORDER BY id DESC LIMIT 1', $g_tbl, $hunt_id, $user_id ) );
 				wp_cache_set( $last_guess_key, $gid );
 			}
 			if ( $gid ) {
-								// db call ok; no-cache ok.
-                                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+				// db call ok; no-cache ok.
+								// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 								$wpdb->update(
 									$g_tbl,
 									array(
@@ -615,7 +615,7 @@ function bhg_handle_submit_guess() {
 
 		// Insert.
 		// db call ok; no-cache ok.
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$wpdb->insert(
 			$g_tbl,
 			array(
@@ -805,7 +805,7 @@ function bhg_generate_leaderboard_html( $timeframe, $paged ) {
 				) t';
 				$params_total[] = $g;
 								// db call ok; no-cache ok.
-                                // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$total = (int) $wpdb->get_var( $wpdb->prepare( $total_query, $params_total ) );
 
 				$list_query  = "SELECT g.user_id, u.user_login, COUNT(*) AS wins
@@ -829,7 +829,7 @@ function bhg_generate_leaderboard_html( $timeframe, $paged ) {
 				$params_list[] = $g;
 				$params_list[] = $per_page;
 				$params_list[] = $offset;
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 		$rows = $wpdb->get_results( $wpdb->prepare( $list_query, $params_list ) );
 	if ( ! $rows ) {
 		return '<p>' . esc_html( bhg_t( 'notice_no_data_available', 'No data available.' ) ) . '</p>';

--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -15,26 +15,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 class BHG_Ads {
 
 	/**
-	* Allowed ad placement values.
-	*
-	* @var string[]
-	*/
+	 * Allowed ad placement values.
+	 *
+	 * @var string[]
+	 */
 	private static $allowed_placements = array( 'none', 'footer', 'bottom', 'sidebar', 'shortcode' );
 
 	/**
-	* Retrieve allowed ad placements.
-	*
-	* @return string[]
-	*/
+	 * Retrieve allowed ad placements.
+	 *
+	 * @return string[]
+	 */
 	public static function get_allowed_placements() {
 		return self::$allowed_placements;
 	}
 
 	/**
-	* Initialize front-end hooks for ads.
-	*
-	* @return void
-	*/
+	 * Initialize front-end hooks for ads.
+	 *
+	 * @return void
+	 */
 	public static function init() {
 		add_action( 'wp_footer', array( 'BHG_Ads', 'render_footer' ) );
 		add_shortcode( 'bhg_ad', array( 'BHG_Ads', 'shortcode' ) );
@@ -42,10 +42,10 @@ class BHG_Ads {
 	}
 
 	/**
-	* Checks if front-end ads are enabled in plugin settings.
-	*
-	* @return bool
-	*/
+	 * Checks if front-end ads are enabled in plugin settings.
+	 *
+	 * @return bool
+	 */
 	protected static function ads_enabled() {
 			$settings = get_option( 'bhg_plugin_settings', array() );
 			$enabled  = isset( $settings['ads_enabled'] ) ? (int) $settings['ads_enabled'] : 1;
@@ -53,10 +53,10 @@ class BHG_Ads {
 	}
 
 	/**
-	* Determine current user's affiliate status (global toggle).
-	*
-	* @return bool
-	*/
+	 * Determine current user's affiliate status (global toggle).
+	 *
+	 * @return bool
+	 */
 	protected static function user_is_affiliate() {
 		if ( ! is_user_logged_in() ) {
 			return false;
@@ -66,12 +66,12 @@ class BHG_Ads {
 	}
 
 	/**
-	* Whether current visitor matches the ad's visibility setting.
-	*
-	* @param string $visibility Visibility rule.
-	*
-	* @return bool
-	*/
+	 * Whether current visitor matches the ad's visibility setting.
+	 *
+	 * @param string $visibility Visibility rule.
+	 *
+	 * @return bool
+	 */
 	protected static function visibility_ok( $visibility ) {
 		$visibility = is_string( $visibility ) ? strtolower( $visibility ) : 'all';
 		switch ( $visibility ) {
@@ -90,12 +90,12 @@ class BHG_Ads {
 	}
 
 	/**
-	* Whether the current page is one of the targeted pages (by slug), if any are set.
-	*
-	* @param string $target_pages Comma-separated list of target page slugs.
-	*
-	* @return bool
-	*/
+	 * Whether the current page is one of the targeted pages (by slug), if any are set.
+	 *
+	 * @param string $target_pages Comma-separated list of target page slugs.
+	 *
+	 * @return bool
+	 */
 	protected static function page_target_ok( $target_pages ) {
 		$target_pages = is_string( $target_pages ) ? trim( $target_pages ) : '';
 		if ( '' === $target_pages ) {
@@ -129,12 +129,12 @@ class BHG_Ads {
 	}
 
 	/**
-	* Render a single ad row to HTML.
-	*
-	* @param object $row Database row object.
-	*
-	* @return string
-	*/
+	 * Render a single ad row to HTML.
+	 *
+	 * @param object $row Database row object.
+	 *
+	 * @return string
+	 */
 	protected static function render_ad_row( $row ) {
 		$msg  = isset( $row->content ) ? $row->content : '';
 		$msg  = wp_kses_post( $msg );
@@ -147,12 +147,12 @@ class BHG_Ads {
 	}
 
 	/**
-	* Fetch active ads for a placement.
-	*
-	* @param string $placement Ad placement.
-	*
-	* @return array
-	*/
+	 * Fetch active ads for a placement.
+	 *
+	 * @param string $placement Ad placement.
+	 *
+	 * @return array
+	 */
 	protected static function get_ads_for_placement( $placement = 'footer' ) {
 		global $wpdb;
 		$table          = $wpdb->prefix . 'bhg_ads';
@@ -176,10 +176,10 @@ class BHG_Ads {
 	}
 
 	/**
-	* Render footer-placed ads.
-	*
-	* @return void
-	*/
+	 * Render footer-placed ads.
+	 *
+	 * @return void
+	 */
 	public static function render_footer() {
 		if ( is_admin() ) {
 			return;
@@ -215,18 +215,18 @@ class BHG_Ads {
 	}
 
 	/**
-	* Shortcode handler for rendering a single ad row regardless of placement.
-	*
-	* Usage examples:
-	* [bhg_ad id="123"]
-	* [bhg_advertising ad="123" status="inactive"]
-	*
-	* @param array  $atts    Shortcode attributes.
-	* @param string $content Content enclosed by shortcode (unused).
-	* @param string $tag     Shortcode tag.
-	*
-	* @return string
-	*/
+	 * Shortcode handler for rendering a single ad row regardless of placement.
+	 *
+	 * Usage examples:
+	 * [bhg_ad id="123"]
+	 * [bhg_advertising ad="123" status="inactive"]
+	 *
+	 * @param array  $atts    Shortcode attributes.
+	 * @param string $content Content enclosed by shortcode (unused).
+	 * @param string $tag     Shortcode tag.
+	 *
+	 * @return string
+	 */
 	public static function shortcode( $atts = array(), $content = '', $tag = '' ) {
 		if ( ! self::ads_enabled() ) {
 			return '';

--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -42,7 +42,7 @@ class BHG_Models {
 		$guesses_tbl = $wpdb->prefix . 'bhg_guesses';
 
 				// Determine number of winners for this hunt.
-                                // phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
+				// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
 								$winners_count = (int) $wpdb->get_var(
 									$wpdb->prepare(
 										sprintf(
@@ -52,7 +52,7 @@ class BHG_Models {
 										$hunt_id
 									)
 								);
-                                // phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
+				// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
 		if ( $winners_count <= 0 ) {
 			$winners_count = 1;
 		}
@@ -73,7 +73,7 @@ class BHG_Models {
 		);
 
 				// Fetch winners based on proximity to final balance.
-                                // phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
+				// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
 								$rows = $wpdb->get_results(
 									$wpdb->prepare(
 										sprintf(
@@ -85,7 +85,7 @@ class BHG_Models {
 										$winners_count
 									)
 								);
-                                // phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
+				// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
 
 		if ( empty( $rows ) ) {
 			return array();

--- a/includes/class-bhg-utils.php
+++ b/includes/class-bhg-utils.php
@@ -100,11 +100,11 @@ class BHG_Utils {
 	}
 
 		/**
-		* Retrieve an admin URL, respecting network admin context.
-		*
-		* @param string $path Optional path relative to the admin URL.
-		* @return string Full admin URL for the current context.
-		*/
+		 * Retrieve an admin URL, respecting network admin context.
+		 *
+		 * @param string $path Optional path relative to the admin URL.
+		 * @return string Full admin URL for the current context.
+		 */
 	public static function admin_url( $path = '' ) {
 			return is_network_admin() ? network_admin_url( $path ) : admin_url( $path );
 	}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -91,7 +91,7 @@ if ( ! function_exists( 'bhg_t' ) ) {
 		 * Retrieve a translation value from the database.
 		 *
 		 * @param string $slug    Translation slug.
- * @param string $default_text Default text if not found.
+		 * @param string $default_text Default text if not found.
 		 * @param string $locale  Locale to use. Defaults to current locale.
 		 * @return string
 		 */


### PR DESCRIPTION
## Summary
- replace leading spaces with tabs across admin and includes directories
- align PHPCS ignore comments and brace style to WordPress conventions

## Testing
- `composer phpcs admin includes bonus-hunt-guesser.php` *(fails: Detected usage of a non-sanitized input variable and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c2347383b4833387f2246c97a56ff7