### PR TITLE
Refactor security guards to multi-line format

### DIFF
--- a/admin/class-bhg-users-table.php
+++ b/admin/class-bhg-users-table.php
@@ -1,6 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 
 if ( ! class_exists( 'WP_List_Table' ) ) {
 	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';

--- a/admin/views/hunts-edit.php
+++ b/admin/views/hunts-edit.php
@@ -1,12 +1,15 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 if ( ! current_user_can( 'manage_options' ) ) {
-	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) ); }
+	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
+}
 
 $hunt_id = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
 if ( ! $hunt_id ) {
-	wp_die( esc_html( bhg_t( 'missing_hunt_id', 'Missing hunt id' ) ) ); }
+	wp_die( esc_html( bhg_t( 'missing_hunt_id', 'Missing hunt id' ) ) );
+}
 
 check_admin_referer( 'bhg_edit_hunt_' . $hunt_id, 'bhg_nonce' );
 
@@ -26,7 +29,8 @@ if ( ! function_exists( 'bhg_get_hunt' ) || ! function_exists( 'bhg_get_hunt_par
 
 $hunt = bhg_get_hunt( $hunt_id );
 if ( ! $hunt ) {
-	wp_die( esc_html( bhg_t( 'hunt_not_found', 'Hunt not found' ) ) ); }
+	wp_die( esc_html( bhg_t( 'hunt_not_found', 'Hunt not found' ) ) );
+}
 
 $paged    = max( 1, isset( $_GET['ppaged'] ) ? absint( wp_unslash( $_GET['ppaged'] ) ) : 1 );
 $per_page = 30;

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -1,6 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
 }

--- a/includes/class-bhg-bonus-hunts-helpers.php
+++ b/includes/class-bhg-bonus-hunts-helpers.php
@@ -1,6 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
 
 /**
 	* Helper functions for hunts and guesses used by admin dashboard, list and results.


### PR DESCRIPTION
## Summary
- replace single-line `exit` guards with multi-line blocks
- expand `wp_die` guards in hunt edit view to multi-line format

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68c388c6c558833384a8fd6822e3a244