### PR TITLE
Fix demo tools submenu parent

### DIFF
--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -31,7 +31,7 @@ class BHG_Demo {
 	 */
 	public function demo_menu() {
 		add_submenu_page(
-			'bhg_dashboard',
+			'bhg',
 			__( 'Demo Tools', 'bonus-hunt-guesser' ),
 			__( 'Demo Tools', 'bonus-hunt-guesser' ),
 			'manage_options',


### PR DESCRIPTION
## Summary
- update the demo tools submenu registration to use the primary Bonus Hunt menu slug

## Testing
- not run (WordPress admin UI verification requires a running WordPress instance)

------
https://chatgpt.com/codex/tasks/task_e_68cce16b8d708333a0463a600dc7a162