### PR TITLE
Harden tournament ordering sanitization

### DIFF
--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -18,13 +18,13 @@ $row     = $edit_id
                 : null;
 
 $search          = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
-$orderby         = isset( $_GET['orderby'] ) ? sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) : 'id';
-$order           = isset( $_GET['order'] ) ? strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) : 'DESC';
+$orderby         = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'id';
+$order           = isset( $_GET['order'] ) ? sanitize_key( wp_unslash( $_GET['order'] ) ) : 'DESC';
 $allowed_orderby = array( 'id', 'title', 'start_date', 'end_date', 'status' );
 if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
-		$orderby = 'id';
+                $orderby = 'id';
 }
-$order           = ( 'ASC' === $order ) ? 'ASC' : 'DESC';
+$order           = in_array( strtolower( $order ), array( 'asc', 'desc' ), true ) ? strtoupper( $order ) : 'DESC';
 $order_by_clause = sanitize_sql_orderby( $orderby . ' ' . $order );
 if ( empty( $order_by_clause ) ) {
 		$order_by_clause = 'id DESC';


### PR DESCRIPTION
## Summary
- Sanitize `orderby` and `order` query parameters with `sanitize_key`
- Validate tournament ordering values before calling `sanitize_sql_orderby`

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*
- `vendor/bin/phpcs admin/views/tournaments.php` *(fails: FOUND 41 ERRORS AND 30 WARNINGS AFFECTING 35 LINES)*
- `php -l admin/views/tournaments.php`

------
https://chatgpt.com/codex/tasks/task_e_68c39bc91350833390f652c8554b52aa