### PR TITLE
Ensure DB update errors are logged

### DIFF
--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -124,7 +124,7 @@ class BHG_Models {
                     )
                 );
                 if ( $existing ) {
-                    $wpdb->update(
+                    $updated = $wpdb->update(
                         $tres_tbl,
                         array(
                             'wins'         => (int) $existing->wins + 1,
@@ -134,6 +134,11 @@ class BHG_Models {
                         array( '%d', '%s' ),
                         array( '%d' )
                     );
+
+                    if ( false === $updated ) {
+                        bhg_log( $wpdb->last_error );
+                        return false;
+                    }
                 } else {
                     $wpdb->insert(
                         $tres_tbl,


### PR DESCRIPTION
## Summary
- Log and bail when tournament results table update fails

## Testing
- `composer phpcs` *(fails: Use placeholders and $wpdb->prepare(); found interpolated variable {$table_name} at "DROP TABLE IF EXISTS {$table_name}" in uninstall.php)*


------
https://chatgpt.com/codex/tasks/task_e_68c3ea15b3788333afd9cf6ca9ef40f6