### PR TITLE
Sanitize numeric POST values with wp_unslash

### DIFF
--- a/admin/class-bhg-bonus-hunts-controller.php
+++ b/admin/class-bhg-bonus-hunts-controller.php
@@ -88,11 +88,11 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 			switch ( $action ) {
 				case 'create_bonus_hunt':
 					$title             = sanitize_text_field( wp_unslash( $_POST['title'] ?? '' ) );
-					$starting_balance  = floatval( $_POST['starting_balance'] ?? 0 );
-					$num_bonuses       = intval( $_POST['num_bonuses'] ?? 0 );
+					$starting_balance  = floatval( wp_unslash( $_POST['starting_balance'] ?? 0 ) );
+					$num_bonuses       = intval( wp_unslash( $_POST['num_bonuses'] ?? 0 ) );
 					$prizes            = sanitize_textarea_field( wp_unslash( $_POST['prizes'] ?? '' ) );
 					$status            = sanitize_text_field( wp_unslash( $_POST['status'] ?? '' ) );
-					$affiliate_site_id = isset( $_POST['affiliate_site_id'] ) ? intval( $_POST['affiliate_site_id'] ) : 0;
+					$affiliate_site_id = isset( $_POST['affiliate_site_id'] ) ? intval( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
 
 					$result = $db->create_bonus_hunt(
 						array(
@@ -111,14 +111,14 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 					break;
 
 				case 'update_bonus_hunt':
-					$id                = intval( $_POST['id'] ?? 0 );
+					$id                = intval( wp_unslash( $_POST['id'] ?? 0 ) );
 					$title             = sanitize_text_field( wp_unslash( $_POST['title'] ?? '' ) );
-					$starting_balance  = floatval( $_POST['starting_balance'] ?? 0 );
-					$num_bonuses       = intval( $_POST['num_bonuses'] ?? 0 );
+					$starting_balance  = floatval( wp_unslash( $_POST['starting_balance'] ?? 0 ) );
+					$num_bonuses       = intval( wp_unslash( $_POST['num_bonuses'] ?? 0 ) );
 					$prizes            = sanitize_textarea_field( wp_unslash( $_POST['prizes'] ?? '' ) );
 					$status            = sanitize_text_field( wp_unslash( $_POST['status'] ?? '' ) );
-					$final_balance     = isset( $_POST['final_balance'] ) ? floatval( $_POST['final_balance'] ) : null;
-					$affiliate_site_id = isset( $_POST['affiliate_site_id'] ) ? intval( $_POST['affiliate_site_id'] ) : 0;
+					$final_balance     = isset( $_POST['final_balance'] ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
+					$affiliate_site_id = isset( $_POST['affiliate_site_id'] ) ? intval( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
 
 					$result = $db->update_bonus_hunt(
 						$id,
@@ -146,7 +146,7 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 					break;
 
 				case 'delete_bonus_hunt':
-					$id      = intval( $_POST['id'] ?? 0 );
+					$id      = intval( wp_unslash( $_POST['id'] ?? 0 ) );
 					$result  = $db->delete_bonus_hunt( $id );
 					$message = $result ? 'deleted' : 'error';
 					break;


### PR DESCRIPTION
## Summary
- sanitize numeric `$_POST` values in bonus hunt controller with `wp_unslash`

## Testing
- `composer phpcs` *(fails: Tabs must be used to indent lines; spaces are not allowed)*
- `vendor/bin/phpcs admin/class-bhg-bonus-hunts-controller.php`

------
https://chatgpt.com/codex/tasks/task_e_68c38a44349483338a561a0c538bad56