### PR TITLE
Restore demo tools admin page with reset handler

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -75,10 +75,14 @@ class BHG_Admin {
 			array( $this, 'bhg_tools_page' )
 		);
 
-		// NOTE: By default, WordPress adds a submenu item that duplicates the
-		// top-level “Bonus Hunt” menu. The previous `remove_submenu_page()`
-		// call removed this submenu, but it also inadvertently removed our
-		// custom “Dashboard” submenu. Removing the call ensures the Dashboard
+		if ( class_exists( 'BHG_Demo' ) ) {
+			BHG_Demo::instance()->register_menu( $slug, $cap );
+		}
+
+                // NOTE: By default, WordPress adds a submenu item that duplicates the
+                // top-level “Bonus Hunt” menu. The previous `remove_submenu_page()`
+                // call removed this submenu, but it also inadvertently removed our
+                // custom “Dashboard” submenu. Removing the call ensures the Dashboard
 		// item remains visible under the "Bonus Hunt" menu.
 	}
 
@@ -1057,8 +1061,10 @@ exit;
                        ),
 			'nonce'         => bhg_t( 'security_check_failed_please_retry', 'Security check failed. Please retry.' ),
 			'noaccess'      => bhg_t( 'you_do_not_have_permission_to_do_that', 'You do not have permission to do that.' ),
-			'tools_success' => bhg_t( 'tools_action_completed', 'Tools action completed.' ),
-		);
+                        'tools_success' => bhg_t( 'tools_action_completed', 'Tools action completed.' ),
+                        'demo_reset_ok' => bhg_t( 'demo_data_reset_complete', 'Demo data was reset and reseeded.' ),
+                        'demo_reset_error' => bhg_t( 'demo_data_reset_failed', 'Demo data reset failed.' ),
+                );
 		$class = ( strpos( $msg, 'error' ) !== false || 'nonce' === $msg || 'noaccess' === $msg ) ? 'notice notice-error' : 'notice notice-success';
 		$text  = isset( $map[ $msg ] ) ? $map[ $msg ] : esc_html( $msg );
 		echo '<div class="' . esc_attr( $class ) . '"><p>' . esc_html( $text ) . '</p></div>';

--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -10,18 +10,236 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Class BHG_Demo
- *
- * Handles demo tools for admin.
+ * Handles Demo Tools administration and data reset.
  */
 class BHG_Demo {
 
 	/**
-	 * Constructor.
+	 * Singleton instance.
 	 *
-	 * Intentionally left blank as demo tooling has been retired.
+	 * @var BHG_Demo|null
 	 */
-	public function __construct() {
-		// Demo submenu registration removed.
+	protected static $instance = null;
+
+	/**
+	 * Parent menu slug.
+	 *
+	 * @var string
+	 */
+	protected $parent_slug = 'bhg';
+
+	/**
+	 * Capability required to manage demo data.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Submenu slug.
+	 *
+	 * @var string
+	 */
+	protected $menu_slug = 'bhg-demo-tools';
+
+	/**
+	 * Constructor.
+	 */
+	protected function __construct() {
+		$this->capability = apply_filters( 'bhg_demo_tools_capability', $this->capability );
+
+		add_action( 'admin_menu', array( $this, 'maybe_register_menu' ), 20 );
+		add_action( 'admin_post_bhg_demo_reset', array( $this, 'handle_reset' ) );
+	}
+
+	/**
+	 * Retrieve the singleton instance.
+	 *
+	 * @return BHG_Demo
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Register the submenu entry under the Bonus Hunt menu.
+	 *
+	 * @param string|null $parent_slug Optional parent slug override.
+	 * @param string|null $capability  Optional capability override.
+	 * @return void
+	 */
+	public function register_menu( $parent_slug = null, $capability = null ) {
+		if ( null !== $parent_slug ) {
+			$this->parent_slug = sanitize_title( (string) $parent_slug );
+		}
+
+		if ( null !== $capability && is_string( $capability ) && '' !== $capability ) {
+			$this->capability = $capability;
+		}
+
+		add_submenu_page(
+			$this->parent_slug,
+			bhg_t( 'demo_tools', 'Demo Tools' ),
+			bhg_t( 'demo_tools', 'Demo Tools' ),
+			$this->capability,
+			$this->menu_slug,
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Ensure the submenu exists when the admin menu is built.
+	 *
+	 * @return void
+	 */
+	public function maybe_register_menu() {
+		if ( $this->submenu_exists() ) {
+			return;
+		}
+
+		$this->register_menu();
+	}
+
+	/**
+	 * Render the Demo Tools page.
+	 *
+	 * @return void
+	 */
+	public function render_page() {
+		if ( ! current_user_can( $this->capability ) ) {
+			wp_die( esc_html( bhg_t( 'you_do_not_have_permission_to_access_this_page', 'You do not have permission to access this page' ) ) );
+		}
+
+		$counts     = $this->get_counts();
+		$action_url = class_exists( 'BHG_Utils' ) ? BHG_Utils::admin_url( 'admin-post.php' ) : admin_url( 'admin-post.php' );
+
+		require BHG_PLUGIN_DIR . 'admin/views/demo-data.php';
+	}
+
+	/**
+	 * Handle demo data reset requests.
+	 *
+	 * @return void
+	 */
+	public function handle_reset() {
+		if ( ! current_user_can( $this->capability ) ) {
+			$this->redirect( 'noaccess' );
+		}
+
+		$nonce_valid = false;
+
+		if ( class_exists( 'BHG_Utils' ) ) {
+			$nonce_valid = BHG_Utils::verify_nonce( 'bhg_demo_reset' );
+		} elseif ( isset( $_POST['bhg_demo_reset_nonce'] ) ) {
+			$nonce_valid = wp_verify_nonce(
+				sanitize_text_field( wp_unslash( $_POST['bhg_demo_reset_nonce'] ) ),
+				'bhg_demo_reset'
+			);
+		}
+
+		if ( ! $nonce_valid ) {
+			$this->redirect( 'nonce' );
+		}
+
+		$result = false;
+
+		if ( function_exists( 'bhg_reset_demo_and_seed' ) ) {
+                        try {
+                                bhg_reset_demo_and_seed();
+                                $result = true;
+                        } catch ( Throwable $throwable ) {
+                                do_action( 'bhg_demo_reset_error', $throwable );
+                        }
+                }
+
+		$this->redirect( $result ? 'demo_reset_ok' : 'demo_reset_error' );
+	}
+
+	/**
+	 * Redirect back to the Demo Tools screen with an optional notice code.
+	 *
+	 * @param string $message Optional message code.
+	 * @return void
+	 */
+	protected function redirect( $message = '' ) {
+		$url = class_exists( 'BHG_Utils' ) ? BHG_Utils::admin_url( 'admin.php?page=' . $this->menu_slug ) : admin_url( 'admin.php?page=' . $this->menu_slug );
+
+		if ( '' !== $message ) {
+			$url = add_query_arg( 'bhg_msg', $message, $url );
+		}
+
+		wp_safe_redirect( $url );
+		exit;
+	}
+
+	/**
+	 * Determine if the submenu already exists.
+	 *
+	 * @return bool
+	 */
+	protected function submenu_exists() {
+		global $submenu;
+
+		if ( ! isset( $submenu[ $this->parent_slug ] ) || ! is_array( $submenu[ $this->parent_slug ] ) ) {
+			return false;
+		}
+
+		foreach ( $submenu[ $this->parent_slug ] as $item ) {
+			if ( isset( $item[2] ) && $this->menu_slug === $item[2] ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Gather diagnostic counts for relevant demo tables.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function get_counts() {
+		global $wpdb;
+
+		$prefix = $wpdb->prefix;
+		$tables = array(
+			'hunts'       => array(
+				'label' => bhg_t( 'label_bonus_hunts', 'Bonus Hunts' ),
+				'table' => "{$prefix}bhg_bonus_hunts",
+			),
+			'guesses'     => array(
+				'label' => bhg_t( 'guesses', 'Guesses' ),
+				'table' => "{$prefix}bhg_guesses",
+			),
+			'tournaments' => array(
+				'label' => bhg_t( 'tournaments', 'Tournaments:' ),
+				'table' => "{$prefix}bhg_tournaments",
+			),
+			'ads'         => array(
+				'label' => bhg_t( 'ads', 'Ads:' ),
+				'table' => "{$prefix}bhg_ads",
+			),
+			'translations' => array(
+				'label' => bhg_t( 'menu_translations', 'Translations' ),
+				'table' => "{$prefix}bhg_translations",
+			),
+		);
+
+		foreach ( $tables as $key => $info ) {
+			$table = esc_sql( $info['table'] );
+			$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+
+			if ( $exists === $table ) {
+				$tables[ $key ]['count'] = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table}" );
+			} else {
+				$tables[ $key ]['count'] = null;
+			}
+		}
+
+		return $tables;
 	}
 }

--- a/admin/views/demo-data.php
+++ b/admin/views/demo-data.php
@@ -1,8 +1,80 @@
 <?php
 /**
- * Demo data installer for Bonus Hunt Guesser.
- *
- * Seeds sample hunts, guesses, tournaments, ads, translations.
+ * Demo data tools view for Bonus Hunt Guesser.
  *
  * @package Bonus_Hunt_Guesser
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+<div class="wrap">
+	<h1><?php echo esc_html( bhg_t( 'demo_tools', 'Demo Tools' ) ); ?></h1>
+
+	<p class="description" style="max-width:800px;">
+		<?php echo esc_html( bhg_t( 'this_will_delete_all_demo_data_and_pages_then_recreate_fresh_demo_content', 'This will delete all demo data and pages, then recreate fresh demo content.' ) ); ?>
+	</p>
+
+	<div class="card" style="max-width:780px;padding:16px;margin-top:16px;">
+		<h2><?php echo esc_html( bhg_t( 'summary', 'Summary' ) ); ?></h2>
+		<p><?php echo esc_html( bhg_t( 'note_this_will_remove_any_demo_data_and_reset_tables_to_their_initial_state', 'Note: This will remove any demo data and reset tables to their initial state.' ) ); ?></p>
+
+		<?php if ( ! empty( $counts ) ) : ?>
+			<table class="widefat striped" style="max-width:100%;">
+				<thead>
+					<tr>
+						<th scope="col"><?php echo esc_html( bhg_t( 'table_name', 'Table Name' ) ); ?></th>
+						<th scope="col" style="width:140px;">
+							<?php echo esc_html( bhg_t( 'rows', 'Rows' ) ); ?>
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php foreach ( $counts as $info ) : ?>
+						<tr>
+							<td><?php echo esc_html( $info['label'] ); ?></td>
+							<td>
+								<?php
+								if ( null === $info['count'] ) {
+									echo '&#8212;';
+								} else {
+									echo esc_html( number_format_i18n( (int) $info['count'] ) );
+								}
+								?>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		<?php endif; ?>
+	</div>
+
+	<form method="post" action="<?php echo esc_url( $action_url ); ?>" style="margin-top:24px;">
+		<input type="hidden" name="action" value="bhg_demo_reset" />
+		<?php
+		if ( class_exists( 'BHG_Utils' ) ) {
+			BHG_Utils::nonce_field( 'bhg_demo_reset' );
+		} else {
+			wp_nonce_field( 'bhg_demo_reset', 'bhg_demo_reset_nonce' );
+		}
+		?>
+
+		<p class="description">
+			<?php echo esc_html( bhg_t( 'reset_reseed_demo', 'Reset & Reseed Demo' ) ); ?>
+		</p>
+
+		<?php
+		submit_button(
+			bhg_t( 'reset_reseed_demo_data', 'Reset & Reseed Demo Data' ),
+			'primary',
+			'submit',
+			false,
+			array(
+				'onclick' => "return confirm('" . esc_js( bhg_t( 'are_you_sure', 'Are you sure?' ) ) . "');",
+			)
+		);
+		?>
+	</form>
+</div>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -213,6 +213,7 @@ spl_autoload_register(
 
 		$class_map = array(
 			'BHG_Admin'                  => 'admin/class-bhg-admin.php',
+			'BHG_Demo'                   => 'admin/class-bhg-demo.php',
 			'BHG_Shortcodes'             => 'includes/class-bhg-shortcodes.php',
 			'BHG_Logger'                 => 'includes/class-bhg-logger.php',
 			'BHG_Utils'                  => 'includes/class-bhg-utils.php',
@@ -382,6 +383,10 @@ function bhg_init_plugin() {
 
 		// Initialize components.
 	if ( is_admin() ) {
+		if ( class_exists( 'BHG_Demo' ) ) {
+			BHG_Demo::instance();
+		}
+
 		if ( class_exists( 'BHG_Admin' ) ) {
 			new BHG_Admin();
 		}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -615,6 +615,8 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'remove_this_guess'                            => 'Remove this guess?',
 			'reset_reseed_demo'                            => 'Reset & Reseed Demo',
 			'reset_reseed_demo_data'                       => 'Reset & Reseed Demo Data',
+			'demo_data_reset_complete'                     => 'Demo data was reset and reseeded.',
+			'demo_data_reset_failed'                       => 'Demo data reset failed.',
 			'results_for'                                  => 'Results for ',
 			'results_for_s'                                => 'Results for %s',
 			'role'                                         => 'Role',


### PR DESCRIPTION
## Summary
- register a Demo Tools submenu under the Bonus Hunt admin and expose success/error notices for demo reseeding
- implement a new `BHG_Demo` controller to render the demo tooling screen, gather diagnostics, and process reset requests with capability and nonce checks
- add a dedicated demo-data admin view and supporting translation strings for the new messaging

## Testing
- composer phpcs *(fails: repository contains pre-existing coding standard violations across multiple files)*
- vendor/bin/phpcs admin/class-bhg-admin.php admin/class-bhg-demo.php admin/views/demo-data.php bonus-hunt-guesser.php includes/helpers.php *(fails: repository contains extensive pre-existing coding standard violations beyond the touched sections)*

------
https://chatgpt.com/codex/tasks/task_e_68cd17f3b184833394c930aa5931e4b9