### PR TITLE
Ensure invalid final balance notice and redirect

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -383,36 +383,32 @@ class BHG_Admin {
 		}
 			check_admin_referer( 'bhg_close_hunt', 'bhg_close_hunt_nonce' );
 
-		$hunt_id           = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
-		$final_balance_raw = isset( $_POST['final_balance'] ) ? wp_unslash( $_POST['final_balance'] ) : '';
+               $hunt_id           = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
+               $final_balance_raw = isset( $_POST['final_balance'] ) ? wp_unslash( $_POST['final_balance'] ) : '';
 
-		$final_balance = function_exists( 'bhg_parse_amount' ) ? bhg_parse_amount( $final_balance_raw ) : null;
+               $final_balance = function_exists( 'bhg_parse_amount' ) ? bhg_parse_amount( $final_balance_raw ) : null;
+               $redirect_url  = BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' );
 
-		if ( null === $final_balance ) {
-			wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
-			exit;
-		}
+               if ( null === $final_balance || (float) $final_balance < 0 ) {
+                       wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', $redirect_url ) );
+                       exit;
+               }
 
-		$final_balance = (float) $final_balance;
+               $final_balance = (float) $final_balance;
 
-		if ( $final_balance < 0 ) {
-			wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
-			exit;
-		}
-
-		if ( $hunt_id ) {
-						$result = BHG_Models::close_hunt( $hunt_id, $final_balance );
-			if ( false === $result ) {
-						wp_safe_redirect(
-							add_query_arg(
-								'bhg_msg',
-								'close_failed',
-								BHG_Utils::admin_url( 'admin.php?page=bhg-bonus-hunts' )
-							)
-						);
-						exit;
-			}
-		}
+               if ( $hunt_id ) {
+                                               $result = BHG_Models::close_hunt( $hunt_id, $final_balance );
+                       if ( false === $result ) {
+                                               wp_safe_redirect(
+                                                       add_query_arg(
+                                                               'bhg_msg',
+                                                               'close_failed',
+                                                               $redirect_url
+                                                       )
+                                               );
+                                               exit;
+                       }
+               }
 
 								$redirect_url = add_query_arg(
 									'closed',

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -107,9 +107,9 @@ $hunts = $wpdb->get_results( $hunts_query );
 </form>
 
 <?php if ( isset( $_GET['bhg_msg'] ) && 'invalid_final_balance' === sanitize_key( wp_unslash( $_GET['bhg_msg'] ) ) ) : ?>
-       <div class="notice notice-error is-dismissible">
-               <p><?php echo esc_html( bhg_t( 'invalid_final_balance_please_enter_a_nonnegative_number', 'Invalid final balance. Please enter a non-negative number.' ) ); ?></p>
-       </div>
+<div class="notice notice-error notice-large is-dismissible">
+<p><strong><?php echo esc_html( bhg_t( 'hunt_not_closed_invalid_final_balance', 'Hunt not closed. Please enter a non-negative final balance.' ) ); ?></strong></p>
+</div>
 <?php endif; ?>
 
        <?php if ( isset( $_GET['closed'] ) && '1' === sanitize_text_field( wp_unslash( $_GET['closed'] ) ) ) : ?>


### PR DESCRIPTION
## Summary
- Redirect back to Bonus Hunts with `bhg_msg=invalid_final_balance` when final balance is missing or negative
- Add a prominent admin notice explaining the hunt was not closed due to an invalid final balance

## Testing
- `composer install`
- `composer run phpcs` *(fails: existing coding standards violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c43a24d89c8333b0a41187d29c95cb