### PR TITLE
Use dedicated cache group for translations

### DIFF
--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -75,10 +75,10 @@ if ( isset( $_POST['bhg_save_translation'] ) && check_admin_referer( 'bhg_save_t
 					);
 		}
 
-			// Invalidate cached value so updates appear immediately.
-			wp_cache_delete( 'bhg_t_' . $slug . '_' . $locale );
-			$notice = bhg_t( 'translation_saved', 'Translation saved.' );
-	}
+                        // Invalidate cached value so updates appear immediately.
+                        wp_cache_delete( 'bhg_t_' . $slug . '_' . $locale, 'bhg_translations' );
+                        $notice = bhg_t( 'translation_saved', 'Translation saved.' );
+        }
 }
 
 // Fetch rows with pagination and optional search.

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -98,10 +98,10 @@ if ( ! function_exists( 'bhg_t' ) ) {
 	function bhg_t( $slug, $default_text = '', $locale = '' ) {
 			global $wpdb;
 
-			$slug      = (string) $slug;
-			$locale    = $locale ? (string) $locale : get_locale();
-			$cache_key = 'bhg_t_' . $slug . '_' . $locale;
-			$cached    = wp_cache_get( $cache_key );
+                        $slug      = (string) $slug;
+                        $locale    = $locale ? (string) $locale : get_locale();
+                        $cache_key = 'bhg_t_' . $slug . '_' . $locale;
+                        $cached    = wp_cache_get( $cache_key, 'bhg_translations' );
 
 		if ( false !== $cached ) {
 				return (string) $cached;
@@ -116,14 +116,14 @@ if ( ! function_exists( 'bhg_t' ) ) {
 						$row   = $wpdb->get_row( $sql );
 
 		if ( $row ) {
-			$value = '' !== $row->text ? (string) $row->text : (string) $row->default_text;
-			wp_cache_set( $cache_key, $value );
-			return $value;
-		}
+                        $value = '' !== $row->text ? (string) $row->text : (string) $row->default_text;
+                        wp_cache_set( $cache_key, $value, 'bhg_translations' );
+                        return $value;
+                }
 
-			wp_cache_set( $cache_key, (string) $default_text );
-			return (string) $default_text;
-	}
+                        wp_cache_set( $cache_key, (string) $default_text, 'bhg_translations' );
+                        return (string) $default_text;
+        }
 }
 
 if ( ! function_exists( 'bhg_get_default_translations' ) ) {


### PR DESCRIPTION
## Summary
- Add custom `bhg_translations` cache group to `bhg_t()` so translations are stored and retrieved consistently
- Clear translation cache entries using the same group when saving updates in the admin

## Testing
- `composer install`
- `composer phpcs includes/helpers.php admin/views/translations.php` *(fails: numerous existing coding-standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c3fc0daba883338991f2ead0ebf0e3