### PR TITLE
Bump version to 8.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 # Changelog
 
+## 8.0.11 — 2025-09-14
+- Version bump.
+
 ## 8.0.10 — 2025-09-12
 - Bump version to 8.0.10.
 - Set minimum WordPress version to 5.5.5.

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -3,7 +3,7 @@
  * Plugin Name: Bonus Hunt Guesser
  * Plugin URI: https://yourdomain.com/
  * Description: Comprehensive bonus hunt management system with tournaments, leaderboards, and user guessing functionality
- * Version: 8.0.10
+ * Version: 8.0.11
  * Requires at least: 5.5.5
  * Requires PHP: 7.4
  * Author: Bonus Hunt Guesser Development Team
@@ -120,7 +120,7 @@ if ( ! function_exists( 'bhg_sanitize_tournament_id' ) ) {
 require_once __DIR__ . '/includes/class-bhg-db.php';
 
 // Define plugin constants.
-define( 'BHG_VERSION', '8.0.10' );
+define( 'BHG_VERSION', '8.0.11' );
 define( 'BHG_MIN_WP', '5.5.5' );
 define( 'BHG_PLUGIN_FILE', __FILE__ );
 define( 'BHG_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/languages/bonus-hunt-guesser.pot
+++ b/languages/bonus-hunt-guesser.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Bonus Hunt Guesser 8.0.10\n"
+"Project-Id-Version: Bonus Hunt Guesser 8.0.11\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/my-awesome-wordpress-plugin\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## Summary
- bump version constant and plugin header to 8.0.11
- update project ID version in translation template
- add changelog entry for 8.0.11

## Testing
- `composer phpcs` *(fails: numerous coding standard errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c6df9a78e48333b3fb26c7d657f062