### PR TITLE
Capture Nextend social profile on registration

### DIFF
--- a/includes/class-bhg-login-redirect.php
+++ b/includes/class-bhg-login-redirect.php
@@ -13,19 +13,21 @@ if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
 	/**
 	 * Manage login redirection.
 	 */
-	class BHG_Login_Redirect {
+        class BHG_Login_Redirect {
 
 		/**
 		 * Setup hooks.
 		 */
-		public function __construct() {
-			add_filter( 'login_redirect', array( $this, 'core_login_redirect' ), 10, 3 );
+                public function __construct() {
+                        add_filter( 'login_redirect', array( $this, 'core_login_redirect' ), 10, 3 );
 
-			// Nextend Social Login compatibility if plugin active.
-			if ( function_exists( 'NextendSocialLogin' ) ) {
-				add_filter( 'nsl_login_redirect', array( $this, 'nextend_redirect' ), 10, 3 );
-			}
-		}
+                        // Nextend Social Login compatibility if plugin active.
+                        if ( function_exists( 'NextendSocialLogin' ) ) {
+                                require_once BHG_PLUGIN_DIR . 'includes/class-bhg-nextend-profile.php';
+                                add_filter( 'nsl_login_redirect', array( $this, 'nextend_redirect' ), 10, 3 );
+                                add_action( 'nsl_register_new_user', array( $this, 'capture_nextend_profile' ), 10, 3 );
+                        }
+                }
 
 		/**
 		 * Core login redirect handler.
@@ -61,7 +63,7 @@ if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
 		 * @param string  $provider    Social login provider slug.
 		 * @return string Sanitized redirect URL.
 		 */
-		public function nextend_redirect( $redirect_to, $user, $provider ) {
+                public function nextend_redirect( $redirect_to, $user, $provider ) {
 			if ( ! empty( $_REQUEST['redirect_to'] ) ) {
 				$requested_redirect = sanitize_text_field( wp_unslash( $_REQUEST['redirect_to'] ) );
 				$validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
@@ -74,8 +76,56 @@ if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
 				return esc_url_raw( $validated_ref );
 			}
 
-			$validated_default = wp_validate_redirect( $redirect_to, home_url( '/' ) );
-			return esc_url_raw( $validated_default );
-		}
-	}
+                        $validated_default = wp_validate_redirect( $redirect_to, home_url( '/' ) );
+                        return esc_url_raw( $validated_default );
+                }
+
+                /**
+                 * Capture profile data when a user registers via Nextend Social Login.
+                 *
+                 * @param int    $user_id  Newly created user ID.
+                 * @param string $provider Provider slug (e.g., google, twitch).
+                 * @param array  $data     Raw profile data from Nextend.
+                 * @return void
+                 */
+                public function capture_nextend_profile( $user_id, $provider, $data ) {
+                        if ( ! $user_id ) {
+                                return;
+                        }
+
+                        $profile = BHG_Nextend_Profile::sanitize_profile( $data );
+                        $profile['provider'] = sanitize_text_field( $provider );
+
+                        /**
+                         * Filter profile data captured from Nextend before saving.
+                         *
+                         * @param array $profile Sanitized profile data.
+                         * @param int   $user_id User ID.
+                         * @param array $data    Raw profile data from Nextend.
+                         */
+                        $profile = apply_filters( 'bhg_nextend_profile_data', $profile, $user_id, $data );
+
+                        if ( ! empty( $profile['provider'] ) ) {
+                                update_user_meta( $user_id, 'bhg_social_provider', $profile['provider'] );
+                        }
+                        if ( ! empty( $profile['profile_url'] ) ) {
+                                update_user_meta( $user_id, 'bhg_social_profile_url', $profile['profile_url'] );
+                        }
+                        if ( ! empty( $profile['avatar'] ) ) {
+                                update_user_meta( $user_id, 'bhg_social_avatar', $profile['avatar'] );
+                        }
+                        if ( ! empty( $profile['display_name'] ) ) {
+                                update_user_meta( $user_id, 'bhg_social_display_name', $profile['display_name'] );
+                        }
+
+                        /**
+                         * Fires after Nextend profile meta was saved.
+                         *
+                         * @param int   $user_id User ID.
+                         * @param array $profile Profile data saved to user meta.
+                         * @param array $data    Raw profile data from Nextend.
+                         */
+                        do_action( 'bhg_nextend_profile_saved', $user_id, $profile, $data );
+                }
+        }
 }

--- a/includes/class-bhg-nextend-profile.php
+++ b/includes/class-bhg-nextend-profile.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Helpers for Nextend Social Login profile data.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'BHG_Nextend_Profile' ) ) {
+    /**
+     * Utility methods for sanitizing profile data from Nextend.
+     */
+    class BHG_Nextend_Profile {
+
+        /**
+         * Sanitize raw profile data array.
+         *
+         * @param array $data Raw profile array from Nextend Social Login.
+         * @return array {
+         *     @type string $avatar       Avatar image URL.
+         *     @type string $display_name Display name from provider.
+         *     @type string $profile_url  Link to provider profile.
+         * }
+         */
+        public static function sanitize_profile( $data ) {
+            $data = is_array( $data ) ? $data : array();
+
+            $avatar       = isset( $data['avatar'] ) ? esc_url_raw( $data['avatar'] ) : '';
+            $display_name = isset( $data['displayName'] ) ? sanitize_text_field( $data['displayName'] ) : '';
+            $profile_url  = isset( $data['profileUrl'] ) ? esc_url_raw( $data['profileUrl'] ) : '';
+
+            return array(
+                'avatar'       => $avatar,
+                'display_name' => $display_name,
+                'profile_url'  => $profile_url,
+            );
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Capture profile data when users register via Nextend Social Login
- Save social provider and profile URL to user meta and expose filters/actions

## Testing
- `phpcs --standard=phpcs.xml` *(fails: /usr/bin/phpcs: No such file or directory)*
- `php -l includes/class-bhg-login-redirect.php` *(fails: /usr/bin/php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ba7273d4833386a219944ec091b6