### PR TITLE
Sanitize ordering parameters

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -68,21 +68,15 @@ if ( 'list' === $view ) :
 	$order_by_clause   = sprintf( '%s %s', $order_by_column, $order_direction );
 	$search_like       = '%' . $wpdb->esc_like( $search_term ) . '%';
 
-	$sql = sprintf(
-		'SELECT h.*, a.name AS affiliate_name FROM %s h LEFT JOIN %s a ON a.id = h.affiliate_site_id WHERE h.title LIKE %%s ORDER BY %s LIMIT %%d OFFSET %%d',
-		$hunts_table,
-		$aff_table,
-		$order_by_clause
-	);
-	$hunts_query = $wpdb->prepare(
-		$sql,
-		$search_like,
-		$per_page,
-		$offset
-	);
+$hunts_query = $wpdb->prepare(
+"SELECT h.*, a.name AS affiliate_name FROM {$hunts_table} h LEFT JOIN {$aff_table} a ON a.id = h.affiliate_site_id WHERE h.title LIKE %s ORDER BY {$order_by_clause} LIMIT %d OFFSET %d",
+$search_like,
+$per_page,
+$offset
+);
 
-								// db call ok; no-cache ok.
-								$hunts = $wpdb->get_results( $hunts_query );
+// db call ok; no-cache ok.
+$hunts = $wpdb->get_results( $hunts_query );
 
 		$count_query = $wpdb->prepare(
 			"SELECT COUNT(*) FROM {$hunts_table} h WHERE h.title LIKE %s",


### PR DESCRIPTION
## Summary
- validate and map `orderby` and `order` query args against whitelists
- construct ORDER BY fragment and integrate into prepared hunt query

## Testing
- `composer phpcs` *(fails: numerous pre-existing coding standard issues in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c3df6799b883339c1b46e603f49f41