### PR TITLE
Sanitize option values in guess form

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -287,11 +287,11 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 						echo esc_html( bhg_t( 'label_select_hunt', 'Select a hunt' ) );
 						?>
 </option>
-						<?php foreach ( $open_hunts as $oh ) : ?>
-							<option value="<?php echo (int) $oh->id; ?>" <?php selected( $hunt_id, (int) $oh->id ); ?>>
-								<?php echo esc_html( $oh->title ); ?>
-							</option>
-						<?php endforeach; ?>
+                                                <?php foreach ( $open_hunts as $oh ) : ?>
+                                                        <option value="<?php echo esc_attr( (int) $oh->id ); ?>" <?php selected( $hunt_id, (int) $oh->id ); ?>>
+                                                                <?php echo esc_html( $oh->title ); ?>
+                                                        </option>
+                                                <?php endforeach; ?>
 					</select>
 				<?php else : ?>
 					<input type="hidden" name="hunt_id" value="<?php echo esc_attr( $hunt_id ); ?>">


### PR DESCRIPTION
## Summary
- escape bonus hunt IDs in guess form options using `esc_attr`

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d977221c8333b8ec9e4790ba2208