### PR TITLE
Use dedicated cache group for translations and flush on updates

### DIFF
--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -75,8 +75,8 @@ if ( isset( $_POST['bhg_save_translation'] ) && check_admin_referer( 'bhg_save_t
 					);
 		}
 
-                        // Invalidate cached value so updates appear immediately.
-                        wp_cache_delete( 'bhg_t_' . $slug . '_' . $locale, 'bhg_translations' );
+                        // Invalidate cached values so updates appear immediately.
+                        bhg_clear_translation_cache();
                         $notice = bhg_t( 'translation_saved', 'Translation saved.' );
         }
 }

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -126,6 +126,7 @@ define( 'BHG_PLUGIN_FILE', __FILE__ );
 define( 'BHG_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BHG_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'BHG_TABLE_PREFIX', 'bhg_' );
+define( 'BHG_TRANSLATION_CACHE_GROUP', 'bhg_translations' );
 
 // Table creation function.
 /**


### PR DESCRIPTION
## Summary
- centralize translation cache group via `BHG_TRANSLATION_CACHE_GROUP`
- ensure `bhg_t()` stores and fetches translations in that cache group
- add helper to flush translation cache and call it after translation updates and seeding

## Testing
- `composer install --no-progress`
- `./vendor/bin/phpcs -n --report=summary admin/views/translations.php bonus-hunt-guesser.php includes/helpers.php` *(fails: 248 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c412b8c4d48333a1d49a8e3f98ca76