### PR TITLE
Sanitize pagination parameter in shortcode

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -290,8 +290,10 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 								}
 								$orderby = $allowed_orderby[ $orderby_key ];
 
-								$paged    = isset( $_GET['bhg_page'] ) ? (int) $_GET['bhg_page'] : (int) $a['paged'];
-								$paged    = max( 1, $paged );
+                                                                $paged    = isset( $_GET['bhg_page'] )
+                                                                        ? max( 1, absint( wp_unslash( $_GET['bhg_page'] ) ) )
+                                                                        : (int) $a['paged'];
+                                                                $paged    = max( 1, $paged );
 								$per_page = max( 1, (int) $a['per_page'] );
 								$offset   = ( $paged - 1 ) * $per_page;
 


### PR DESCRIPTION
## Summary
- sanitize `bhg_page` query parameter before using it for pagination

## Testing
- `composer run-script phpcs includes/class-bhg-shortcodes.php` *(fails: Use placeholders and $wpdb->prepare(); found $sql)*


------
https://chatgpt.com/codex/tasks/task_e_68c391827b34833390705c5a1887e309