### PR TITLE
Use absint for pagination and hunt IDs

### DIFF
--- a/admin/class-bhg-users-table.php
+++ b/admin/class-bhg-users-table.php
@@ -67,7 +67,7 @@ class BHG_Users_Table extends WP_List_Table {
 	}
 
 	public function prepare_items() {
-				$paged   = isset( $_REQUEST['paged'] ) ? max( 1, (int) wp_unslash( $_REQUEST['paged'] ) ) : 1;
+                               $paged   = isset( $_REQUEST['paged'] ) ? max( 1, absint( wp_unslash( $_REQUEST['paged'] ) ) ) : 1;
 				$orderby = isset( $_REQUEST['orderby'] ) ? sanitize_key( wp_unslash( $_REQUEST['orderby'] ) ) : 'username';
 				$order   = isset( $_REQUEST['order'] ) && in_array( strtolower( wp_unslash( $_REQUEST['order'] ) ), array( 'asc', 'desc' ), true )
 						? strtoupper( wp_unslash( $_REQUEST['order'] ) )

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -34,7 +34,7 @@ $view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] 
 
 /** LIST VIEW */
 if ( 'list' === $view ) :
-	$current_page = max( 1, isset( $_GET['paged'] ) ? (int) wp_unslash( $_GET['paged'] ) : 1 );
+        $current_page = max( 1, isset( $_GET['paged'] ) ? absint( wp_unslash( $_GET['paged'] ) ) : 1 );
 	$per_page     = 30;
 		$offset   = ( $current_page - 1 ) * $per_page;
 		$search   = '';
@@ -305,7 +305,7 @@ endif;
 <?php
 /** CLOSE VIEW */
 if ( 'close' === $view ) :
-				$id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
+                               $id = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
 				// db call ok; no-cache ok.
                                 $hunt = $wpdb->get_row(
                                         $wpdb->prepare(
@@ -453,7 +453,7 @@ if ( 'add' === $view ) :
 <?php
 /** EDIT VIEW */
 if ( 'edit' === $view ) :
-		$id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
+            $id = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
 		// db call ok; no-cache ok.
                                 $hunt = $wpdb->get_row(
                                         $wpdb->prepare(


### PR DESCRIPTION
## Summary
- Sanitize user table pagination using `absint`
- Sanitize hunt list pagination and hunt ID handling with `absint`

## Testing
- `composer phpcs` (fails: The method parameter $requested is never used, The method parameter $user is never used, Processing form data without nonce verification., Processing form data without nonce verification., The method parameter $user is never used, The method parameter $provider is never used, Processing form data without nonce verification., Processing form data without nonce verification.)`

------
https://chatgpt.com/codex/tasks/task_e_68c39512567483339b3ce6804ee4ef38