### PR TITLE
Adjust user guesses shortcode to use hunt context

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Requires at least: WordPress 5.5.5
 ## Shortcodes
 
 ### `[bhg_user_guesses]`
-Display guesses submitted by a user.
+Display guesses submitted for a specific bonus hunt. Pass `id` to target a hunt; omit it to use the most recent active hunt.
 
 - `timeline`: limit results to `day`, `week`, `month`, `year`, or the legacy aliases `this_week`, `this_month`, `this_year`, `last_year`.
 


### PR DESCRIPTION
## Summary
- update `[bhg_user_guesses]` shortcode to select guesses by hunt, defaulting to the latest active hunt when no ID is provided
- ensure affiliate/site/timeline filters continue working by constraining the query to the chosen hunt and including the guesser IDs
- document the shortcode's new behavior in the README

## Testing
- `composer phpcs` *(fails: pre-existing coding standard violations across admin view templates)*

------
https://chatgpt.com/codex/tasks/task_e_68cce795949083338e90ea30f4c14e91