### PR TITLE
Allow comma-separated final balances in admin

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -390,9 +390,9 @@ class BHG_Admin {
                if ( function_exists( 'bhg_parse_amount' ) ) {
                        $final_balance = bhg_parse_amount( $final_balance_raw );
                }
-               if ( null === $final_balance || $final_balance < 0 ) {
-                                                               wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
-                               exit;
+               if ( null === $final_balance || ! is_numeric( $final_balance ) || $final_balance < 0 ) {
+                       wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
+                       exit;
                }
 
                 if ( $hunt_id ) {

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -324,7 +324,7 @@ if ( 'close' === $view ) :
 		<tbody>
 		<tr>
 			<th scope="row"><label for="bhg_final_balance"><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></label></th>
-			<td><input type="number" step="0.01" min="0" id="bhg_final_balance" name="final_balance" required></td>
+                        <td><input type="text" id="bhg_final_balance" name="final_balance" required></td>
 		</tr>
 		</tbody>
 	</table>
@@ -437,8 +437,8 @@ if ( 'add' === $view ) :
 			</td>
 		</tr>
 		<tr>
-			<th scope="row"><label for="bhg_final"><?php echo esc_html( bhg_t( 'final_balance_optional', 'Final Balance (optional)' ) ); ?></label></th>
-			<td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value=""></td>
+                        <th scope="row"><label for="bhg_final"><?php echo esc_html( bhg_t( 'final_balance_optional', 'Final Balance (optional)' ) ); ?></label></th>
+                        <td><input type="text" id="bhg_final" name="final_balance" value=""></td>
 		</tr>
 		</tbody>
 	</table>
@@ -566,7 +566,7 @@ if ( 'edit' === $view ) :
 </tr>
 <tr>
 <th scope="row"><label for="bhg_final"><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></label></th>
-<td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html( bhg_t( 'label_emdash', '—' ) ) ); ?>"></td>
+<td><input type="text" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html( bhg_t( 'label_emdash', '—' ) ) ); ?>"></td>
 </tr>
 		<tr>
 			<th scope="row"><label for="bhg_status"><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) ); ?></label></th>


### PR DESCRIPTION
## Summary
- Allow commas in final balance fields by switching inputs to text
- Validate parsed final balance and redirect with `invalid_final_balance` notice on failure
- Show admin notice when closing a hunt with an invalid final balance

## Testing
- `php -l admin/class-bhg-admin.php`
- `php -l admin/views/bonus-hunts.php`
- `vendor/bin/phpcs --standard=WordPress admin/views/bonus-hunts.php admin/class-bhg-admin.php` *(fails: numerous existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ff3206e08333b95de7df9a940768