### PR TITLE
Record hunt winners and update tournament standings

### DIFF
--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -12,7 +12,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-		exit;
+    exit;
 }
 
 /**
@@ -20,77 +20,129 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class BHG_Models {
 
-	/**
-	 * Close a bonus hunt and determine winners.
-	 *
-	 * @param int   $hunt_id       Hunt identifier.
-	 * @param float $final_balance Final balance for the hunt.
-	 *
-	 * @return int[] Array of winning user IDs.
-	 */
-	public static function close_hunt( $hunt_id, $final_balance ) {
-		global $wpdb;
+    /**
+     * Close a bonus hunt and determine winners.
+     *
+     * @param int   $hunt_id       Hunt identifier.
+     * @param float $final_balance Final balance for the hunt.
+     *
+     * @return int[] Array of winning user IDs.
+     */
+    public static function close_hunt( $hunt_id, $final_balance ) {
+        global $wpdb;
 
-		$hunt_id       = (int) $hunt_id;
-		$final_balance = (float) $final_balance;
+        $hunt_id       = (int) $hunt_id;
+        $final_balance = (float) $final_balance;
 
-		if ( $hunt_id <= 0 ) {
-			return array();
-		}
+        if ( $hunt_id <= 0 ) {
+            return array();
+        }
 
-		$hunts_tbl   = $wpdb->prefix . 'bhg_bonus_hunts';
-		$guesses_tbl = $wpdb->prefix . 'bhg_guesses';
+        $hunts_tbl   = $wpdb->prefix . 'bhg_bonus_hunts';
+        $guesses_tbl = $wpdb->prefix . 'bhg_guesses';
+        $winners_tbl = $wpdb->prefix . 'bhg_hunt_winners';
+        $tres_tbl    = $wpdb->prefix . 'bhg_tournament_results';
 
-				// Determine number of winners for this hunt.
-				// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
-								$winners_count = (int) $wpdb->get_var(
-									$wpdb->prepare(
-										sprintf(
-											'SELECT winners_count FROM %s WHERE id = %%d',
-											esc_sql( $hunts_tbl )
-										),
-										$hunt_id
-									)
-								);
-				// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
-		if ( $winners_count <= 0 ) {
-			$winners_count = 1;
-		}
+        // Determine number of winners and tournament association for this hunt.
+        $hunt_row = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT winners_count, tournament_id FROM {$hunts_tbl} WHERE id=%d",
+                $hunt_id
+            )
+        );
+        $winners_count = $hunt_row ? (int) $hunt_row->winners_count : 0;
+        if ( $winners_count <= 0 ) {
+            $winners_count = 1;
+        }
+        $tournament_id = $hunt_row ? (int) $hunt_row->tournament_id : 0;
 
-		// Update hunt status and final details.
-		$now = current_time( 'mysql' );
-		$wpdb->update(
-			$hunts_tbl,
-			array(
-				'status'        => 'closed',
-				'final_balance' => $final_balance,
-				'closed_at'     => $now,
-				'updated_at'    => $now,
-			),
-			array( 'id' => $hunt_id ),
-			array( '%s', '%f', '%s', '%s' ),
-			array( '%d' )
-		);
+        // Update hunt status and final details.
+        $now = current_time( 'mysql' );
+        $wpdb->update(
+            $hunts_tbl,
+            array(
+                'status'        => 'closed',
+                'final_balance' => $final_balance,
+                'closed_at'     => $now,
+                'updated_at'    => $now,
+            ),
+            array( 'id' => $hunt_id ),
+            array( '%s', '%f', '%s', '%s' ),
+            array( '%d' )
+        );
 
-				// Fetch winners based on proximity to final balance.
-				// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
-								$rows = $wpdb->get_results(
-									$wpdb->prepare(
-										sprintf(
-											'SELECT user_id FROM %s WHERE hunt_id = %%d ORDER BY ABS(guess - %%f) ASC, id ASC LIMIT %%d',
-											esc_sql( $guesses_tbl )
-										),
-										$hunt_id,
-										$final_balance,
-										$winners_count
-									)
-								);
-				// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
+        // Fetch winners based on proximity to final balance.
+        // phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                sprintf(
+                    'SELECT user_id, guess, ABS(guess - %%f) AS diff FROM %s WHERE hunt_id = %%d ORDER BY diff ASC, id ASC LIMIT %%d',
+                    esc_sql( $guesses_tbl )
+                ),
+                $final_balance,
+                $hunt_id,
+                $winners_count
+            )
+        );
+        // phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch
 
-		if ( empty( $rows ) ) {
-			return array();
-		}
+        if ( empty( $rows ) ) {
+            return array();
+        }
 
-		return array_map( 'intval', wp_list_pluck( $rows, 'user_id' ) );
-	}
+        // Record winners and update tournament results.
+        $position = 1;
+        foreach ( (array) $rows as $row ) {
+            $wpdb->insert(
+                $winners_tbl,
+                array(
+                    'hunt_id'    => $hunt_id,
+                    'user_id'    => (int) $row->user_id,
+                    'position'   => $position,
+                    'guess'      => (float) $row->guess,
+                    'diff'       => (float) $row->diff,
+                    'created_at' => $now,
+                ),
+                array( '%d', '%d', '%d', '%f', '%f', '%s' )
+            );
+
+            if ( $tournament_id > 0 ) {
+                $existing = $wpdb->get_row(
+                    $wpdb->prepare(
+                        "SELECT id, wins FROM {$tres_tbl} WHERE tournament_id = %d AND user_id = %d",
+                        $tournament_id,
+                        $row->user_id
+                    )
+                );
+                if ( $existing ) {
+                    $wpdb->update(
+                        $tres_tbl,
+                        array(
+                            'wins'         => (int) $existing->wins + 1,
+                            'last_win_date' => $now,
+                        ),
+                        array( 'id' => (int) $existing->id ),
+                        array( '%d', '%s' ),
+                        array( '%d' )
+                    );
+                } else {
+                    $wpdb->insert(
+                        $tres_tbl,
+                        array(
+                            'tournament_id' => $tournament_id,
+                            'user_id'       => (int) $row->user_id,
+                            'wins'          => 1,
+                            'last_win_date' => $now,
+                        ),
+                        array( '%d', '%d', '%d', '%s' )
+                    );
+                }
+            }
+
+            $position++;
+        }
+
+        return array_map( 'intval', wp_list_pluck( $rows, 'user_id' ) );
+    }
 }
+


### PR DESCRIPTION
## Summary
- capture winning guesses in `bhg_hunt_winners`
- track tournament wins and last win date in `bhg_tournament_results`

## Testing
- `php -l includes/class-bhg-models.php`
- `composer phpcs` *(fails: Multi-line function call not indented correctly; Tabs must be used to indent lines; Use placeholders and $wpdb->prepare(); found interpolated variable {$table}...)*

------
https://chatgpt.com/codex/tasks/task_e_68c3cfbc39408333814105bc03adceae