### PR TITLE
Clear last guess cache key after insert

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -641,6 +641,7 @@ function bhg_handle_submit_guess() {
 			array( '%d', '%d', '%f', '%s' )
 		);
 	wp_cache_delete( $count_cache_key );
+	$last_guess_key = 'bhg_last_guess_' . $hunt_id . '_' . $user_id;
 	if ( $last_guess_key ) {
 		wp_cache_delete( $last_guess_key );
 	}


### PR DESCRIPTION
## Summary
- prevent empty cache deletes for last guess key
- ensure last guess cache is refreshed when a new guess is inserted

## Testing
- `composer install`
- `composer phpcs` *(fails: Use placeholders and $wpdb->prepare(); found interpolated variable {$hunts} at "SELECT id, status, guessing_enabled FROM {$hunts} WHERE id = %d"...)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e31651448333b0ddf71d9af9f0ab