### PR TITLE
Use absint for positive integers

### DIFF
--- a/admin/class-bhg-bonus-hunts-controller.php
+++ b/admin/class-bhg-bonus-hunts-controller.php
@@ -90,10 +90,10 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 				case 'bhg_create_bonus_hunt':
 						$title                         = sanitize_text_field( wp_unslash( $_POST['title'] ?? '' ) );
 						$starting_balance              = floatval( wp_unslash( $_POST['starting_balance'] ?? 0 ) );
-						$num_bonuses                   = intval( wp_unslash( $_POST['num_bonuses'] ?? 0 ) );
+						$num_bonuses                   = absint( wp_unslash( $_POST['num_bonuses'] ?? 0 ) );
 									$prizes            = sanitize_textarea_field( wp_unslash( $_POST['prizes'] ?? '' ) );
 									$status            = sanitize_text_field( wp_unslash( $_POST['status'] ?? '' ) );
-									$affiliate_site_id = isset( $_POST['affiliate_site_id'] ) ? intval( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
+									$affiliate_site_id = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
 
 									$result = $db->create_bonus_hunt(
 										array(
@@ -112,14 +112,14 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 					break;
 
 				case 'bhg_update_bonus_hunt':
-						$id               = intval( wp_unslash( $_POST['id'] ?? 0 ) );
+						$id               = absint( wp_unslash( $_POST['id'] ?? 0 ) );
 						$title            = sanitize_text_field( wp_unslash( $_POST['title'] ?? '' ) );
 						$starting_balance = floatval( wp_unslash( $_POST['starting_balance'] ?? 0 ) );
-					$num_bonuses          = intval( wp_unslash( $_POST['num_bonuses'] ?? 0 ) );
+					$num_bonuses          = absint( wp_unslash( $_POST['num_bonuses'] ?? 0 ) );
 					$prizes               = sanitize_textarea_field( wp_unslash( $_POST['prizes'] ?? '' ) );
 					$status               = sanitize_text_field( wp_unslash( $_POST['status'] ?? '' ) );
 					$final_balance        = isset( $_POST['final_balance'] ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
-					$affiliate_site_id    = isset( $_POST['affiliate_site_id'] ) ? intval( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
+					$affiliate_site_id    = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
 
 					$result = $db->update_bonus_hunt(
 						$id,
@@ -147,7 +147,7 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 					break;
 
 				case 'bhg_delete_bonus_hunt':
-						$id      = intval( wp_unslash( $_POST['id'] ?? 0 ) );
+						$id      = absint( wp_unslash( $_POST['id'] ?? 0 ) );
 						$result  = $db->delete_bonus_hunt( $id );
 						$message = $result ? 'deleted' : 'error';
 					break;

--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -219,7 +219,7 @@ if ( isset( $_GET['message'] ) ) { // phpcs:ignore WordPress.Security.NonceVerif
 							</td>
 							<td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $hunt->created_at ) ) ); ?></td>
 							<td>
-								<a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg_bonus_hunts&action=edit&id=' . intval( $hunt->id ) ) ); ?>" class="button button-small">
+								<a href="<?php echo esc_url( admin_url( 'admin.php?page=bhg_bonus_hunts&action=edit&id=' . absint( $hunt->id ) ) ); ?>" class="button button-small">
 									<?php
 									echo esc_html( bhg_t( 'button_edit', 'Edit' ) );
 									?>


### PR DESCRIPTION
## Summary
- use `absint` when handling bonus hunt counts and IDs
- update header edit link to sanitize hunt IDs with `absint`

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*
- `vendor/bin/phpcs admin/class-bhg-bonus-hunts-controller.php admin/views/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3a1b0030c83338f54d3008d97b1e1