### PR TITLE
Add leaderboard filter controls

### DIFF
--- a/assets/css/bhg-shortcodes.css
+++ b/assets/css/bhg-shortcodes.css
@@ -96,6 +96,67 @@
     font-weight: 600;
 }
 
+.bhg-search-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.bhg-filter-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: flex-end;
+}
+
+.bhg-filter-label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-weight: 600;
+    color: #1e293b;
+}
+
+.bhg-filter-select,
+.bhg-search-form input[type="text"] {
+    min-width: 200px;
+    padding: 6px 10px;
+    border: 1px solid #cbd5e1;
+    border-radius: 4px;
+    background-color: #fff;
+    box-shadow: 0 1px 1px rgba(15, 23, 42, 0.05);
+}
+
+.bhg-filter-select:focus,
+.bhg-search-form input[type="text"]:focus {
+    outline: 2px solid var(--bhg-accent-color);
+    outline-offset: 1px;
+}
+
+.bhg-search-control {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.bhg-search-control button {
+    background-color: var(--bhg-accent-color);
+    border: 1px solid var(--bhg-accent-color);
+    color: #fff;
+    padding: 8px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.bhg-search-control button:hover,
+.bhg-search-control button:focus {
+    background-color: var(--bhg-accent-color);
+    border-color: var(--bhg-accent-color);
+    color: #fff;
+    filter: brightness(0.9);
+}
+
 .bhg-hunt-select {
     min-width: 220px;
     padding: 6px 10px;


### PR DESCRIPTION
## Summary
- gather available tournaments, hunts, and affiliate sites inside `leaderboards_shortcode()` so the leaderboard filters can be populated
- render tournament, hunt, site, and affiliate status `<select>` inputs ahead of the existing search box and persist selected values
- update the shortcode CSS to style the new filter controls and shared search form layout

## Testing
- `composer phpcs` *(fails: existing whitespace and documentation violations elsewhere in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cd040f14c08333b3404c777270c2f2