### PR TITLE
Remove leading whitespace before PHP open tags

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -1,4 +1,4 @@
-	<?php
+<?php
 /**
  * Shortcodes for Bonus Hunt Guesser.
  *


### PR DESCRIPTION
## Summary
- strip leading whitespace before the opening PHP tag in `includes/class-bhg-shortcodes.php`
- scan the rest of the PHP files to confirm no additional files contain whitespace before the opening tag

## Testing
- php -l includes/class-bhg-shortcodes.php

------
https://chatgpt.com/codex/tasks/task_e_68ccc7b8e1e8833384832dc8b7db4598