### PR TITLE
Refactor database admin tools into reusable include

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -186,15 +186,19 @@ class BHG_Admin {
 			require $view; } else {
 			echo '<div class="wrap"><h1>' . esc_html( bhg_t( 'menu_translations', 'Translations' ) ) . '</h1><p>' . esc_html( bhg_t( 'no_translations_ui_found', 'No translations UI found.' ) ) . '</p></div>'; }
 	}
-	/**
-	 * Render the database maintenance page.
-	 */
-	public function database() {
-		$view = BHG_PLUGIN_DIR . 'admin/views/database.php';
-		if ( file_exists( $view ) ) {
-			require $view; } else {
-			echo '<div class="wrap"><h1>' . esc_html( bhg_t( 'database', 'Database' ) ) . '</h1><p>' . esc_html( bhg_t( 'no_database_ui_found', 'No database UI found.' ) ) . '</p></div>'; }
-	}
+        /**
+         * Render the database maintenance page.
+         */
+        public function database() {
+                require_once BHG_PLUGIN_DIR . 'includes/admin-database-tools.php';
+
+                $view = BHG_PLUGIN_DIR . 'admin/views/database.php';
+                if ( file_exists( $view ) ) {
+                        require $view;
+                } else {
+                        echo '<div class="wrap"><h1>' . esc_html( bhg_t( 'database', 'Database' ) ) . '</h1><p>' . esc_html( bhg_t( 'no_database_ui_found', 'No database UI found.' ) ) . '</p></div>';
+                }
+        }
 	/**
 	 * Render the settings page.
 	 */

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -27,90 +27,11 @@ if ( 'db_cleanup' === $db_action && ! empty( $cleanup_request ) ) {
 	bhg_database_cleanup();
 	$cleanup_completed = true;
 } elseif ( 'db_optimize' === $db_action && ! empty( $optimize_request ) ) {
-	check_admin_referer( 'bhg_db_optimize_action', 'bhg_nonce' );
+        check_admin_referer( 'bhg_db_optimize_action', 'bhg_nonce' );
 
-	// Perform database optimization.
-	bhg_database_optimize();
-	$optimize_completed = true;
-}
-
-/**
- * Truncate all plugin tables and reinsert demo data.
- *
- * @return void
- */
-function bhg_database_cleanup() {
-	global $wpdb;
-
-        $tables = array(
-                esc_sql( $wpdb->prefix . 'bhg_bonus_hunts' ),
-                esc_sql( $wpdb->prefix . 'bhg_guesses' ),
-                esc_sql( $wpdb->prefix . 'bhg_tournaments' ),
-                esc_sql( $wpdb->prefix . 'bhg_tournament_results' ),
-                esc_sql( $wpdb->prefix . 'bhg_translations' ),
-                esc_sql( $wpdb->prefix . 'bhg_affiliate_websites' ),
-                esc_sql( $wpdb->prefix . 'bhg_hunt_winners' ),
-                esc_sql( $wpdb->prefix . 'bhg_ads' ),
-        );
-
-	foreach ( $tables as $table ) {
-                if ( $wpdb->get_var( "SHOW TABLES LIKE '{$table}'" ) === $table ) {
-                        $wpdb->query( "TRUNCATE TABLE {$table}" );
-                }
-	}
-
-	// Reinsert default data if needed.
-	bhg_insert_demo_data();
-}
-
-/**
- * Optimize all plugin tables.
- *
- * @return void
- */
-function bhg_database_optimize() {
-	global $wpdb;
-
-        $tables = array(
-                esc_sql( $wpdb->prefix . 'bhg_bonus_hunts' ),
-                esc_sql( $wpdb->prefix . 'bhg_guesses' ),
-                esc_sql( $wpdb->prefix . 'bhg_tournaments' ),
-                esc_sql( $wpdb->prefix . 'bhg_tournament_results' ),
-                esc_sql( $wpdb->prefix . 'bhg_translations' ),
-                esc_sql( $wpdb->prefix . 'bhg_affiliate_websites' ),
-                esc_sql( $wpdb->prefix . 'bhg_hunt_winners' ),
-                esc_sql( $wpdb->prefix . 'bhg_ads' ),
-        );
-
-	foreach ( $tables as $table ) {
-                if ( $wpdb->get_var( "SHOW TABLES LIKE '{$table}'" ) === $table ) {
-                        $wpdb->query( "OPTIMIZE TABLE {$table}" );
-                }
-	}
-}
-
-/**
- * Insert basic demo data.
- *
- * This would typically live in a separate demo seeder file.
- *
- * @return void
- */
-function bhg_insert_demo_data() {
-	global $wpdb;
-
-	// Insert default bonus hunt.
-	$wpdb->insert(
-		$wpdb->prefix . 'bhg_bonus_hunts',
-		array(
-			'title'            => 'Demo Bonus Hunt',
-			'starting_balance' => 2000,
-			'num_bonuses'      => 10,
-			'status'           => 'active',
-			'created_at'       => current_time( 'mysql' ),
-		),
-		array( '%s', '%d', '%d', '%s', '%s' )
-	);
+        // Perform database optimization.
+        bhg_database_optimize();
+        $optimize_completed = true;
 }
 
 ?>

--- a/includes/admin-database-tools.php
+++ b/includes/admin-database-tools.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Database maintenance tools for Bonus Hunt Guesser.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! function_exists( 'bhg_database_cleanup' ) ) {
+    /**
+     * Truncate all plugin tables and reinsert demo data.
+     */
+    function bhg_database_cleanup() {
+        global $wpdb;
+
+        $tables = array(
+            esc_sql( $wpdb->prefix . 'bhg_bonus_hunts' ),
+            esc_sql( $wpdb->prefix . 'bhg_guesses' ),
+            esc_sql( $wpdb->prefix . 'bhg_tournaments' ),
+            esc_sql( $wpdb->prefix . 'bhg_tournament_results' ),
+            esc_sql( $wpdb->prefix . 'bhg_translations' ),
+            esc_sql( $wpdb->prefix . 'bhg_affiliate_websites' ),
+            esc_sql( $wpdb->prefix . 'bhg_hunt_winners' ),
+            esc_sql( $wpdb->prefix . 'bhg_ads' ),
+        );
+
+        foreach ( $tables as $table ) {
+            if ( $wpdb->get_var( "SHOW TABLES LIKE '{$table}'" ) === $table ) {
+                $wpdb->query( "TRUNCATE TABLE {$table}" );
+            }
+        }
+
+        bhg_insert_demo_data();
+    }
+}
+
+if ( ! function_exists( 'bhg_database_optimize' ) ) {
+    /**
+     * Optimize all plugin tables.
+     */
+    function bhg_database_optimize() {
+        global $wpdb;
+
+        $tables = array(
+            esc_sql( $wpdb->prefix . 'bhg_bonus_hunts' ),
+            esc_sql( $wpdb->prefix . 'bhg_guesses' ),
+            esc_sql( $wpdb->prefix . 'bhg_tournaments' ),
+            esc_sql( $wpdb->prefix . 'bhg_tournament_results' ),
+            esc_sql( $wpdb->prefix . 'bhg_translations' ),
+            esc_sql( $wpdb->prefix . 'bhg_affiliate_websites' ),
+            esc_sql( $wpdb->prefix . 'bhg_hunt_winners' ),
+            esc_sql( $wpdb->prefix . 'bhg_ads' ),
+        );
+
+        foreach ( $tables as $table ) {
+            if ( $wpdb->get_var( "SHOW TABLES LIKE '{$table}'" ) === $table ) {
+                $wpdb->query( "OPTIMIZE TABLE {$table}" );
+            }
+        }
+    }
+}
+
+if ( ! function_exists( 'bhg_insert_demo_data' ) ) {
+    /**
+     * Insert basic demo data.
+     */
+    function bhg_insert_demo_data() {
+        global $wpdb;
+
+        $wpdb->insert(
+            $wpdb->prefix . 'bhg_bonus_hunts',
+            array(
+                'title'            => 'Demo Bonus Hunt',
+                'starting_balance' => 2000,
+                'num_bonuses'      => 10,
+                'status'           => 'active',
+                'created_at'       => current_time( 'mysql' ),
+            ),
+            array( '%s', '%d', '%d', '%s', '%s' )
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- Extract database cleanup and optimization functions into `includes/admin-database-tools.php`
- Load database tools before rendering admin database page
- Trim `admin/views/database.php` to markup and simple control flow

## Testing
- `composer phpcs` *(fails: Use placeholders and $wpdb->prepare(); found $list_query, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c3828e3adc833396aae1478396a173