### PR TITLE
Refactor ABSPATH checks to multiline

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -6,7 +6,8 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
 }

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -6,7 +6,8 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-		exit; }
+	exit;
+}
 if ( ! current_user_can( 'manage_options' ) ) {
 				wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
 }

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -6,7 +6,8 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 
 if ( ! current_user_can( 'manage_options' ) ) {
 		wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );

--- a/admin/views/users.php
+++ b/admin/views/users.php
@@ -1,6 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
 }

--- a/includes/class-bhg-bonus-hunts.php
+++ b/includes/class-bhg-bonus-hunts.php
@@ -1,6 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 
 /**
  * Bonus hunt data helpers.


### PR DESCRIPTION
## Summary
- Use multiline WordPress standard for ABSPATH exit checks in bonus-hunt helpers and admin views

## Testing
- `composer phpcs` *(fails: Tabs must be used to indent lines; spaces are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68c380bdd37083338f9c40286423baf9