### PR TITLE
Ensure bhg_user_guesses shows usernames by default

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -771,7 +771,7 @@ $wpdb->usermeta,
                   'website'  => 0,
                   'status'   => '',
                   'timeline' => '',
-                  'fields'   => 'hunt,guess,final',
+          'fields'   => 'hunt,user,guess,final',
                   'orderby'  => 'hunt',
                   'order'    => 'DESC',
                   'paged'    => 1,
@@ -792,7 +792,7 @@ $wpdb->usermeta,
                 )
         );
         if ( empty( $fields_arr ) ) {
-                $fields_arr = array( 'hunt', 'guess', 'final' );
+                $fields_arr = array( 'hunt', 'user', 'guess', 'final' );
         }
 
         $need_site  = in_array( 'site', $fields_arr, true );


### PR DESCRIPTION
## Summary
- include the user column in the default bhg_user_guesses fields string so participant names render by default
- keep the fallback fields array aligned with the new default to retain optional column toggling

## Testing
- composer phpcs *(fails: existing coding standard violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd211308488333a5ad7e7eb54d597a