### PR TITLE
Add admin action column for delete

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -198,14 +198,15 @@ if ( 'list' === $view ) :
 	?>
 				"><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) ); ?></a></th>
 <th><?php echo esc_html( bhg_t( 'label_actions', 'Actions' ) ); ?></th>
+<th><?php echo esc_html( bhg_t( 'admin_action', 'Admin Action' ) ); ?></th>
 </tr>
 </thead>
-	<tbody>
-		<?php if ( empty( $hunts ) ) : ?>
-<tr><td colspan="8"><?php echo esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ); ?></td></tr>
-			<?php
-		else :
-			foreach ( $hunts as $h ) :
+        <tbody>
+                <?php if ( empty( $hunts ) ) : ?>
+<tr><td colspan="9"><?php echo esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ); ?></td></tr>
+                        <?php
+                else :
+                        foreach ( $hunts as $h ) :
 				?>
 		<tr>
 <td><?php echo esc_html( (int) $h->id ); ?></td>
@@ -254,24 +255,27 @@ if ( 'list' === $view ) :
 "><?php echo esc_html( bhg_t( 'close_hunt', 'Close Hunt' ) ); ?></a>
 <?php elseif ( null !== $h->final_balance ) : ?>
 <a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html( bhg_t( 'button_results', 'Results' ) ); ?></a>
+
 <?php endif; ?>
-<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( bhg_t( 'delete_this_hunt', 'Delete this hunt?' ) ); ?>');" class="bhg-inline-form">
-				<?php wp_nonce_field( 'bhg_delete_hunt', 'bhg_delete_hunt_nonce' ); ?>
-<input type="hidden" name="action" value="bhg_delete_hunt" />
-<input type="hidden" name="hunt_id" value="<?php echo esc_attr( (int) $h->id ); ?>" />
-<button type="submit" class="button-link-delete"><?php echo esc_html( bhg_t( 'delete', 'Delete' ) ); ?></button>
-</form>
 <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-inline-form">
-				<?php wp_nonce_field( 'bhg_toggle_guessing', 'bhg_toggle_guessing_nonce' ); ?>
+<?php wp_nonce_field( 'bhg_toggle_guessing', 'bhg_toggle_guessing_nonce' ); ?>
 <input type="hidden" name="action" value="bhg_toggle_guessing" />
 <input type="hidden" name="hunt_id" value="<?php echo esc_attr( (int) $h->id ); ?>" />
 <input type="hidden" name="guessing_enabled" value="<?php echo esc_attr( $h->guessing_enabled ? 0 : 1 ); ?>" />
 <button type="submit" class="button"><?php echo esc_html( $h->guessing_enabled ? bhg_t( 'disable_guessing', 'Disable Guessing' ) : bhg_t( 'enable_guessing', 'Enable Guessing' ) ); ?></button>
 </form>
 </td>
-		</tr>
-				<?php
-			endforeach;
+<td>
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( bhg_t( 'delete_this_hunt', 'Delete this hunt?' ) ); ?>');" class="bhg-inline-form">
+<?php wp_nonce_field( 'bhg_delete_hunt', 'bhg_delete_hunt_nonce' ); ?>
+<input type="hidden" name="action" value="bhg_delete_hunt" />
+<input type="hidden" name="hunt_id" value="<?php echo esc_attr( (int) $h->id ); ?>" />
+<button type="submit" class="button-link-delete"><?php echo esc_html( bhg_t( 'delete', 'Delete' ) ); ?></button>
+</form>
+</td>
+</tr>
+                                <?php
+                        endforeach;
 endif;
 		?>
 		</tbody>


### PR DESCRIPTION
## Summary
- add "Admin Action" column to bonus hunts list
- move delete form into its own column
- adjust empty table colspan

## Testing
- `composer phpcs` *(fails: PHPCS reported existing coding standard violations)*
- `vendor/bin/phpcs admin/views/bonus-hunts.php` *(fails: PHPCS reported existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c3753b64608333a4ab8d78bda1b7cf