### PR TITLE
Ensure bhg_hunts shortcode site column respects fields selection

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -1287,7 +1287,7 @@ $wpdb->usermeta,
                                 return '<p>' . esc_html( bhg_t( 'notice_no_hunts_found', 'No hunts found.' ) ) . '</p>';
                         }
 
-                        $show_site = $need_site_field && in_array( strtolower( (string) $a['aff'] ), array( 'yes', '1', 'true' ), true );
+                        $show_site = $need_site_field;
 
                         wp_enqueue_style(
                                 'bhg-shortcodes',


### PR DESCRIPTION
## Summary
- always display the site column when the `site` field is requested in the `[bhg_hunts]` shortcode

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68cd37ab9d6083339ee0543dfb85155d