### PR TITLE
Ensure guesses table tracks update times

### DIFF
--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -197,15 +197,10 @@ KEY tournament_id (tournament_id)
 							$wpdb->query( "ALTER TABLE `{$hunts_table}` ADD KEY tournament_id (tournament_id)" );
 			}
 
-						// Guesses columns.
-			$gneed = array(
-				'updated_at' => 'ADD COLUMN updated_at DATETIME NULL',
-			);
-			foreach ( $gneed as $c => $alter ) {
-				if ( ! $this->column_exists( $guesses_table, $c ) ) {
-               // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
-								$wpdb->query( "ALTER TABLE `{$guesses_table}` {$alter}" );
-				}
+			// Guesses columns.
+			if ( ! $this->column_exists( $guesses_table, 'updated_at' ) ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+				$wpdb->query( "ALTER TABLE `{$guesses_table}` ADD COLUMN updated_at DATETIME NULL" );
 			}
 
 												// Tournaments: make sure common columns exist.

--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -31,6 +31,10 @@ class BHG_Models {
     public static function close_hunt( $hunt_id, $final_balance ) {
         global $wpdb;
 
+        if ( class_exists( 'BHG_DB' ) ) {
+            BHG_DB::migrate();
+        }
+
         $hunt_id       = (int) $hunt_id;
         $final_balance = (float) $final_balance;
 


### PR DESCRIPTION
## Summary
- add `updated_at` column to guesses table and idempotent migration
- run database migrations before closing hunts to guarantee column availability

## Testing
- `vendor/bin/phpcs includes/class-bhg-db.php includes/class-bhg-models.php`
- `php -r 'define("ABSPATH", "."); require "includes/class-bhg-db.php"; BHG_DB::migrate();'` *(fails: Failed opening required '.wp-admin/includes/upgrade.php')*

------
https://chatgpt.com/codex/tasks/task_e_68c3e1d1e0108333a3ae29c4486f98b3