### PR TITLE
Initialize last guess cache key and document guesses table

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -498,6 +498,7 @@ function bhg_handle_settings_save() {
  * @return void
  */
 function bhg_handle_submit_guess() {
+	$last_guess_key = '';
 	if ( wp_doing_ajax() ) {
 			check_ajax_referer( 'bhg_public_nonce', 'nonce' );
 	} else {
@@ -577,10 +578,9 @@ function bhg_handle_submit_guess() {
 
 		// Insert or update last guess per settings.
 
-	// db call ok; caching added.
-        $last_guess_key = '';
-        $count_cache_key = 'bhg_guess_count_' . $hunt_id . '_' . $user_id;
-        $count = wp_cache_get( $count_cache_key );
+		// db call ok; caching added.
+		$count_cache_key = 'bhg_guess_count_' . $hunt_id . '_' . $user_id;
+		$count           = wp_cache_get( $count_cache_key );
 	if ( false === $count ) {
                 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 								$count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$g_tbl} WHERE hunt_id = %d AND user_id = %d", $hunt_id, $user_id ) );
@@ -609,9 +609,9 @@ function bhg_handle_submit_guess() {
 									array( '%f', '%s' ),
 									array( '%d' )
 								);
-				wp_cache_delete( $count_cache_key );
-				if ( $last_guess_key ) {
-					wp_cache_delete( $last_guess_key );
+								wp_cache_delete( $count_cache_key );
+				if ( ! empty( $last_guess_key ) ) {
+						wp_cache_delete( $last_guess_key );
 				}
 				if ( wp_doing_ajax() ) {
 					wp_send_json_success();
@@ -641,9 +641,9 @@ function bhg_handle_submit_guess() {
 			array( '%d', '%d', '%f', '%s' )
 		);
 	wp_cache_delete( $count_cache_key );
-	$last_guess_key = 'bhg_last_guess_' . $hunt_id . '_' . $user_id;
-	if ( $last_guess_key ) {
-		wp_cache_delete( $last_guess_key );
+		$last_guess_key = 'bhg_last_guess_' . $hunt_id . '_' . $user_id;
+	if ( ! empty( $last_guess_key ) ) {
+			wp_cache_delete( $last_guess_key );
 	}
 
 	if ( wp_doing_ajax() ) {

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -83,8 +83,8 @@ KEY status (status),
 KEY tournament_id (tournament_id)
 ) {$charset_collate};";
 
-				// Guesses.
-								$sql[] = "CREATE TABLE `{$guesses_table}` (
+		// Guesses table includes updated_at for tracking edits.
+		$sql[] = "CREATE TABLE `{$guesses_table}` (
                         id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
                         hunt_id BIGINT UNSIGNED NOT NULL,
                         user_id BIGINT UNSIGNED NOT NULL,
@@ -200,6 +200,7 @@ KEY tournament_id (tournament_id)
 
 			// Guesses columns.
 			$gneed = array(
+				// Ensure timestamp for guess updates.
 				'updated_at' => 'ADD COLUMN updated_at DATETIME NULL',
 			);
 			foreach ( $gneed as $c => $alter ) {


### PR DESCRIPTION
## Summary
- initialize `$last_guess_key` before any conditionals and delete cached guesses only when the key is set
- document `updated_at` column in guess table creation and migration routines

## Testing
- `vendor/bin/phpcs bonus-hunt-guesser.php` *(fails: Use placeholders and $wpdb->prepare warnings)*
- `vendor/bin/phpcs includes/class-bhg-db.php`
- `composer phpcs` *(fails: existing coding standard violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ecbfc73083339cd094e42a3446ac