### PR TITLE
Add nonce verification for bonus hunt editing

### DIFF
--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -4,8 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! current_user_can( 'manage_options' ) ) {
-		wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
+                wp_die( esc_html( bhg_t( 'you_do_not_have_sufficient_permissions_to_access_this_page', 'You do not have sufficient permissions to access this page.' ) ) );
 }
+
+check_admin_referer( 'bhg_edit_hunt' );
 
 global $wpdb;
 
@@ -16,7 +18,7 @@ if ( ! $hunt ) {
 		return;
 }
 
-\$aff_table = esc_sql( $wpdb->prefix . 'bhg_affiliate_websites' );
+$aff_table = esc_sql( $wpdb->prefix . 'bhg_affiliate_websites' );
 if ( isset( $allowed_tables ) && ! in_array( $aff_table, $allowed_tables, true ) ) {
 				wp_die( esc_html( bhg_t( 'notice_invalid_table', 'Invalid table.' ) ) );
 }

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -217,15 +217,18 @@ if ( 'list' === $view ) :
 			<td><a href="
 				<?php
 				echo esc_url(
-					add_query_arg(
-						array(
-							'view' => 'edit',
-							'id'   => (int) $h->id,
-						)
-					)
-				);
-				?>
-							"><?php echo esc_html( $h->title ); ?></a></td>
+                                        wp_nonce_url(
+                                                add_query_arg(
+                                                        array(
+                                                                'view' => 'edit',
+                                                                'id'   => (int) $h->id,
+                                                        )
+                                                ),
+                                                'bhg_edit_hunt'
+                                        )
+                                );
+                                ?>
+                                        "><?php echo esc_html( $h->title ); ?></a></td>
 <td><?php echo esc_html( bhg_format_currency( (float) $h->starting_balance ) ); ?></td>
 <td><?php echo null !== $h->final_balance ? esc_html( bhg_format_currency( (float) $h->final_balance ) ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
 <td><?php echo $h->affiliate_name ? esc_html( $h->affiliate_name ) : esc_html( bhg_t( 'label_emdash', '—' ) ); ?></td>
@@ -234,16 +237,20 @@ if ( 'list' === $view ) :
 <td>
 <a class="button" href="
 				<?php
-				echo esc_url(
-					add_query_arg(
-						array(
-							'view' => 'edit',
-							'id'   => (int) $h->id,
-						)
-					)
-				);
-				?>
-"><?php echo esc_html( bhg_t( 'button_edit', 'Edit' ) ); ?></a>
+                                echo esc_url(
+                                        wp_nonce_url(
+                                                add_query_arg(
+                                                        array(
+                                                                'view' => 'edit',
+                                                                'id'   => (int) $h->id,
+                                                        )
+                                                ),
+                                                'bhg_edit_hunt'
+                                        )
+                                );
+                                ?>
+">
+                                        <?php echo esc_html( bhg_t( 'button_edit', 'Edit' ) ); ?></a>
 				<?php if ( 'open' === $h->status ) : ?>
 <a class="button" href="
 					<?php


### PR DESCRIPTION
## Summary
- Wrap edit hunt links in a nonce-protected URL
- Validate edit nonce before rendering hunt edit screen
- Fix affiliate table variable declaration in edit view

## Testing
- `composer install --no-progress`
- `php -l admin/views/bonus-hunts.php admin/views/bonus-hunts-edit.php`
- `./vendor/bin/phpcs --standard=phpcs.xml admin/views/bonus-hunts.php admin/views/bonus-hunts-edit.php` *(fails: placeholders, global overrides, escaping)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b84ef8188333a9ecd3cf644150eb