### PR TITLE
Use selected() helper in select loops

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -386,14 +386,9 @@ if ( 'add' === $view ) :
 						?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
 				<option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
-				<?php foreach ( $affs as $a ) : ?>
-				<option value="<?php echo esc_attr( (int) $a->id ); ?>" 
-					<?php
-					if ( $sel === (int) $a->id ) {
-						echo 'selected';}
-					?>
-				><?php echo esc_html( $a->name ); ?></option>
-				<?php endforeach; ?>
+                                <?php foreach ( $affs as $a ) : ?>
+                                <option value="<?php echo esc_attr( (int) $a->id ); ?>" <?php selected( $sel, (int) $a->id ); ?>><?php echo esc_html( $a->name ); ?></option>
+                                <?php endforeach; ?>
 			</select>
 			</td>
 				</tr>
@@ -413,15 +408,9 @@ if ( 'add' === $view ) :
 												?>
 						<select id="bhg_tournament" name="tournament_id">
 								<option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
-								<?php foreach ( $tours as $t ) : ?>
-								<option value="<?php echo esc_attr( (int) $t->id ); ?>"
-										<?php
-										if ( $tsel === (int) $t->id ) {
-												echo 'selected';
-										}
-										?>
-								><?php echo esc_html( $t->title ); ?></option>
-								<?php endforeach; ?>
+                                                                <?php foreach ( $tours as $t ) : ?>
+                                                                <option value="<?php echo esc_attr( (int) $t->id ); ?>" <?php selected( $tsel, (int) $t->id ); ?>><?php echo esc_html( $t->title ); ?></option>
+                                                                <?php endforeach; ?>
 						</select>
 						</td>
 				</tr>
@@ -523,14 +512,9 @@ if ( 'edit' === $view ) :
 						?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
 				<option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
-				<?php foreach ( $affs as $a ) : ?>
-				<option value="<?php echo esc_attr( (int) $a->id ); ?>" 
-					<?php
-					if ( $sel === (int) $a->id ) {
-						echo 'selected';}
-					?>
-				><?php echo esc_html( $a->name ); ?></option>
-				<?php endforeach; ?>
+                                <?php foreach ( $affs as $a ) : ?>
+                                <option value="<?php echo esc_attr( (int) $a->id ); ?>" <?php selected( $sel, (int) $a->id ); ?>><?php echo esc_html( $a->name ); ?></option>
+                                <?php endforeach; ?>
 			</select>
 						</td>
 				</tr>
@@ -550,15 +534,9 @@ if ( 'edit' === $view ) :
 												?>
 						<select id="bhg_tournament" name="tournament_id">
 								<option value="0"><?php echo esc_html( bhg_t( 'none', 'None' ) ); ?></option>
-								<?php foreach ( $tours as $t ) : ?>
-								<option value="<?php echo esc_attr( (int) $t->id ); ?>"
-										<?php
-										if ( $tsel === (int) $t->id ) {
-												echo 'selected';
-										}
-										?>
-								><?php echo esc_html( $t->title ); ?></option>
-								<?php endforeach; ?>
+                                                                <?php foreach ( $tours as $t ) : ?>
+                                                                <option value="<?php echo esc_attr( (int) $t->id ); ?>" <?php selected( $tsel, (int) $t->id ); ?>><?php echo esc_html( $t->title ); ?></option>
+                                                                <?php endforeach; ?>
 						</select>
 						</td>
 				</tr>


### PR DESCRIPTION
## Summary
- Use WordPress `selected()` helper instead of manual checks in affiliate and tournament `<select>` loops.

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml admin/views/bonus-hunts.php` *(fails: Found 141 errors and 46 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dae106f88333af40212eb0891c54