### PR TITLE
Sanitize order query var for bonus hunts view

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -42,8 +42,8 @@ if ( 'list' === $view ) :
 			check_admin_referer( 'bhg_hunts_search', 'bhg_hunts_search_nonce' );
 			$search = sanitize_text_field( wp_unslash( $_GET['s'] ) );
 	}
-				$orderby = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'id';
-		$order           = ( isset( $_GET['order'] ) && 'asc' === strtolower( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) ? 'ASC' : 'DESC';
+                $orderby = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'id';
+                $order   = isset( $_GET['order'] ) && 'asc' === strtolower( sanitize_key( wp_unslash( $_GET['order'] ) ) ) ? 'ASC' : 'DESC';
 
 		$allowed_orderby = array(
 			'id'               => 'h.id',


### PR DESCRIPTION
## Summary
- sanitize `order` query variable with `sanitize_key`
- normalize order direction to `ASC` or `DESC`

## Testing
- `composer install`
- `composer phpcs` *(fails: existing PHPCS violations in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c39c692d348333976fb690b9c7b103