### PR TITLE
Add closure flag to hunt redirect

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -393,13 +393,18 @@ class BHG_Admin {
 
 			$final_balance = (float) $final_balance_raw;
 
-		if ( $hunt_id ) {
-				BHG_Models::close_hunt( $hunt_id, $final_balance );
-		}
+                if ( $hunt_id ) {
+                                BHG_Models::close_hunt( $hunt_id, $final_balance );
+                }
 
-				wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
-		exit;
-	}
+                                $redirect_url = add_query_arg(
+                                        'closed',
+                                        1,
+                                        BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' )
+                                );
+                                wp_safe_redirect( $redirect_url );
+                exit;
+        }
 
 	/**
 	 * Delete a bonus hunt and its guesses.


### PR DESCRIPTION
## Summary
- Redirect to bonus hunts admin page with `closed=1` after closing a hunt so success notice is displayed

## Testing
- `composer phpcs` *(fails: existing coding standard issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d27719488333b0f10ead693bc34b