### PR TITLE
Clean up tournament data when deleting hunts

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -432,23 +432,13 @@ $hunts_table    = esc_sql( $wpdb->prefix . 'bhg_bonus_hunts' );
 $guesses_table  = esc_sql( $wpdb->prefix . 'bhg_guesses' );
 $winners_table  = esc_sql( $wpdb->prefix . 'bhg_hunt_winners' );
 $results_table  = esc_sql( $wpdb->prefix . 'bhg_tournament_results' );
-			$hunt_id        = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
+                        $hunt_id        = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
 
 if ( $hunt_id ) {
-$tournament_id = (int) $wpdb->get_var(
-$wpdb->prepare(
-"SELECT tournament_id FROM {$hunts_table} WHERE id = %d",
-			$hunt_id
-)
-);
-
 $wpdb->delete( $hunts_table, array( 'id' => $hunt_id ), array( '%d' ) );
 $wpdb->delete( $guesses_table, array( 'hunt_id' => $hunt_id ), array( '%d' ) );
 $wpdb->delete( $winners_table, array( 'hunt_id' => $hunt_id ), array( '%d' ) );
-
-if ( $tournament_id ) {
-$wpdb->delete( $results_table, array( 'tournament_id' => $tournament_id ), array( '%d' ) );
-}
+$wpdb->delete( $results_table, array( 'hunt_id' => $hunt_id ), array( '%d' ) );
 }
 
 wp_safe_redirect( BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts&bhg_msg=hunt_deleted' ) );


### PR DESCRIPTION
## Summary
- Ensure `handle_delete_hunt` removes related records from `bhg_hunt_winners` and `bhg_tournament_results`

## Testing
- `composer phpcs` *(fails: PHPCBF CAN FIX THE 356 MARKED SNIFF VIOLATIONS AUTOMATICALLY)*
- `php -l admin/class-bhg-admin.php`

------
https://chatgpt.com/codex/tasks/task_e_68c4116c28708333bdb214e2992a594d