### PR TITLE
Stop repopulating demo data during database cleanup

### DIFF
--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -38,7 +38,7 @@ if ( 'db_cleanup' === $db_action && ! empty( $cleanup_request ) ) {
 <div class="wrap">
 <h1><?php echo esc_html( bhg_t( 'database', 'Database' ) ); ?></h1>
 <?php if ( ! empty( $cleanup_completed ) ) : ?>
-<div class="notice notice-success is-dismissible"><p><?php echo esc_html( bhg_t( 'database_cleanup_completed', 'Database cleanup completed.' ) ); ?></p></div>
+<div class="notice notice-success is-dismissible"><p><?php echo esc_html( bhg_t( 'database_cleanup_completed', 'Database cleanup completed. All plugin tables are now empty.' ) ); ?></p></div>
 <?php endif; ?>
 <?php if ( ! empty( $optimize_completed ) ) : ?>
 <div class="notice notice-success is-dismissible"><p><?php echo esc_html( bhg_t( 'database_optimization_completed', 'Database optimization completed.' ) ); ?></p></div>

--- a/includes/admin-database-tools.php
+++ b/includes/admin-database-tools.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! function_exists( 'bhg_database_cleanup' ) ) {
     /**
-     * Truncate all plugin tables and reinsert demo data.
+     * Truncate all plugin tables.
      */
     function bhg_database_cleanup() {
         global $wpdb;
@@ -32,8 +32,6 @@ if ( ! function_exists( 'bhg_database_cleanup' ) ) {
                 $wpdb->query( "TRUNCATE TABLE {$table}" );
             }
         }
-
-        bhg_insert_demo_data();
     }
 }
 
@@ -60,27 +58,6 @@ if ( ! function_exists( 'bhg_database_optimize' ) ) {
                 $wpdb->query( "OPTIMIZE TABLE {$table}" );
             }
         }
-    }
-}
-
-if ( ! function_exists( 'bhg_insert_demo_data' ) ) {
-    /**
-     * Insert basic demo data.
-     */
-    function bhg_insert_demo_data() {
-        global $wpdb;
-
-        $wpdb->insert(
-            $wpdb->prefix . 'bhg_bonus_hunts',
-            array(
-                'title'            => 'Demo Bonus Hunt',
-                'starting_balance' => 2000,
-                'num_bonuses'      => 10,
-                'status'           => 'active',
-                'created_at'       => current_time( 'mysql' ),
-            ),
-            array( '%s', '%d', '%d', '%s', '%s' )
-        );
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the demo data reinsertion from the database cleanup helper so it only truncates plugin tables
- drop the unused demo data helper entirely
- clarify the admin success notice to mention the tables are left empty after cleanup

## Testing
- composer phpcs *(fails: existing coding standard violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0d53f90083339cd11cb94f3e9303