### PR TITLE
Accept localized final balance formats in hunt closure

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -383,16 +383,17 @@ class BHG_Admin {
 		}
 			check_admin_referer( 'bhg_close_hunt', 'bhg_close_hunt_nonce' );
 
-			$hunt_id           = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
-			$final_balance_raw = isset( $_POST['final_balance'] ) ? sanitize_text_field( wp_unslash( $_POST['final_balance'] ) ) : '';
-			$final_balance_raw = str_replace( ',', '', $final_balance_raw );
+                       $hunt_id           = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
+                       $final_balance_raw = isset( $_POST['final_balance'] ) ? sanitize_text_field( wp_unslash( $_POST['final_balance'] ) ) : '';
 
-		if ( '' === $final_balance_raw || ! is_numeric( $final_balance_raw ) || (float) $final_balance_raw < 0 ) {
-								wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
-				exit;
-		}
-
-			$final_balance = (float) $final_balance_raw;
+               $final_balance = null;
+               if ( function_exists( 'bhg_parse_amount' ) ) {
+                       $final_balance = bhg_parse_amount( $final_balance_raw );
+               }
+               if ( null === $final_balance || $final_balance < 0 ) {
+                                                               wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
+                               exit;
+               }
 
                 if ( $hunt_id ) {
                                 $result = BHG_Models::close_hunt( $hunt_id, $final_balance );
@@ -809,10 +810,9 @@ class BHG_Admin {
                         't_deleted'             => bhg_t( 'tournament_deleted', 'Tournament deleted.' ),
                        't_closed'              => bhg_t( 'tournament_closed', 'Tournament closed.' ),
                         'nonce'                 => bhg_t( 'security_check_failed_please_retry', 'Security check failed. Please retry.' ),
-                        'noaccess'              => bhg_t( 'you_do_not_have_permission_to_do_that', 'You do not have permission to do that.' ),
-                        'invalid_final_balance' => bhg_t( 'invalid_final_balance_please_enter_a_nonnegative_number', 'Invalid final balance. Please enter a non-negative number.' ),
-                        'tools_success'         => bhg_t( 'tools_action_completed', 'Tools action completed.' ),
-                );
+                       'noaccess'              => bhg_t( 'you_do_not_have_permission_to_do_that', 'You do not have permission to do that.' ),
+                       'tools_success'         => bhg_t( 'tools_action_completed', 'Tools action completed.' ),
+               );
 		$class = ( strpos( $msg, 'error' ) !== false || 'nonce' === $msg || 'noaccess' === $msg ) ? 'notice notice-error' : 'notice notice-success';
 		$text  = isset( $map[ $msg ] ) ? $map[ $msg ] : esc_html( $msg );
 		echo '<div class="' . esc_attr( $class ) . '"><p>' . esc_html( $text ) . '</p></div>';

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -93,7 +93,7 @@ $hunts = $wpdb->get_results( $hunts_query );
 
 <form method="get" class="search-form">
 <input type="hidden" name="page" value="bhg-bonus-hunts" />
-	<?php wp_nonce_field( 'bhg_hunts_search', 'bhg_hunts_search_nonce' ); ?>
+        <?php wp_nonce_field( 'bhg_hunts_search', 'bhg_hunts_search_nonce' ); ?>
 <p class="search-box">
 <input type="search" name="s" value="<?php echo esc_attr( $search_term ); ?>" />
 <?php if ( $orderby_param ) : ?>
@@ -106,9 +106,13 @@ $hunts = $wpdb->get_results( $hunts_query );
 </p>
 </form>
 
-	<?php if ( isset( $_GET['closed'] ) && '1' === sanitize_text_field( wp_unslash( $_GET['closed'] ) ) ) : ?>
-	<div class="notice notice-success is-dismissible"><p><?php echo esc_html( bhg_t( 'hunt_closed_successfully', 'Hunt closed successfully.' ) ); ?></p></div>
-	<?php endif; ?>
+       <?php if ( isset( $_GET['bhg_msg'] ) && 'invalid_final_balance' === sanitize_text_field( wp_unslash( $_GET['bhg_msg'] ) ) ) : ?>
+       <div class="notice notice-error is-dismissible"><p><?php echo esc_html( bhg_t( 'invalid_final_balance_please_enter_a_nonnegative_number', 'Invalid final balance. Please enter a non-negative number.' ) ); ?></p></div>
+       <?php endif; ?>
+
+        <?php if ( isset( $_GET['closed'] ) && '1' === sanitize_text_field( wp_unslash( $_GET['closed'] ) ) ) : ?>
+        <div class="notice notice-success is-dismissible"><p><?php echo esc_html( bhg_t( 'hunt_closed_successfully', 'Hunt closed successfully.' ) ); ?></p></div>
+        <?php endif; ?>
 
 <table class="widefat striped bhg-margin-top-small">
 <thead>


### PR DESCRIPTION
## Summary
- Use `bhg_parse_amount()` for final balance parsing in `handle_close_hunt`
- Display invalid balance notice in Bonus Hunts admin view

## Testing
- `composer phpcs` *(fails: existing coding standard violations)*


------
https://chatgpt.com/codex/tasks/task_e_68c3fb50b790833396b534436557c918