### PR TITLE
Guard last guess cache deletion

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -569,6 +569,7 @@ function bhg_handle_submit_guess() {
 	// db call ok; caching added.
 	$count_cache_key = 'bhg_guess_count_' . $hunt_id . '_' . $user_id;
 	$count           = wp_cache_get( $count_cache_key );
+	$last_guess_key  = '';
 	if ( false === $count ) {
                 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
                                 $count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$g_tbl} WHERE hunt_id = %d AND user_id = %d", $hunt_id, $user_id ) );
@@ -598,7 +599,9 @@ function bhg_handle_submit_guess() {
 									array( '%d' )
 								);
 				wp_cache_delete( $count_cache_key );
+				if ( $last_guess_key ) {
 				wp_cache_delete( $last_guess_key );
+				}
 				if ( wp_doing_ajax() ) {
 					wp_send_json_success();
 				}
@@ -627,7 +630,9 @@ function bhg_handle_submit_guess() {
 			array( '%d', '%d', '%f', '%s' )
 		);
 	wp_cache_delete( $count_cache_key );
+	if ( $last_guess_key ) {
 	wp_cache_delete( $last_guess_key );
+	}
 
 	if ( wp_doing_ajax() ) {
 		wp_send_json_success();


### PR DESCRIPTION
## Summary
- initialize `$last_guess_key` before use when recording guesses
- avoid undefined variable by clearing last guess cache only when key present

## Testing
- `composer phpcs` *(fails: Tabs must be used to indent lines; spaces are not allowed)*
- `php -l bonus-hunt-guesser.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3c463e4948333a388cde7fc512690