### PR TITLE
Allow archiving tournaments

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -655,9 +655,10 @@ class BHG_Admin {
 				'status'            => isset( $_POST['status'] ) ? sanitize_key( wp_unslash( $_POST['status'] ) ) : 'active',
 				'updated_at'        => current_time( 'mysql' ),
 			);
-			if ( ! in_array( $data['status'], array( 'active', 'inactive' ), true ) ) {
-				$data['status'] = 'active';
-			}
+                        $allowed_statuses = array( 'active', 'archived' );
+                        if ( ! in_array( $data['status'], $allowed_statuses, true ) ) {
+                                $data['status'] = 'active';
+                        }
 			try {
 					$format = array( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' );
 				if ( $id > 0 ) {


### PR DESCRIPTION
## Summary
- align the tournament status validation with the UI by accepting the "archived" option instead of reverting to "active"

## Testing
- composer phpcs *(fails: existing coding standard violations in the codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbab40c0883338b78fbba12caacc1