### PR TITLE
Fix leaderboard sort direction toggling

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -1514,8 +1514,7 @@ $wpdb->usermeta,
                                 'asc'  => 'ASC',
                                 'desc' => 'DESC',
                         );
-                        $direction_key = strtolower( sanitize_key( $a['order'] ) );
-                        $direction     = $direction_map[ $direction_key ] ?? 'DESC';
+                        $direction     = isset( $direction_map[ $direction_key ] ) ? $direction_map[ $direction_key ] : $direction_map['desc'];
                         $orderby       = isset( $orderby_map[ $orderby_key ] ) ? $orderby_map[ $orderby_key ] : $orderby_map['wins'];
                         $select_sql   .= sprintf( ' ORDER BY %s %s LIMIT %%d OFFSET %%d', $orderby, $direction );
 


### PR DESCRIPTION
## Summary
- reuse the request-derived direction key when building the leaderboard ORDER BY clause
- ensure the generated SQL direction mirrors the current sort parameter so column headers toggle correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cceb2f18908333b82688140d81d7d1