### PR TITLE
Initialize last_guess_key earlier and guard cache deletions

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -567,9 +567,9 @@ function bhg_handle_submit_guess() {
 		// Insert or update last guess per settings.
 
 	// db call ok; caching added.
+	$last_guess_key  = '';
 	$count_cache_key = 'bhg_guess_count_' . $hunt_id . '_' . $user_id;
 	$count           = wp_cache_get( $count_cache_key );
-	$last_guess_key  = '';
 	if ( false === $count ) {
                 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
                                 $count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$g_tbl} WHERE hunt_id = %d AND user_id = %d", $hunt_id, $user_id ) );


### PR DESCRIPTION
## Summary
- Initialize `$last_guess_key` before cache queries.
- Add conditional checks before deleting cached last guesses.

## Testing
- `composer phpcs` *(fails: Tabs must be used to indent lines; spaces are not allowed, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d82ee4a483339a62afb4e685584d