### PR TITLE
Handle count query without prepare when no params

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -1003,7 +1003,11 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
                         if ( $where ) {
                                 $count_sql .= $where;
                         }
-                        $total = (int) $wpdb->get_var( $wpdb->prepare( $count_sql, ...$prep_where ) );
+                        if ( empty( $prep_where ) ) {
+                                $total = (int) $wpdb->get_var( $count_sql );
+                        } else {
+                                $total = (int) $wpdb->get_var( $wpdb->prepare( $count_sql, ...$prep_where ) );
+                        }
 
                         $sql .= ' GROUP BY r.user_id, u.user_login';
                         $orderby_map = array(


### PR DESCRIPTION
## Summary
- Avoid unnecessary $wpdb->prepare for leaderboard count query when no parameters

## Testing
- `composer install --no-interaction`
- `composer phpcs` *(fails: Tabs must be used to indent lines; spaces are not allowed, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cc57d7948333a8013281e86cf387