### PR TITLE
Remove automatic DB migration from user guesses shortcode

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -1,4 +1,4 @@
-<?php
+	<?php
 /**
  * Shortcodes for Bonus Hunt Guesser.
  *
@@ -10,7 +10,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) {
 				exit;
-}
+			}
 
 if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 
@@ -596,11 +596,11 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
                 return '';
         }
 
-			// Ensure hunts table has created_at column. If missing, attempt migration and fall back.
+			// Ensure hunts table has created_at column. If missing, inform admin to run upgrades manually.
 	$has_created_at = $wpdb->get_var( $wpdb->prepare( "SHOW COLUMNS FROM {$h} LIKE %s", 'created_at' ) );
-			if ( empty( $has_created_at ) && class_exists( 'BHG_DB' ) ) {
-								BHG_DB::migrate();
-								$has_created_at = $wpdb->get_var( $wpdb->prepare( "SHOW COLUMNS FROM {$h} LIKE %s", 'created_at' ) );
+			if ( empty( $has_created_at ) ) {
+								error_log( 'Bonus Hunt Guesser: missing required column created_at in table ' . $h );
+								return '<p>' . esc_html( bhg_t( 'notice_db_update_required', 'Database upgrade required. Please run plugin upgrades.' ) ) . '</p>';
 			}
 
 			$where  = array( 'g.user_id = %d' );

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -385,6 +385,7 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'notice_guess_removed'                         => 'Guess removed.',
 			'notice_hunt_closed_successfully'              => 'Hunt closed successfully.',
 			'notice_missing_hunt_id'                       => 'Missing hunt id.',
+			'notice_db_update_required'                    => 'Database upgrade required. Please run plugin upgrades.',
 			'notice_no_active_hunt'                        => 'No active bonus hunt found.',
 			'notice_no_results'                            => 'No results available.',
 			'notice_user_removed'                          => 'User removed.',


### PR DESCRIPTION
## Summary
- avoid automatic database migrations when rendering user guesses
- log missing column and return friendly message directing admin to run upgrades
- add translation string for database upgrade message

## Testing
- `composer phpcs` *(fails: Use placeholders and $wpdb->prepare; existing warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dc8ccfd883339379ef4a10aeec56