### PR TITLE
Bump plugin version to 8.0.12

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -3,7 +3,7 @@
  * Plugin Name: Bonus Hunt Guesser
  * Plugin URI: https://yourdomain.com/
  * Description: Comprehensive bonus hunt management system with tournaments, leaderboards, and user guessing functionality
- * Version: 8.0.11
+ * Version: 8.0.12
  * Requires at least: 5.5.5
  * Requires PHP: 7.4
  * Author: Bonus Hunt Guesser Development Team
@@ -120,7 +120,7 @@ if ( ! function_exists( 'bhg_sanitize_tournament_id' ) ) {
 require_once __DIR__ . '/includes/class-bhg-db.php';
 
 // Define plugin constants.
-define( 'BHG_VERSION', '8.0.11' );
+define( 'BHG_VERSION', '8.0.12' );
 define( 'BHG_MIN_WP', '5.5.5' );
 define( 'BHG_PLUGIN_FILE', __FILE__ );
 define( 'BHG_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
## Summary
- update the plugin header metadata to version 8.0.12
- align the `BHG_VERSION` constant with the new version value
- confirmed no other version strings require adjustment after the bump

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccbf82748083339e32f8348144df15