### PR TITLE
Ensure ads_enabled respects submitted value

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -496,7 +496,8 @@ function bhg_handle_settings_save() {
 		}
 	}
 
-		$settings['ads_enabled'] = isset( $_POST['bhg_ads_enabled'] ) ? 1 : 0;
+$ads_enabled_value       = isset( $_POST['bhg_ads_enabled'] ) ? wp_unslash( $_POST['bhg_ads_enabled'] ) : '';
+$settings['ads_enabled'] = (string) $ads_enabled_value === '1' ? 1 : 0;
 
         if ( isset( $_POST['bhg_email_from'] ) ) {
                         $email_from = sanitize_email( wp_unslash( $_POST['bhg_email_from'] ) );


### PR DESCRIPTION
## Summary
- ensure the ads enabled setting is only treated as enabled when the submitted value equals "1"

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cce36d0398833380e8009299f2ef60