### PR TITLE
Fix bonus hunts sort toggle detection

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -126,91 +126,91 @@ $hunts = $wpdb->get_results( $hunts_query );
 <th><a href="
 	<?php
 	echo esc_url(
-		add_query_arg(
-			array(
-				'orderby' => 'id',
-'order'   => ( 'id' === $orderby_param && 'ASC' === $order_param ? 'desc' : 'asc' ),
-			),
-			$sort_base
-		)
+                add_query_arg(
+                        array(
+                                'orderby' => 'id',
+                                'order'   => ( 'id' === $orderby_param && 'asc' === $order_param ) ? 'desc' : 'asc',
+                        ),
+                        $sort_base
+                )
 	);
 	?>
 				"><?php echo esc_html( bhg_t( 'id', 'ID' ) ); ?></a></th>
 <th><a href="
 	<?php
 	echo esc_url(
-		add_query_arg(
-			array(
-				'orderby' => 'title',
-'order'   => ( 'title' === $orderby_param && 'ASC' === $order_param ? 'desc' : 'asc' ),
-			),
-			$sort_base
-		)
+                add_query_arg(
+                        array(
+                                'orderby' => 'title',
+                                'order'   => ( 'title' === $orderby_param && 'asc' === $order_param ) ? 'desc' : 'asc',
+                        ),
+                        $sort_base
+                )
 	);
 	?>
 				"><?php echo esc_html( bhg_t( 'sc_title', 'Title' ) ); ?></a></th>
 <th><a href="
 	<?php
 	echo esc_url(
-		add_query_arg(
-			array(
-				'orderby' => 'starting_balance',
-'order'   => ( 'starting_balance' === $orderby_param && 'ASC' === $order_param ? 'desc' : 'asc' ),
-			),
-			$sort_base
-		)
+                add_query_arg(
+                        array(
+                                'orderby' => 'starting_balance',
+                                'order'   => ( 'starting_balance' === $orderby_param && 'asc' === $order_param ) ? 'desc' : 'asc',
+                        ),
+                        $sort_base
+                )
 	);
 	?>
 				"><?php echo esc_html( bhg_t( 'sc_start_balance', 'Start Balance' ) ); ?></a></th>
 <th><a href="
 	<?php
 	echo esc_url(
-		add_query_arg(
-			array(
-				'orderby' => 'final_balance',
-'order'   => ( 'final_balance' === $orderby_param && 'ASC' === $order_param ? 'desc' : 'asc' ),
-			),
-			$sort_base
-		)
+                add_query_arg(
+                        array(
+                                'orderby' => 'final_balance',
+                                'order'   => ( 'final_balance' === $orderby_param && 'asc' === $order_param ) ? 'desc' : 'asc',
+                        ),
+                        $sort_base
+                )
 	);
 	?>
 				"><?php echo esc_html( bhg_t( 'sc_final_balance', 'Final Balance' ) ); ?></a></th>
 <th><a href="
 	<?php
 	echo esc_url(
-		add_query_arg(
-			array(
-				'orderby' => 'affiliate',
-'order'   => ( 'affiliate' === $orderby_param && 'ASC' === $order_param ? 'desc' : 'asc' ),
-			),
-			$sort_base
-		)
+                add_query_arg(
+                        array(
+                                'orderby' => 'affiliate',
+                                'order'   => ( 'affiliate' === $orderby_param && 'asc' === $order_param ) ? 'desc' : 'asc',
+                        ),
+                        $sort_base
+                )
 	);
 	?>
 				"><?php echo esc_html( bhg_t( 'affiliate', 'Affiliate' ) ); ?></a></th>
 <th><a href="
 	<?php
 	echo esc_url(
-		add_query_arg(
-			array(
-				'orderby' => 'winners',
-'order'   => ( 'winners' === $orderby_param && 'ASC' === $order_param ? 'desc' : 'asc' ),
-			),
-			$sort_base
-		)
+                add_query_arg(
+                        array(
+                                'orderby' => 'winners',
+                                'order'   => ( 'winners' === $orderby_param && 'asc' === $order_param ) ? 'desc' : 'asc',
+                        ),
+                        $sort_base
+                )
 	);
 	?>
 				"><?php echo esc_html( bhg_t( 'winners', 'Winners' ) ); ?></a></th>
 <th><a href="
 	<?php
 	echo esc_url(
-		add_query_arg(
-			array(
-				'orderby' => 'status',
-'order'   => ( 'status' === $orderby_param && 'ASC' === $order_param ? 'desc' : 'asc' ),
-			),
-			$sort_base
-		)
+                add_query_arg(
+                        array(
+                                'orderby' => 'status',
+                                'order'   => ( 'status' === $orderby_param && 'asc' === $order_param ) ? 'desc' : 'asc',
+                        ),
+                        $sort_base
+                )
 	);
 	?>
 				"><?php echo esc_html( bhg_t( 'sc_status', 'Status' ) ); ?></a></th>


### PR DESCRIPTION
## Summary
- normalize sort direction comparisons in the bonus hunts admin list to use the lower-case order value that is stored in the query string
- ensure each sortable table header now flips between ascending and descending order values on repeated clicks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccd7b971e88333af1f5b28a070fa47