### PR TITLE
Avoid unnecessary prepare call

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -1073,7 +1073,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
                         $orderby = isset( $orderby_map[ $orderby_key ] ) ? $orderby_map[ $orderby_key ] : $orderby_map['wins'];
                         $sql    .= sprintf( ' ORDER BY %s %s LIMIT %d OFFSET %d', $orderby, $direction, $limit, $offset );
                         $params  = $prep_where;
-                        $query   = $wpdb->prepare( $sql, ...$params );
+                        $query   = $params ? $wpdb->prepare( $sql, ...$params ) : $sql;
                         $rows    = $wpdb->get_results( $query );
                         $pages   = (int) ceil( $total / $limit );
 


### PR DESCRIPTION
## Summary
- prevent calling `$wpdb->prepare()` when no parameters are provided in `BHG_Shortcodes`

## Testing
- `composer phpcs` *(fails: missing dependency or code style issues)*
- `vendor/bin/phpcs includes/class-bhg-shortcodes.php` *(fails: tabs must be used to indent lines; spaces are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d589d8508333bbf06650cd7b85fc