### PR TITLE
Handle invalid final balance on hunt close

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -383,17 +383,22 @@ class BHG_Admin {
 		}
 			check_admin_referer( 'bhg_close_hunt', 'bhg_close_hunt_nonce' );
 
-			$hunt_id           = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
-			$final_balance_raw = isset( $_POST['final_balance'] ) ? wp_unslash( $_POST['final_balance'] ) : '';
+		$hunt_id           = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
+		$final_balance_raw = isset( $_POST['final_balance'] ) ? wp_unslash( $_POST['final_balance'] ) : '';
 
-               $final_balance = null;
-               if ( function_exists( 'bhg_parse_amount' ) ) {
-                       $final_balance = bhg_parse_amount( $final_balance_raw );
-               }
-               if ( null === $final_balance || ! is_numeric( $final_balance ) || $final_balance < 0 ) {
-                       wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
-                       exit;
-               }
+		$final_balance = function_exists( 'bhg_parse_amount' ) ? bhg_parse_amount( $final_balance_raw ) : null;
+
+		if ( null === $final_balance ) {
+			wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
+			exit;
+		}
+
+		$final_balance = (float) $final_balance;
+
+		if ( $final_balance < 0 ) {
+			wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
+			exit;
+		}
 
                 if ( $hunt_id ) {
                                 $result = BHG_Models::close_hunt( $hunt_id, $final_balance );

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -106,9 +106,11 @@ $hunts = $wpdb->get_results( $hunts_query );
 </p>
 </form>
 
-       <?php if ( isset( $_GET['bhg_msg'] ) && 'invalid_final_balance' === sanitize_text_field( wp_unslash( $_GET['bhg_msg'] ) ) ) : ?>
-       <div class="notice notice-error is-dismissible"><p><?php echo esc_html( bhg_t( 'invalid_final_balance_please_enter_a_nonnegative_number', 'Invalid final balance. Please enter a non-negative number.' ) ); ?></p></div>
-       <?php endif; ?>
+<?php if ( isset( $_GET['bhg_msg'] ) && 'invalid_final_balance' === sanitize_key( wp_unslash( $_GET['bhg_msg'] ) ) ) : ?>
+       <div class="notice notice-error is-dismissible">
+               <p><?php echo esc_html( bhg_t( 'invalid_final_balance_please_enter_a_nonnegative_number', 'Invalid final balance. Please enter a non-negative number.' ) ); ?></p>
+       </div>
+<?php endif; ?>
 
        <?php if ( isset( $_GET['closed'] ) && '1' === sanitize_text_field( wp_unslash( $_GET['closed'] ) ) ) : ?>
        <div class="notice notice-success is-dismissible"><p><?php echo esc_html( bhg_t( 'hunt_closed_successfully', 'Hunt closed successfully.' ) ); ?></p></div>
@@ -328,7 +330,7 @@ if ( 'close' === $view ) :
 		<tbody>
 		<tr>
 			<th scope="row"><label for="bhg_final_balance"><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></label></th>
-                        <td><input type="text" id="bhg_final_balance" name="final_balance" required></td>
+                       <td><input type="text" id="bhg_final_balance" name="final_balance" value="" required></td>
 		</tr>
 		</tbody>
 	</table>


### PR DESCRIPTION
## Summary
- Treat close-hunt final balance as text input
- Show admin error when final balance fails to parse
- Redirect back with `invalid_final_balance` flag if final balance invalid

## Testing
- `composer phpcs` *(fails: missing phpcs binary earlier; installed; but repository has coding standard errors in unrelated files)*
- `vendor/bin/phpcs admin/class-bhg-admin.php admin/views/bonus-hunts.php` *(fails: existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c4330521148333bd520ebe09b90030