### PR TITLE
Handle database update failures when closing hunts

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -395,13 +395,23 @@ class BHG_Admin {
 			$final_balance = (float) $final_balance_raw;
 
                 if ( $hunt_id ) {
-                                BHG_Models::close_hunt( $hunt_id, $final_balance );
+                                $result = BHG_Models::close_hunt( $hunt_id, $final_balance );
+                                if ( false === $result ) {
+                                                wp_safe_redirect(
+                                                                add_query_arg(
+                                                                                'bhg_msg',
+                                                                                'close_failed',
+                                                                                BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' )
+                                                                )
+                                                );
+                                                exit;
+                                }
                 }
 
                                 $redirect_url = add_query_arg(
-                                        'closed',
-                                        1,
-                                        BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' )
+                                                'closed',
+                                                1,
+                                                BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' )
                                 );
                                 wp_safe_redirect( $redirect_url );
                 exit;

--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -26,7 +26,7 @@ class BHG_Models {
      * @param int   $hunt_id       Hunt identifier.
      * @param float $final_balance Final balance for the hunt.
      *
-     * @return int[] Array of winning user IDs.
+     * @return int[]|false Array of winning user IDs or false on failure.
      */
     public static function close_hunt( $hunt_id, $final_balance ) {
         global $wpdb;
@@ -58,7 +58,7 @@ class BHG_Models {
 
         // Update hunt status and final details.
         $now = current_time( 'mysql' );
-        $wpdb->update(
+        $updated = $wpdb->update(
             $hunts_tbl,
             array(
                 'status'        => 'closed',
@@ -70,6 +70,11 @@ class BHG_Models {
             array( '%s', '%f', '%s', '%s' ),
             array( '%d' )
         );
+
+        if ( false === $updated ) {
+            bhg_log( $wpdb->last_error );
+            return false;
+        }
 
         // Fetch winners based on proximity to final balance.
         // phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsMismatch


### PR DESCRIPTION
## Summary
- capture and check `$wpdb->update()` result when closing a hunt
- handle failed hunt closure in admin and redirect with error notice

## Testing
- `vendor/bin/phpcs admin/class-bhg-admin.php includes/class-bhg-models.php` *(fails: Tabs must be used to indent lines; spaces are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d6f18dc083339dc4d5d2b46a16ac