### PR TITLE
Allow closing bonus hunts via close view

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -31,8 +31,8 @@ if (
 
 
 $view = isset( $_GET['view'] ) ? sanitize_key( wp_unslash( $_GET['view'] ) ) : 'list';
-if ( ! in_array( $view, array( 'list', 'add', 'edit' ), true ) ) {
-	$view = 'list';
+if ( ! in_array( $view, array( 'list', 'add', 'edit', 'close' ), true ) ) {
+        $view = 'list';
 }
 
 /** LIST VIEW */


### PR DESCRIPTION
## Summary
- permit `view=close` when rendering bonus hunt admin view

## Testing
- `php -l admin/views/bonus-hunts.php`
- `php /tmp/test-close-form.php` *(manual stub to verify close form)*
- `composer phpcs -- admin/views/bonus-hunts.php` *(fails: 129 errors, 46 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c4433b51a08333ae5edd87557c2ab1