### PR TITLE
Adjust affiliate filtering defaults for user guesses shortcode

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -752,7 +752,7 @@ $wpdb->usermeta,
         $a = shortcode_atts(
           array(
                   'id'       => 0,
-                  'aff'      => 'yes',
+                  'aff'      => '',
                   'website'  => 0,
                   'status'   => '',
                   'timeline' => '',
@@ -994,7 +994,7 @@ $wpdb->usermeta,
                                 return '<p>' . esc_html( bhg_t( 'notice_no_guesses_found', 'No guesses found.' ) ) . '</p>';
                         }
 
-          $show_aff = in_array( 'user', $fields_arr, true ) && in_array( strtolower( (string) $a['aff'] ), array( 'yes', '1', 'true' ), true );
+          $show_aff = $need_users;
 
           ob_start();
           echo '<form method="get" class="bhg-search-form">';


### PR DESCRIPTION
## Summary
- default the `aff` attribute for the user guesses shortcode to an empty string so affiliates are not filtered unless requested
- always render the affiliate indicator when the user column is displayed so affiliate status remains visible even without filtering

## Testing
- php -l includes/class-bhg-shortcodes.php

------
https://chatgpt.com/codex/tasks/task_e_68ccf40b17f88333b38efede7400c77e