### PR TITLE
Lower minimum WordPress version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## 8.0.10 — 2025-09-12
 - Bump version to 8.0.10.
+- Set minimum WordPress version to 5.5.5.
 
 ## 8.0.06 — 2025-09-05
 - Removed legacy deprecated database layer (deprecated/ directory and includes/deprecated-db.php).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bonus Hunt Guesser
 
+Requires at least: WordPress 5.5.5
+
 ## Shortcodes
 
 ### `[bhg_user_guesses]`

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://yourdomain.com/
  * Description: Comprehensive bonus hunt management system with tournaments, leaderboards, and user guessing functionality
  * Version: 8.0.10
- * Requires at least: 6.3.5
+ * Requires at least: 5.5.5
  * Requires PHP: 7.4
  * Author: Bonus Hunt Guesser Development Team
  * Text Domain: bonus-hunt-guesser
@@ -121,7 +121,7 @@ require_once __DIR__ . '/includes/class-bhg-db.php';
 
 // Define plugin constants.
 define( 'BHG_VERSION', '8.0.10' );
-define( 'BHG_MIN_WP', '6.3.5' );
+define( 'BHG_MIN_WP', '5.5.5' );
 define( 'BHG_PLUGIN_FILE', __FILE__ );
 define( 'BHG_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BHG_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -2,7 +2,7 @@
 /**
  * Shortcodes for Bonus Hunt Guesser.
  *
- * PHP 7.4 safe, WP 6.3.5 compatible.
+ * PHP 7.4 safe, WP 5.5.5+ compatible.
  * Registers all shortcodes on init (once) and avoids parse errors.
  *
  * @package Bonus_Hunt_Guesser


### PR DESCRIPTION
## Summary
- Update plugin header and constant to require WordPress 5.5.5
- Document the 5.5.5 requirement in README and changelog
- Clarify shortcodes file compatibility comment

## Testing
- `composer phpcs` *(fails: phpcs: not found)*
- `composer install`
- `vendor/bin/phpcs bonus-hunt-guesser.php README.md CHANGELOG.md includes/class-bhg-shortcodes.php` *(fails: existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ad188434833385ce8880672a783c