### PR TITLE
Align dashboard table cells to the left

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -192,6 +192,10 @@ flex: 1;
     text-align: left;
 }
 
+.bhg-dashboard-table td {
+    text-align: left;
+}
+
 .bhg-summary-table td,
 .bhg-summary-table th {
     text-align: center;
@@ -202,10 +206,6 @@ flex: 1;
     font-weight: 600;
 }
 
-.bhg-latest-hunts-table td:nth-child(3),
-.bhg-latest-hunts-table td:nth-child(4) {
-    text-align: right;
-}
 
 .bhg-card-content > p {
     margin-top: var(--bhg-spacing);


### PR DESCRIPTION
## Summary
- Left-align dashboard table cells for consistent admin styling
- Remove explicit right alignment so Start and Final Balance columns inherit left alignment

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68c37477cc8883338107568dd988947a