### PR TITLE
Adjust active hunt per-page default to 30

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -211,10 +211,10 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 
 		       $selected_hunt = $hunts_map[ $selected_hunt_id ];
 
-		       $per_page = (int) apply_filters( 'bhg_active_hunt_per_page', 25 );
-		       if ( $per_page <= 0 ) {
-			       $per_page = 25;
-		       }
+                       $per_page = (int) apply_filters( 'bhg_active_hunt_per_page', 30 );
+                       if ( $per_page <= 0 ) {
+                               $per_page = 30;
+                       }
 
 		       $current_page = 1;
 		       if ( isset( $_GET['bhg_hunt_page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Viewing data.


### PR DESCRIPTION
## Summary
- update the `bhg_active_hunt_per_page` default and fallback to 30 so the shortcode shows 30 guesses per page by default

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccbddc12808333aa153066923717c4