### PR TITLE
Add timeframe filter and empty results notice

### DIFF
--- a/assets/js/admin-results.js
+++ b/assets/js/admin-results.js
@@ -1,15 +1,19 @@
 (function(){
-    var select = document.getElementById('bhg-results-select');
-    if (!select || typeof bhgResults === 'undefined') {
+    var huntSelect = document.getElementById('bhg-results-select');
+    var timeSelect = document.getElementById('bhg-results-timeframe');
+    if (!huntSelect || !timeSelect || typeof bhgResults === 'undefined') {
         return;
     }
-    select.addEventListener('change', function(){
-        var val = this.value.split('-');
+    var navigate = function(){
+        var val = huntSelect.value.split('-');
         if (val.length < 2) {
             return;
         }
         var type = val[0];
         var id = val[1];
-        window.location = bhgResults.base_url + '&type=' + type + '&id=' + id;
-    });
+        var timeframe = timeSelect.value;
+        window.location = bhgResults.base_url + '&timeframe=' + timeframe + '&type=' + type + '&id=' + id;
+    };
+    huntSelect.addEventListener('change', navigate);
+    timeSelect.addEventListener('change', navigate);
 })();


### PR DESCRIPTION
## Summary
- show message when no winners recorded
- support filtering hunts by this month, year or all time with a new dropdown
- refresh results based on timeframe selection

## Testing
- `composer install`
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*


------
https://chatgpt.com/codex/tasks/task_e_68c376b8af248333b8102d14c68fa6f4