### PR TITLE
Allow global affiliate fallback for site checks

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -879,13 +879,21 @@ if ( ! function_exists( 'bhg_is_user_affiliate_for_site' ) ) {
 	 * @param int $site_id Site ID.
 	 * @return bool
 	 */
-	function bhg_is_user_affiliate_for_site( $user_id, $site_id ) {
-		if ( ! $site_id ) {
-			return bhg_is_user_affiliate( (int) $user_id );
-		}
-				$sites = bhg_get_user_affiliate_websites( (int) $user_id );
-				return in_array( absint( $site_id ), array_map( 'absint', (array) $sites ), true );
-	}
+        function bhg_is_user_affiliate_for_site( $user_id, $site_id ) {
+                $user_id = (int) $user_id;
+
+                if ( ! $site_id ) {
+                        return bhg_is_user_affiliate( $user_id );
+                }
+
+                                $sites = bhg_get_user_affiliate_websites( $user_id );
+
+                if ( empty( $sites ) ) {
+                        return bhg_is_user_affiliate( $user_id );
+                }
+
+                                return in_array( absint( $site_id ), array_map( 'absint', (array) $sites ), true );
+        }
 }
 
 if ( ! function_exists( 'bhg_render_affiliate_dot' ) ) {


### PR DESCRIPTION
## Summary
- ensure bhg_is_user_affiliate_for_site falls back to global affiliate status when no site assignments exist
- retain site-specific affiliate behavior when assignments are present, keeping affiliate dot output consistent

## Testing
- composer install
- vendor/bin/phpcs includes/helpers.php *(fails: existing coding standard violations throughout file)*

------
https://chatgpt.com/codex/tasks/task_e_68cd28c46e488333a6be56b7aa20b893