### PR TITLE
Remove retired demo admin tools

### DIFF
--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -18,90 +18,10 @@ class BHG_Demo {
 
 	/**
 	 * Constructor.
+	 *
+	 * Intentionally left blank as demo tooling has been retired.
 	 */
 	public function __construct() {
-		add_action( 'admin_menu', array( $this, 'demo_menu' ) );
-		add_action( 'admin_post_bhg_demo_reseed', array( $this, 'reseed' ) );
-	}
-
-	/**
-	 * Add demo submenu page.
-	 *
-	 * @return void
-	 */
-	public function demo_menu() {
-		add_submenu_page(
-			'bhg',
-			__( 'Demo Tools', 'bonus-hunt-guesser' ),
-			__( 'Demo Tools', 'bonus-hunt-guesser' ),
-			'manage_options',
-			'bhg_demo',
-			array( $this, 'render_demo' )
-		);
-	}
-
-	/**
-	 * Render the demo tools page.
-	 *
-	 * @return void
-	 */
-	public function render_demo() {
-		echo '<div class="wrap"><h1>' . esc_html__( 'Demo Tools', 'bonus-hunt-guesser' ) . '</h1>';
-		echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '">';
-		echo '<input type="hidden" name="action" value="bhg_demo_reseed" />';
-		wp_nonce_field( 'bhg_demo_reseed', 'bhg_demo_reseed_nonce' );
-		submit_button( __( 'Reset & Reseed Demo', 'bonus-hunt-guesser' ) );
-		echo '</form></div>';
-	}
-
-	/**
-	 * Reset and reseed demo data.
-	 *
-	 * @return void
-	 */
-	public function reseed() {
-		check_admin_referer( 'bhg_demo_reseed', 'bhg_demo_reseed_nonce' );
-		global $wpdb;
-
-                // Wipe demo data.
-                $hunts_table       = esc_sql( $wpdb->prefix . 'bhg_bonus_hunts' );
-                $tournaments_table = esc_sql( $wpdb->prefix . 'bhg_tournaments' );
-
-                                $wpdb->query(
-                                        $wpdb->prepare(
-                                                "DELETE FROM {$hunts_table} WHERE title LIKE %s",
-                                                '%\(Demo\)%'
-                                        )
-                                );
-
-                                $wpdb->query(
-                                        $wpdb->prepare(
-                                                "DELETE FROM {$tournaments_table} WHERE title LIKE %s",
-                                                '%\(Demo\)%'
-                                        )
-                                );
-
-		// Insert demo hunt.
-		$wpdb->insert(
-			$hunts_table,
-			array(
-				'title'            => 'Sample Hunt (Demo)',
-				'starting_balance' => 1000,
-				'num_bonuses'      => 5,
-				'status'           => 'open',
-			)
-		);
-
-		// Insert demo tournament.
-		$wpdb->insert(
-			$tournaments_table,
-			array(
-				'title'  => 'August Tournament (Demo)',
-				'status' => 'active',
-			)
-		);
-
-			wp_safe_redirect( esc_url_raw( BHG_Utils::admin_url( 'admin.php?page=bhg_demo&demo_reset=1' ) ) );
-		exit;
+		// Demo submenu registration removed.
 	}
 }

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -221,7 +221,6 @@ spl_autoload_register(
 			'BHG_Ads'                    => 'includes/class-bhg-ads.php',
 			'BHG_Login_Redirect'         => 'includes/class-bhg-login-redirect.php',
 			'BHG_Tournaments_Controller' => 'includes/class-bhg-tournaments-controller.php',
-			'BHG_Demo'                   => 'admin/class-bhg-demo.php',
 		);
 
 		if ( isset( $class_map[ $class_name ] ) ) {
@@ -385,9 +384,6 @@ function bhg_init_plugin() {
 	if ( is_admin() ) {
 		if ( class_exists( 'BHG_Admin' ) ) {
 			new BHG_Admin();
-		}
-		if ( class_exists( 'BHG_Demo' ) ) {
-			new BHG_Demo();
 		}
 	}
 


### PR DESCRIPTION
## Summary
- strip the demo admin class down to an inert constructor so it no longer registers the submenu or reseed handler
- drop the `BHG_Demo` autoload mapping and instantiation so the retired demo tooling is no longer loaded on admin requests

## Testing
- composer phpcs *(fails: existing coding standards issues across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cced9900048333923080be9f93d370