### PR TITLE
Ensure table names used as raw strings in migrations

### DIFF
--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -48,16 +48,17 @@ class BHG_DB {
 		global $wpdb;
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-		$charset_collate = $wpdb->get_charset_collate();
+                $charset_collate = $wpdb->get_charset_collate();
 
-		$hunts_table        = $wpdb->prefix . 'bhg_bonus_hunts'; // Raw table names without backticks.
-		$guesses_table      = $wpdb->prefix . 'bhg_guesses';
-		$tours_table        = $wpdb->prefix . 'bhg_tournaments';
-		$tres_table         = $wpdb->prefix . 'bhg_tournament_results';
-		$ads_table          = $wpdb->prefix . 'bhg_ads';
-		$trans_table        = $wpdb->prefix . 'bhg_translations';
-		$aff_websites_table = $wpdb->prefix . 'bhg_affiliate_websites';
-		$winners_table      = $wpdb->prefix . 'bhg_hunt_winners';
+                // Raw table names without backticks.
+                $hunts_table        = $wpdb->prefix . 'bhg_bonus_hunts';
+                $guesses_table      = $wpdb->prefix . 'bhg_guesses';
+                $tours_table        = $wpdb->prefix . 'bhg_tournaments';
+                $tres_table         = $wpdb->prefix . 'bhg_tournament_results';
+                $ads_table          = $wpdb->prefix . 'bhg_ads';
+                $trans_table        = $wpdb->prefix . 'bhg_translations';
+                $aff_websites_table = $wpdb->prefix . 'bhg_affiliate_websites';
+                $winners_table      = $wpdb->prefix . 'bhg_hunt_winners';
 
 		$sql = array();
 

--- a/includes/upgrade/add-winners-limit.php
+++ b/includes/upgrade/add-winners-limit.php
@@ -22,7 +22,7 @@ function bhg_upgrade_add_winners_limit_column() {
 	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
 	// Ensure table exists and has winners_count column.
-	$sql = "CREATE TABLE {$hunts} (
+        $sql = "CREATE TABLE `{$hunts}` (
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 			title VARCHAR(190) NOT NULL,
 			starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,


### PR DESCRIPTION
## Summary
- Clarify that database table variables are defined as raw strings before being wrapped with backticks when composing SQL
- Quote table name with backticks in the winners-limit upgrade script to avoid duplicate quoting

## Testing
- `composer phpcs` *(fails: Use placeholders and $wpdb->prepare(); etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e61664bc8333b0e3186ecce1857d